### PR TITLE
fix(ci): unblock site deploy + tidy workflow

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,4 +4,7 @@ mkdocs-material-extensions~=1.3
 mkdocs-git-revision-date-localized-plugin==1.2.0
 mkdocs-minify-plugin==0.7.1
 markdown-include==0.8.1
-pymdown-extensions==10.8.1 
+pymdown-extensions==10.8.1
+# Pygments 2.20.0 calls html.escape() on the formatter's `filename` option,
+# which crashes when pymdown-extensions 10.8.1 passes filename=None.
+Pygments<2.20 


### PR DESCRIPTION
## Summary
Three fixes to the (now renamed) site-deploy pipeline on `main`:

1. **`requirements-docs.txt`** — pin `Pygments<2.20`. Pygments 2.20.0 wraps the formatter's `filename` option in `html.escape(...)`, which crashes when pinned `pymdown-extensions==10.8.1` passes `filename=None`. Result: every push to `main` since #112 has failed at the `Build Site` step, blocking splash + docs + Bunny CDN + nsite deploys (including the homepage redesign in #115).
2. **`.github/workflows/docs.yml` → `deploy-site.yml`** — the workflow doesn't just build docs, it builds the splash page, syncs to Bunny CDN, purges the cache, and publishes the bundle to nsite. Renamed file + workflow `name:` and job `name:` to "Deploy Site" / "Build and Deploy Site".
3. **nsite-action upgrade** — move off the long-running `multi-tool-support` branch onto the `v0.3.1` release tag, and bump the installed nsyte CLI from `v0.21.0` to `v0.26.0` to match `deno.json`.

After merge, the workflow runs automatically on `main` and re-publishes the homepage + docs + nsite that have been stuck.

Reference: failing run https://github.com/sandwichfarm/nsyte/actions/runs/25312509038

## Test plan
- [x] Reproduced the Pygments failure locally with current `requirements-docs.txt` (Pygments 2.20.0).
- [x] Applied pin in clean venv → `mkdocs build` exits 0 (Pygments 2.19.2 resolved).
- [x] Verified no external references to `docs.yml` / "Deploy Docs" beyond the workflow itself.
- [ ] CI Deploy Site run on `main` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)