### PR TITLE
Fix type errors breaking v0.25.0 release

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -87,6 +87,10 @@ export interface DeployCommandOptions {
   handlerKinds?: string;
   nonInteractive: boolean;
   name?: string;
+  /** Skip the pre-deploy secrets scan */
+  skipSecretsScan: boolean;
+  /** Secrets scan sensitivity level (low, medium, high) */
+  scanLevel?: string;
 }
 
 /**

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -23,6 +23,7 @@ export function formatFindings(
     high: 0,
     medium: 1,
     low: 2,
+    warning: 3,
   };
   const sorted = [...findings].sort((a, b) => {
     const severityDiff = severityOrder[a.severity] - severityOrder[b.severity];
@@ -36,7 +37,9 @@ export function formatFindings(
         ? colors.red
         : finding.severity === "medium"
           ? colors.yellow
-          : colors.dim;
+          : finding.severity === "warning"
+            ? colors.yellow
+            : colors.dim;
 
     const locationStr =
       finding.line > 0
@@ -67,6 +70,9 @@ export function formatSummary(result: ScanResult): string[] {
     (f) => f.severity === "medium",
   ).length;
   const lowCount = result.findings.filter((f) => f.severity === "low").length;
+  const warningCount = result.findings.filter(
+    (f) => f.severity === "warning",
+  ).length;
 
   lines.push("");
   lines.push(colors.bold("  Scan Results"));
@@ -86,6 +92,9 @@ export function formatSummary(result: ScanResult): string[] {
     }
     if (lowCount > 0) {
       lines.push(`    ${colors.dim("Low severity:")}    ${lowCount}`);
+    }
+    if (warningCount > 0) {
+      lines.push(`    ${colors.yellow("Warnings:")}        ${warningCount}`);
     }
   } else {
     lines.push(colors.green(`  Findings:         0`));

--- a/src/lib/scanner/types.ts
+++ b/src/lib/scanner/types.ts
@@ -9,7 +9,7 @@ export type ScanLevel = "low" | "medium" | "high";
 /**
  * Pattern severity for color-coded output
  */
-export type Severity = "high" | "medium" | "low";
+export type Severity = "high" | "medium" | "low" | "warning";
 
 /**
  * A single pattern definition for the scanner


### PR DESCRIPTION
## Summary
- Add missing `skipSecretsScan` and `scanLevel` properties to `DeployCommandOptions` interface
- Add `"warning"` to `Severity` union type in scanner types

Fixes the 3 type errors that caused the v0.25.0 release build to fail.

## Test plan
- [x] `deno check src/cli.ts` passes
- [x] All scanner unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)