### PR TITLE
fix(nip46): wire global pool to NostrConnectSigner for manual bunker URIs

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsyte/cli",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "nsyte - publish your site to nostr and blossom servers",
   "license": "MIT",
   "exports": "./src/cli.ts",

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -67,6 +67,21 @@ export interface PublishEventsResult {
 // Create a global relay pool for connections
 export const pool = new RelayPool();
 
+// Wire the global pool into NostrConnectSigner as the static fallback so any
+// code path that constructs / resumes a NIP-46 signer (including
+// NostrConnectSigner.fromBunkerURI for manually-entered bunker:// URIs)
+// inherits subscription/publish methods without per-call wiring.
+//
+// applesauce-signers v5 lookup chain (see applesauce-signers/dist/interop.js):
+//   options.subscriptionMethod
+//   -> options.pool?.subscription.bind(options.pool)
+//   -> cls?.subscriptionMethod
+//   -> cls?.pool?.subscription.bind(cls.pool)        // <-- this assignment
+// Without this, fromBunkerURI throws:
+// "Missing subscriptionMethod, either pass a method or set subscriptionMethod
+//  globally on the class" (GitHub #114).
+NostrConnectSigner.pool = pool;
+
 // Create an in-memory event store for managing events
 export const store = new EventStore();
 


### PR DESCRIPTION
## Summary
- `nsyte bunker connect` → "Enter Bunker URL manually" threw `Missing subscriptionMethod` because `NostrConnectSigner.fromBunkerURI` had no pool wired and `applesauce-signers` v5 falls back to the static `NostrConnectSigner.pool`.
- Set `NostrConnectSigner.pool = pool` once in `src/lib/nostr.ts` so every NIP-46 entry point (manual URI, nbunksec reuse, QR Nostr Connect) inherits subscription/publish methods.

Fixes #114

## Test plan
- [x] `deno check src/lib/nostr.ts`
- [x] `deno test --allow-all --no-check tests/unit/` (171 passed, 0 failed)
- [x] Manual: `deno task dev bunker connect` → paste a bunker:// URI → connect succeeds (or fails with a real signer/relay error, not the synthetic one)