### PR TITLE
Correct name of ignore file to .nsyte-ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,13 +395,13 @@ nsyte validate --file path/to/config.json
 nsyte validate --schema
 ```
 
-### Ignoring Files (`.nsite-ignore`)
+### Ignoring Files (`.nsyte-ignore`)
 
-Similar to `.gitignore`, you can create a `.nsite-ignore` file in the root of your project (the
+Similar to `.gitignore`, you can create a `.nsyte-ignore` file in the root of your project (the
 directory where you run the `nsyte` command) to specify files and directories that should be
 excluded from uploads.
 
-- Create a file named `.nsite-ignore`.
+- Create a file named `.nsyte-ignore`.
 - Add patterns using standard [glob syntax](https://en.wikipedia.org/wiki/Glob_(programming)), one
   pattern per line.
 - Lines starting with `#` are treated as comments.
@@ -416,12 +416,12 @@ By default, `nsyte` ignores the following patterns:
 .git/**
 .DS_Store
 node_modules/**
-.nsite-ignore
+.nsyte-ignore
 .nsite/config.json
 .vscode/**
 ```
 
-**Example `.nsite-ignore`:**
+**Example `.nsyte-ignore`:**
 
 ```
 # Ignore build artifacts

--- a/docs/usage/commands/browse.md
+++ b/docs/usage/commands/browse.md
@@ -81,7 +81,7 @@ nsyte browse --privatekey nsec1...
 - **Server indicators** — Colored symbols show which Blossom servers have the file
 - **Selected files** — Highlighted with bright magenta background
 - **Focused file** — Highlighted with darker magenta background
-- **Ignored files** — Shown in red (based on `.nsite-ignore` rules)
+- **Ignored files** — Shown in red (based on `.nsyte-ignore` rules)
 - **Deleting files** — Shown in red during deletion
 
 ## Authentication

--- a/docs/usage/commands/init.md
+++ b/docs/usage/commands/init.md
@@ -71,7 +71,7 @@ After initialization, your project will have this structure:
 .
 ├── .nsite/
 │   └── config.json
-├── .nsite-ignore
+├── .nsyte-ignore
 └── README.md
 ```
 

--- a/docs/usage/commands/ls.md
+++ b/docs/usage/commands/ls.md
@@ -7,7 +7,7 @@ description: List files available on the nostr network
 
 List files available on the nostr network for a given public key. This command shows which files
 have been published to nostr relays and indicates which files would be ignored based on local
-`.nsite-ignore` rules.
+`.nsyte-ignore` rules.
 
 ## Usage
 
@@ -60,7 +60,7 @@ The `ls` command supports multiple authentication methods:
 Files marked in red in the output would be ignored during upload based on:
 
 - Default ignore patterns (`.git/**`, `node_modules/**`, etc.)
-- Custom patterns in `.nsite-ignore` file
+- Custom patterns in `.nsyte-ignore` file
 - Implicit dotfile ignoring (except `.well-known/`)
 
 This helps you understand which remote files would not be re-deployed in a subsequent `nsyte deploy`

--- a/docs/usage/commands/serve.md
+++ b/docs/usage/commands/serve.md
@@ -151,7 +151,7 @@ The serve command respects these configuration options from `.nsite/config.json`
 
 - `fallback`: File to serve for 404 errors (enables SPA routing)
 - Source directory settings
-- File ignore patterns (from `.nsite-ignore`)
+- File ignore patterns (from `.nsyte-ignore`)
 
 ## Comparison with Other Servers
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -150,7 +150,7 @@ You can also configure nsyte using environment variables:
 
 ## Ignoring Files
 
-Create a `.nsite-ignore` file in your project root to specify files and directories that should be
+Create a `.nsyte-ignore` file in your project root to specify files and directories that should be
 excluded from uploads. This uses standard glob syntax:
 
 ```
@@ -169,7 +169,7 @@ nsyte automatically ignores:
 - `.git/**`
 - `.DS_Store`
 - `node_modules/**`
-- `.nsite-ignore`
+- `.nsyte-ignore`
 - `.nsite/config.json`
 - `.vscode/**`
 

--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -122,7 +122,7 @@ export function registerBrowseCommand(): void {
 
           // Load ignore rules
           const cwd = Deno.cwd();
-          const ignoreFilePath = join(cwd, ".nsite-ignore");
+          const ignoreFilePath = join(cwd, ".nsyte-ignore");
           let ignoreRules: IgnoreRule[] = parseIgnorePatterns(DEFAULT_IGNORE_PATTERNS);
 
           if (existsSync(ignoreFilePath)) {
@@ -133,7 +133,7 @@ export function registerBrowseCommand(): void {
               );
               ignoreRules = parseIgnorePatterns([...DEFAULT_IGNORE_PATTERNS, ...customPatterns]);
             } catch (error) {
-              log.warn(`Failed to read .nsite-ignore file: ${error}`);
+              log.warn(`Failed to read .nsyte-ignore file: ${error}`);
             }
           }
 

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -885,7 +885,7 @@ async function scanLocalFiles(state: DeploymentState): Promise<FileEntry[]> {
 
   if (ignoredFilePaths.length > 0) {
     const ignoreMsg =
-      `Ignored ${ignoredFilePaths.length} files/directories based on .nsiteignore rules (or default ignores).`;
+      `Ignored ${ignoredFilePaths.length} files/directories based on .nsyte-ignore rules (or default ignores).`;
     if (displayManager.isInteractive()) log.info(ignoreMsg);
     else console.log(colors.yellow(ignoreMsg));
     if (options.verbose) {

--- a/src/lib/files.ts
+++ b/src/lib/files.ts
@@ -22,7 +22,7 @@ export const DEFAULT_IGNORE_PATTERNS = [
 ];
 
 /**
- * Get all files from a local directory, honoring .nsite-ignore using Deno std lib
+ * Get all files from a local directory, honoring .nsyte-ignore using Deno std lib
  * Returns both the files to include and the paths of those ignored.
  */
 export async function getLocalFiles(
@@ -33,7 +33,7 @@ export async function getLocalFiles(
   const includedFiles: FileEntry[] = [];
   const ignoredFilePaths: string[] = [];
   const normalizedDir = normalize(dirPath).replace(/\/$/, ""); // Target directory for upload
-  const cwd = Deno.cwd(); // Current working directory (where .nsite-ignore lives)
+  const cwd = Deno.cwd(); // Current working directory (where .nsyte-ignore lives)
 
   // --- Load and parse .nsyte-ignore rules from CWD ---
   const ignoreFilePath = join(cwd, ".nsyte-ignore");
@@ -76,7 +76,7 @@ export async function getLocalFiles(
       })
     ) {
       // --- Ignore Check Logic ---
-      // 1. Get path relative to CWD (where .nsite-ignore is)
+      // 1. Get path relative to CWD (where .nsyte-ignore is)
       const pathRelativeToCwd = relative(cwd, entry.path);
       const isDir = entry.isDirectory;
       // 2. Format path for matching (add trailing slash for dirs)
@@ -123,7 +123,7 @@ export async function getLocalFiles(
 
     log.info(
       `Scan complete: ${includedFiles.length} files included, ${ignoredFilePaths.length} ignored.` +
-        (foundIgnoreFile ? ` (Used .nsite-ignore from CWD)` : ""),
+        (foundIgnoreFile ? ` (Used .nsyte-ignore from CWD)` : ""),
     );
 
     return {
@@ -175,7 +175,7 @@ export function parseIgnorePatterns(patterns: string[]): IgnoreRule[] {
       // Safely get error message
       const errorMessage = e instanceof Error ? e.message : String(e);
       log.warn(
-        `Invalid pattern in .nsite-ignore, skipping: "${
+        `Invalid pattern in .nsyte-ignore, skipping: "${
           patterns[patterns.indexOf(pattern)]
         }" - Error: ${errorMessage}`,
       );


### PR DESCRIPTION
Fix all mentions of `.nsite-ignore` to `.nsyte-ignore`

There were two names in the documentation and the implementation uses `.nsyte-ignore`