### PR TITLE
Improve deploy upload progress handling

### DIFF
--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -254,7 +254,7 @@ export function registerBrowseCommand(): void {
             };
 
             // Set up terminal resize handler
-            let resizeTimeout: number | undefined;
+            let resizeTimeout: ReturnType<typeof setTimeout> | undefined;
             const handleResize = () => {
               if (resizeTimeout) {
                 clearTimeout(resizeTimeout);
@@ -278,7 +278,7 @@ export function registerBrowseCommand(): void {
             Deno.addSignalListener("SIGWINCH", handleResize);
 
             // Create throttled render function to prevent flickering
-            let renderTimer: number | null = null;
+            let renderTimer: ReturnType<typeof setTimeout> | null = null;
             let lastRenderTime = 0;
             const RENDER_THROTTLE_MS = 100; // Max 10 renders per second
 
@@ -646,7 +646,7 @@ export function registerBrowseCommand(): void {
                 key.includes("\u001b[8;") || key.includes("\u001b[9;") ||
                 key.includes("\u001b\u001b") || // Double escape sequences
                 (key.length > 10) || // Very long sequences
-                (key.length > 4 && key.startsWith("\u001b[") && !key.match(/^\u001b\[[ABCD]$/)) || // Complex escape sequences (but allow arrow keys)
+                (key.length > 4 && key.startsWith("\u001b[")) || // Complex escape sequences
                 key.includes("\u001b[2~") || key.includes("\u001b[3~") || // Insert/Delete
                 key.includes("\u001b[5~") || key.includes("\u001b[6~") || // Page Up/Down
                 key.includes("\u001b[H") || key.includes("\u001b[F") || // Home/End\

--- a/src/lib/nip46.ts
+++ b/src/lib/nip46.ts
@@ -509,7 +509,7 @@ export async function initiateNostrConnect(
     }
   };
 
-  let timeoutHandle: number | undefined = undefined;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined = undefined;
 
   const signerPromise = signer
     .waitForSigner()

--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -144,7 +144,7 @@ export interface UploadProgress {
   completed: number;
   /** Server-file pairs that failed after retries */
   failed: number;
-  /** Files currently being processed */
+  /** Server-file pairs currently being processed */
   inProgress: number;
   /** Server-file pairs where file already existed */
   skipped: number;
@@ -170,6 +170,8 @@ export type UploadResponse = {
     };
   };
 };
+
+type ServerUploadResult = UploadResponse["serverResults"][string];
 
 /**
  * Sign a batch blob upload authorization covering up to UPLOAD_AUTH_BATCH_SIZE hashes.
@@ -249,7 +251,7 @@ async function uploadToServer(
     try {
       const uploadLabel = `PUT upload ${file.path} to ${server}`;
       log.debug(`Trying PUT to ${serverUrl}upload with auth header`);
-      // Single attempt — retries are handled by uploadFile() with progress visibility
+      // Single attempt — retries are handled by uploadFileToServer() with progress visibility
       const response = await fetchWithTimeout(
         `${serverUrl}upload`,
         {
@@ -345,7 +347,7 @@ export async function processUploads(
   }
 
   log.info(
-    `Starting upload of ${files.length} files to ${servers.length} servers with concurrency ${concurrency}`,
+    `Starting upload of ${files.length} files to ${servers.length} servers with ${concurrency} worker(s) per server`,
   );
 
   const serverProgress: Record<string, ServerProgressEntry> = {};
@@ -369,8 +371,15 @@ export async function processUploads(
     serverProgress,
   };
 
+  const getProgressSnapshot = (): UploadProgress => ({
+    ...progress,
+    serverProgress: Object.fromEntries(
+      Object.entries(serverProgress).map(([server, sp]) => [server, { ...sp }]),
+    ),
+  });
+
   if (progressCallback) {
-    progressCallback({ ...progress, serverProgress: { ...serverProgress } });
+    progressCallback(getProgressSnapshot());
   }
 
   // Pre-sign batch upload auth tokens (up to UPLOAD_AUTH_BATCH_SIZE hashes per token).
@@ -400,92 +409,114 @@ export async function processUploads(
     } batch auth token(s) for ${allHashes.length} files`,
   );
 
-  const results: UploadResponse[] = [];
-  const queue = [...files];
-
+  const results: UploadResponse[] = files.map((file) => ({
+    file,
+    success: false,
+    serverResults: {},
+    eventPublished: false,
+    skipped: false,
+  }));
   const errors: Array<{ file: string; error: string }> = [];
 
   const emitProgress = () => {
     if (progressCallback) {
-      progressCallback({ ...progress, serverProgress: { ...serverProgress } });
+      progressCallback(getProgressSnapshot());
     }
   };
 
-  while (queue.length > 0) {
-    const chunk = queue.splice(0, Math.min(concurrency, queue.length));
-    progress.inProgress = chunk.length;
+  const recordServerEvent = (server: string, event: ServerEventType) => {
+    const sp = serverProgress[server];
+    if (!sp) return;
 
-    emitProgress();
-
-    const chunkResults = await Promise.all(
-      chunk.map(async (file) => {
-        return await uploadFile(
-          file,
-          servers,
-          authTokenMap,
-          force,
-          (server: string, event: string) => {
-            const sp = serverProgress[server];
-            switch (event) {
-              case "completed":
-                progress.completed++;
-                sp.completed++;
-                break;
-              case "skipped":
-                progress.completed++;
-                progress.skipped++;
-                sp.completed++;
-                sp.skipped++;
-                break;
-              case "failed":
-                progress.failed++;
-                sp.failed++;
-                break;
-              case "retry-start":
-                progress.retrying++;
-                sp.retrying++;
-                break;
-              case "retry-end":
-                progress.retrying--;
-                sp.retrying--;
-                break;
-            }
-            // Record when a server finishes all its files
-            if (!sp.finishedAt && sp.completed + sp.failed >= sp.total) {
-              sp.finishedAt = Date.now();
-            }
-            emitProgress();
-          },
-        );
-      }),
-    ).catch((error) => {
-      log.error(`Error processing batch: ${error.message || error}`);
-      return chunk.map((file) => ({
-        file,
-        success: false,
-        error: `Batch processing error: ${error.message || error}`,
-        serverResults: {},
-        eventPublished: false,
-        skipped: false,
-      }));
-    });
-
-    for (const result of chunkResults) {
-      results.push(result);
-
-      if (!result.success) {
-        errors.push({
-          file: result.file.path,
-          error: result.error || "Unknown error",
-        });
-      }
-
-      progress.inProgress = Math.max(0, progress.inProgress - 1);
-      emitProgress();
+    switch (event) {
+      case "completed":
+        progress.completed++;
+        sp.completed++;
+        break;
+      case "skipped":
+        progress.completed++;
+        progress.skipped++;
+        sp.completed++;
+        sp.skipped++;
+        break;
+      case "failed":
+        progress.failed++;
+        sp.failed++;
+        break;
+      case "retry-start":
+        progress.retrying++;
+        sp.retrying++;
+        break;
+      case "retry-end":
+        progress.retrying = Math.max(0, progress.retrying - 1);
+        sp.retrying = Math.max(0, sp.retrying - 1);
+        break;
     }
 
-    if (queue.length > 0) {
-      await new Promise((resolve) => setTimeout(resolve, 200));
+    // Record when a server finishes all its files.
+    if (!sp.finishedAt && sp.completed + sp.failed >= sp.total) {
+      sp.finishedAt = Date.now();
+    }
+
+    emitProgress();
+  };
+
+  const workersPerServer = Math.max(1, Math.floor(concurrency));
+
+  const processServerQueue = async (server: string): Promise<void> => {
+    let nextFileIndex = 0;
+
+    const worker = async () => {
+      while (nextFileIndex < files.length) {
+        const fileIndex = nextFileIndex++;
+        const response = results[fileIndex];
+
+        progress.inProgress++;
+        emitProgress();
+
+        try {
+          response.serverResults[server] = await uploadFileToServer(
+            response.file,
+            server,
+            authTokenMap,
+            force,
+            recordServerEvent,
+          );
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          response.serverResults[server] = {
+            success: false,
+            error: errorMessage,
+            retries: 0,
+          };
+          recordServerEvent(server, "failed");
+        } finally {
+          progress.inProgress = Math.max(0, progress.inProgress - 1);
+          emitProgress();
+        }
+      }
+    };
+
+    const workerCount = Math.min(workersPerServer, files.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  };
+
+  await Promise.all(servers.map((server) => processServerQueue(server)));
+
+  for (const result of results) {
+    const serverResults = Object.values(result.serverResults);
+    const anySuccess = serverResults.some((r) => r.success);
+    const allAlready = serverResults.length > 0 && serverResults.every((r) => r.alreadyExists);
+
+    result.success = anySuccess;
+    result.skipped = allAlready;
+    result.error = anySuccess ? undefined : "Failed to upload to any server";
+
+    if (!result.success) {
+      errors.push({
+        file: result.file.path,
+        error: result.error || "Unknown error",
+      });
     }
   }
 
@@ -503,128 +534,107 @@ export async function processUploads(
 type ServerEventType = "completed" | "failed" | "skipped" | "retry-start" | "retry-end";
 
 /**
- * Upload a single file to all servers with per-server retries.
- * Each server retries in parallel so a slow server doesn't block others.
- * Fires onServerEvent for each server completion/failure/retry for real-time progress.
+ * Upload a single file to one server with retries.
+ * Server queues call this independently so one server cannot block another.
+ * Fires onServerEvent for completion/failure/retry for real-time progress.
  */
-async function uploadFile(
+async function uploadFileToServer(
   file: FileEntry,
-  servers: string[],
+  server: string,
   authTokenMap: Map<string, string>,
   force = false,
   onServerEvent?: (server: string, event: ServerEventType) => void,
-): Promise<UploadResponse> {
-  const serverResults: {
-    [server: string]: {
-      success: boolean;
-      error?: string;
-      alreadyExists?: boolean;
-      retries?: number;
-    };
-  } = {};
-
-  log.debug(`Uploading file ${file.path}`);
-
+): Promise<ServerUploadResult> {
   if (!file.data) {
+    onServerEvent?.(server, "failed");
     return {
-      file,
       success: false,
-      skipped: false,
       error: "File data missing",
-      serverResults,
-      eventPublished: false,
+      retries: 0,
     };
   }
 
   const authHeader = authTokenMap.get(file.sha256);
   if (!authHeader) {
+    onServerEvent?.(server, "failed");
     return {
-      file,
       success: false,
-      skipped: false,
       error: `No auth token found for blob ${file.sha256.substring(0, 8)}...`,
-      serverResults,
-      eventPublished: false,
+      retries: 0,
     };
   }
 
-  // Upload to each server with independent per-server retries, all in parallel
-  await Promise.all(
-    servers.map(async (server) => {
-      // Initial attempt
-      let shouldRetry = true;
+  log.debug(`Uploading file ${file.path} to ${server}`);
+
+  let result: ServerUploadResult = {
+    success: false,
+    error: "Upload failed",
+    retries: 0,
+  };
+  let shouldRetry = true;
+
+  try {
+    const outcome = await uploadToServer(server, file, authHeader, force);
+    const success = outcome.success || outcome.alreadyExists;
+    result = {
+      success,
+      alreadyExists: outcome.alreadyExists,
+      error: success ? undefined : outcome.error,
+      retries: 0,
+    };
+    if (success) {
+      onServerEvent?.(server, outcome.alreadyExists ? "skipped" : "completed");
+      return result;
+    }
+
+    // Don't retry non-retryable HTTP statuses (e.g. 400, 401, 403).
+    if (outcome.httpStatus && !shouldRetryStatus(outcome.httpStatus)) {
+      shouldRetry = false;
+    }
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    result = { success: false, error: errorMessage, retries: 0 };
+  }
+
+  if (!shouldRetry) {
+    onServerEvent?.(server, "failed");
+    return result;
+  }
+
+  // Retries for this server run independently from every other server queue.
+  onServerEvent?.(server, "retry-start");
+  try {
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+      await delay(RETRY_DELAY_MS * attempt);
+      log.debug(`Retrying ${file.path} on ${server} (attempt ${attempt}/${MAX_RETRIES})`);
       try {
         const outcome = await uploadToServer(server, file, authHeader, force);
         const success = outcome.success || outcome.alreadyExists;
-        serverResults[server] = {
+        result = {
           success,
           alreadyExists: outcome.alreadyExists,
           error: success ? undefined : outcome.error,
-          retries: 0,
+          retries: attempt,
         };
         if (success) {
           onServerEvent?.(server, outcome.alreadyExists ? "skipped" : "completed");
-          return;
+          return result;
         }
-        // Don't retry non-retryable HTTP statuses (e.g. 400, 401, 403)
+
+        // Stop retrying on non-retryable HTTP statuses.
         if (outcome.httpStatus && !shouldRetryStatus(outcome.httpStatus)) {
-          shouldRetry = false;
+          break;
         }
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error);
-        serverResults[server] = { success: false, error: errorMessage, retries: 0 };
+        result = { success: false, error: errorMessage, retries: attempt };
       }
+    }
 
-      if (!shouldRetry) {
-        onServerEvent?.(server, "failed");
-        return;
-      }
-
-      // Retries for this server (runs concurrently with other servers' retries)
-      onServerEvent?.(server, "retry-start");
-      try {
-        for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS * attempt));
-          log.debug(`Retrying ${file.path} on ${server} (attempt ${attempt}/${MAX_RETRIES})`);
-          try {
-            const outcome = await uploadToServer(server, file, authHeader, force);
-            const success = outcome.success || outcome.alreadyExists;
-            serverResults[server] = {
-              success,
-              alreadyExists: outcome.alreadyExists,
-              error: success ? undefined : outcome.error,
-              retries: attempt,
-            };
-            if (success) {
-              onServerEvent?.(server, outcome.alreadyExists ? "skipped" : "completed");
-              return;
-            }
-            // Stop retrying on non-retryable HTTP statuses
-            if (outcome.httpStatus && !shouldRetryStatus(outcome.httpStatus)) {
-              break;
-            }
-          } catch (error: unknown) {
-            const errorMessage = error instanceof Error ? error.message : String(error);
-            serverResults[server] = { success: false, error: errorMessage, retries: attempt };
-          }
-        }
-        // All retries exhausted or non-retryable
-        onServerEvent?.(server, "failed");
-      } finally {
-        onServerEvent?.(server, "retry-end");
-      }
-    }),
-  );
-
-  const anySuccess = Object.values(serverResults).some((r) => r.success);
-  const allAlready = Object.values(serverResults).every((r) => r.alreadyExists);
-
-  return {
-    file,
-    success: anySuccess,
-    skipped: allAlready,
-    serverResults,
-    eventPublished: false,
-    error: anySuccess ? undefined : "Failed to upload to any server",
-  };
+    // All retries exhausted or stopped by a non-retryable response.
+    onServerEvent?.(server, "failed");
+    return result;
+  } finally {
+    onServerEvent?.(server, "retry-end");
+  }
 }

--- a/src/ui/progress.ts
+++ b/src/ui/progress.ts
@@ -121,9 +121,10 @@ export function formatServerProgressBars(
     let sGray = SERVER_BAR_WIDTH;
 
     if (sp.total > 0) {
+      const retryingForBar = Math.min(sp.retrying, Math.max(0, sp.total - serverDone));
       sGreen = Math.floor((serverUploaded / sp.total) * SERVER_BAR_WIDTH);
       sSkipped = Math.floor((skipped / sp.total) * SERVER_BAR_WIDTH);
-      sYellow = Math.floor((sp.retrying / sp.total) * SERVER_BAR_WIDTH);
+      sYellow = Math.floor((retryingForBar / sp.total) * SERVER_BAR_WIDTH);
       sRed = Math.floor((sp.failed / sp.total) * SERVER_BAR_WIDTH);
       sGray = Math.max(0, SERVER_BAR_WIDTH - sGreen - sSkipped - sYellow - sRed);
     }
@@ -387,9 +388,10 @@ export class ProgressRenderer {
     let grayW = this.barLength;
 
     if (data.total > 0) {
+      const retryingForBar = Math.min(retrying, Math.max(0, data.total - done));
       greenW = Math.floor((uploadedCompleted / data.total) * this.barLength);
       skippedW = Math.floor((skipped / data.total) * this.barLength);
-      yellowW = Math.floor((retrying / data.total) * this.barLength);
+      yellowW = Math.floor((retryingForBar / data.total) * this.barLength);
       redW = Math.floor((data.failed / data.total) * this.barLength);
       grayW = Math.max(0, this.barLength - greenW - skippedW - yellowW - redW);
     }

--- a/src/ui/progress.ts
+++ b/src/ui/progress.ts
@@ -9,7 +9,8 @@ const PROGRESS_CHAR = "█";
 const INCOMPLETE_CHAR = "░";
 
 function stripAnsi(text: string): string {
-  return text.replace(/\x1b\[[0-9;]*m/g, "");
+  const escape = String.fromCharCode(27);
+  return text.replace(new RegExp(`${escape}\\[[0-9;]*m`, "g"), "");
 }
 
 /**
@@ -108,31 +109,36 @@ export function formatServerProgressBars(
     const symbol = SERVER_SYMBOLS[i % SERVER_SYMBOLS.length];
     const colorFn = SERVER_COLORS[i % SERVER_COLORS.length];
     const name = shortServerName(server).padEnd(maxNameLen);
+    const skipped = Math.min(sp.skipped, sp.completed);
+    const serverUploaded = Math.max(0, sp.completed - skipped);
     const serverDone = sp.completed + sp.failed;
     const serverPercent = sp.total === 0 ? 0 : Math.floor((serverDone / sp.total) * 100);
 
     let sGreen = 0;
+    let sSkipped = 0;
     let sYellow = 0;
     let sRed = 0;
     let sGray = SERVER_BAR_WIDTH;
 
     if (sp.total > 0) {
-      sGreen = Math.floor((sp.completed / sp.total) * SERVER_BAR_WIDTH);
+      sGreen = Math.floor((serverUploaded / sp.total) * SERVER_BAR_WIDTH);
+      sSkipped = Math.floor((skipped / sp.total) * SERVER_BAR_WIDTH);
       sYellow = Math.floor((sp.retrying / sp.total) * SERVER_BAR_WIDTH);
       sRed = Math.floor((sp.failed / sp.total) * SERVER_BAR_WIDTH);
-      sGray = Math.max(0, SERVER_BAR_WIDTH - sGreen - sYellow - sRed);
+      sGray = Math.max(0, SERVER_BAR_WIDTH - sGreen - sSkipped - sYellow - sRed);
     }
 
     const sBar = colors.green("█".repeat(sGreen)) +
+      colors.dim("█".repeat(sSkipped)) +
       colors.yellow("█".repeat(sYellow)) +
       colors.red("█".repeat(sRed)) +
       "░".repeat(sGray);
 
     const pctStr = `${serverPercent}%`.padStart(4);
-    const statParts = [`${sp.completed} ok`];
+    const statParts = [`${serverUploaded} ok`];
     if (sp.failed > 0) statParts.push(colors.red(`${sp.failed} fail`));
     if (sp.retrying > 0) statParts.push(colors.yellow(`${sp.retrying} retry`));
-    if (sp.skipped > 0) statParts.push(colors.dim(`${sp.skipped} skip`));
+    if (skipped > 0) statParts.push(colors.dim(`${skipped} skip`));
 
     let timeStr = "";
     if (sp.finishedAt && startTime) {
@@ -369,32 +375,36 @@ export class ProgressRenderer {
       eta = etaSeconds <= 0 ? "0s" : `${etaSeconds}s`;
     }
 
+    const skipped = Math.min(data.skipped ?? 0, data.completed);
+    const retrying = data.retrying ?? 0;
+    const uploadedCompleted = Math.max(0, data.completed - skipped);
+
     // Build the colored bar segments
     let greenW = 0;
+    let skippedW = 0;
     let yellowW = 0;
     let redW = 0;
     let grayW = this.barLength;
 
     if (data.total > 0) {
-      greenW = Math.floor((data.completed / data.total) * this.barLength);
-      yellowW = Math.floor(((data.retrying ?? 0) / data.total) * this.barLength);
+      greenW = Math.floor((uploadedCompleted / data.total) * this.barLength);
+      skippedW = Math.floor((skipped / data.total) * this.barLength);
+      yellowW = Math.floor((retrying / data.total) * this.barLength);
       redW = Math.floor((data.failed / data.total) * this.barLength);
-      grayW = Math.max(0, this.barLength - greenW - yellowW - redW);
+      grayW = Math.max(0, this.barLength - greenW - skippedW - yellowW - redW);
     }
 
     const bar = colors.green("█".repeat(greenW)) +
+      colors.dim("█".repeat(skippedW)) +
       colors.yellow("█".repeat(yellowW)) +
       colors.red("█".repeat(redW)) +
       "░".repeat(grayW);
-
-    const skipped = data.skipped ?? 0;
-    const retrying = data.retrying ?? 0;
 
     // Build main progress line with droppable segments
     const segments = [
       `[${bar}] ${percent}%`,
       `${done}/${data.total}`,
-      `${data.completed} ok, ${skipped} skip, ${retrying} retry, ${data.failed} fail`,
+      `${uploadedCompleted} ok, ${skipped} skip, ${retrying} retry, ${data.failed} fail`,
       `${elapsed}s`,
       `ETA: ${eta}`,
     ];

--- a/tests/test-setup-global.ts
+++ b/tests/test-setup-global.ts
@@ -77,15 +77,23 @@ const originalDynamicImport = (globalThis as any).import;
 
 // Mock Deno commands that could access system resources
 const originalCommand = Deno.Command;
-Deno.Command = class MockCommand extends originalCommand {
-  constructor(command: string, options?: any) {
+class MockCommand extends originalCommand {
+  constructor(command: string | URL, options?: Deno.CommandOptions) {
+    const commandName = command instanceof URL ? command.toString() : command;
+
     // Block any security-related commands
-    if (command === "security" || command === "cmdkey" || command === "secret-tool") {
-      throw new Error(`Command '${command}' blocked in tests - no keychain access allowed`);
+    if (commandName === "security" || commandName === "cmdkey" || commandName === "secret-tool") {
+      throw new Error(`Command '${commandName}' blocked in tests - no keychain access allowed`);
     }
     super(command, options);
   }
-} as any;
+}
+
+Object.defineProperty(Deno, "Command", {
+  value: MockCommand,
+  configurable: true,
+  writable: true,
+});
 
 console.log("🔒 Test environment setup complete - all keychain access blocked");
 

--- a/tests/unit/ui_progress_test.ts
+++ b/tests/unit/ui_progress_test.ts
@@ -1,3 +1,4 @@
+// deno-lint-ignore-file no-explicit-any
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { restore, returnsNext, stub } from "@std/testing/mock";
 import {
@@ -614,6 +615,35 @@ Deno.test("UI Progress - ProgressRenderer colored bar and retry count", async (t
     stdoutStub.restore();
   });
 
+  await t.step("should render skipped files separately from green completions", () => {
+    restore();
+    stdoutStub = stub(Deno.stdout, "writeSync", () => 0);
+    stub(Deno, "consoleSize", () => ({ columns: 300, rows: 50 }));
+
+    const progress = new ProgressRenderer(10);
+    progress.update({
+      total: 10,
+      completed: 10,
+      failed: 0,
+      inProgress: 0,
+      skipped: 10,
+      retrying: 0,
+    });
+
+    let allOutput = "";
+    for (const call of stdoutStub.calls) {
+      allOutput += new TextDecoder().decode(call.args[0]);
+    }
+
+    assertStringIncludes(allOutput, "0 ok, 10 skip");
+    if (!Deno.noColor) {
+      assertStringIncludes(allOutput, "\x1b[2m");
+      assertEquals(allOutput.includes("\x1b[32m"), false);
+    }
+
+    stdoutStub.restore();
+  });
+
   await t.step("should default retrying to 0 when not provided", () => {
     restore();
     stdoutStub = stub(Deno.stdout, "writeSync", () => 0);
@@ -778,13 +808,13 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
     (renderer as any).showServerBars = true;
     renderer.update({
       total: 6,
-      completed: 2,
+      completed: 5,
       failed: 0,
       inProgress: 1,
       serverProgress: {
         "https://server1.com": {
           total: 6,
-          completed: 2,
+          completed: 5,
           failed: 0,
           retrying: 0,
           skipped: 3,
@@ -797,6 +827,49 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
       allOutput += new TextDecoder().decode(call.args[0]);
     }
     assertStringIncludes(allOutput, "3 skip");
+
+    consoleSizeStub.restore();
+    stdoutStub.restore();
+  });
+
+  await t.step("should render server skips as their own bar segment", () => {
+    stdoutStub = stub(Deno.stdout, "writeSync", () => 0);
+    consoleSizeStub = stub(
+      Deno,
+      "consoleSize",
+      () => ({ columns: 200, rows: 50 }),
+    );
+
+    const renderer = new ProgressRenderer(6, ["https://server1.com"]);
+    (renderer as any).showServerBars = true;
+    renderer.update({
+      total: 6,
+      completed: 6,
+      failed: 0,
+      inProgress: 0,
+      skipped: 4,
+      retrying: 0,
+      serverProgress: {
+        "https://server1.com": {
+          total: 6,
+          completed: 6,
+          failed: 0,
+          retrying: 0,
+          skipped: 4,
+        },
+      },
+    });
+
+    let allOutput = "";
+    for (const call of stdoutStub.calls) {
+      allOutput += new TextDecoder().decode(call.args[0]);
+    }
+
+    assertStringIncludes(allOutput, "2 ok");
+    assertStringIncludes(allOutput, "4 skip");
+    if (!Deno.noColor) {
+      assertStringIncludes(allOutput, "\x1b[2m");
+    }
 
     consoleSizeStub.restore();
     stdoutStub.restore();

--- a/tests/unit/ui_progress_test.ts
+++ b/tests/unit/ui_progress_test.ts
@@ -1,6 +1,5 @@
-// deno-lint-ignore-file no-explicit-any
-import { assertEquals, assertStringIncludes } from "@std/assert";
-import { restore, returnsNext, stub } from "@std/testing/mock";
+import { assertEquals, assertExists, assertStringIncludes } from "@std/assert";
+import { restore, returnsNext, type Stub, stub } from "@std/testing/mock";
 import {
   formatProgressBar,
   formatServerProgressBars,
@@ -18,6 +17,29 @@ function assertColorCodeWhenEnabled(output: string, code: string): void {
   } else {
     assertStringIncludes(output, code);
   }
+}
+
+function stripAnsiCodes(output: string): string {
+  const escape = String.fromCharCode(27);
+  return output.replace(new RegExp(`${escape}\\[[0-9;]*m`, "g"), "");
+}
+
+function extractFirstBar(output: string): string {
+  const match = stripAnsiCodes(output).match(/\[([█░]+)\]/);
+  assertExists(match);
+  return match[1];
+}
+
+function rendererInternals(renderer: ProgressRenderer): {
+  intervalId?: ReturnType<typeof setInterval> | number | null;
+  showServerBars: boolean;
+  startTime: number;
+} {
+  return renderer as unknown as {
+    intervalId?: ReturnType<typeof setInterval> | number | null;
+    showServerBars: boolean;
+    startTime: number;
+  };
 }
 
 Deno.test("UI Progress - formatProgressBar", async (t) => {
@@ -180,12 +202,30 @@ Deno.test("UI Progress - formatServerProgressBars", async (t) => {
     assertStringIncludes(output, "4 ok");
     assertStringIncludes(output, "2 fail");
   });
+
+  await t.step("should keep server bar width stable when retry overlaps completion", () => {
+    const output = formatServerProgressBars(
+      ["https://cdn-a.example"],
+      {
+        "https://cdn-a.example": {
+          total: 4,
+          completed: 4,
+          failed: 0,
+          retrying: 1,
+          skipped: 0,
+        },
+      },
+    );
+
+    assertEquals(extractFirstBar(output).length, 20);
+    assertStringIncludes(output, "1 retry");
+  });
 });
 
 Deno.test("UI Progress - ProgressRenderer", async (t) => {
-  let stdoutStub: any;
-  let dateNowStub: any;
-  let consoleLogStub: any;
+  let stdoutStub: Stub;
+  let dateNowStub: Stub;
+  let consoleLogStub: Stub;
 
   await t.step("should update with number and path", () => {
     stdoutStub = stub(Deno.stdout, "writeSync", () => 0);
@@ -471,7 +511,8 @@ Deno.test("UI Progress - ProgressRenderer", async (t) => {
 
   await t.step("should clear interval on update", () => {
     restore(); // Clean up any previous stubs
-    const mockIntervalId = 789;
+    const mockIntervalId = setInterval(() => {}, 60_000);
+    clearInterval(mockIntervalId);
     const setIntervalStub = stub(
       globalThis,
       "setInterval",
@@ -483,7 +524,7 @@ Deno.test("UI Progress - ProgressRenderer", async (t) => {
     const progress = new ProgressRenderer(5);
 
     // Simulate having an interval
-    (progress as any).intervalId = mockIntervalId;
+    rendererInternals(progress).intervalId = mockIntervalId;
 
     progress.update({
       total: 5,
@@ -503,7 +544,7 @@ Deno.test("UI Progress - ProgressRenderer", async (t) => {
 });
 
 Deno.test("UI Progress - ProgressRenderer colored bar and retry count", async (t) => {
-  let stdoutStub: any;
+  let stdoutStub: Stub;
 
   await t.step("should show retry count in progress text", () => {
     restore();
@@ -615,6 +656,31 @@ Deno.test("UI Progress - ProgressRenderer colored bar and retry count", async (t
     stdoutStub.restore();
   });
 
+  await t.step("should keep bar width stable when retry overlaps completion", () => {
+    restore();
+    stdoutStub = stub(Deno.stdout, "writeSync", () => 0);
+    stub(Deno, "consoleSize", () => ({ columns: 300, rows: 50 }));
+
+    const progress = new ProgressRenderer(10);
+    progress.update({
+      total: 10,
+      completed: 10,
+      failed: 0,
+      inProgress: 0,
+      retrying: 1,
+    });
+
+    let allOutput = "";
+    for (const call of stdoutStub.calls) {
+      allOutput += new TextDecoder().decode(call.args[0]);
+    }
+
+    assertEquals(extractFirstBar(allOutput).length, 30);
+    assertStringIncludes(allOutput, "1 retry");
+
+    stdoutStub.restore();
+  });
+
   await t.step("should render skipped files separately from green completions", () => {
     restore();
     stdoutStub = stub(Deno.stdout, "writeSync", () => 0);
@@ -638,7 +704,6 @@ Deno.test("UI Progress - ProgressRenderer colored bar and retry count", async (t
     assertStringIncludes(allOutput, "0 ok, 10 skip");
     if (!Deno.noColor) {
       assertStringIncludes(allOutput, "\x1b[2m");
-      assertEquals(allOutput.includes("\x1b[32m"), false);
     }
 
     stdoutStub.restore();
@@ -672,8 +737,8 @@ Deno.test("UI Progress - ProgressRenderer colored bar and retry count", async (t
 });
 
 Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
-  let stdoutStub: any;
-  let consoleSizeStub: any;
+  let stdoutStub: Stub;
+  let consoleSizeStub: Stub;
 
   await t.step("should render server bars when showServerBars is true", () => {
     stdoutStub = stub(Deno.stdout, "writeSync", () => 0);
@@ -687,7 +752,7 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
       "https://server1.com",
       "https://server2.com",
     ]);
-    (renderer as any).showServerBars = true;
+    rendererInternals(renderer).showServerBars = true;
     renderer.update({
       total: 6,
       completed: 3,
@@ -733,7 +798,7 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
     );
 
     const renderer = new ProgressRenderer(6, ["https://server1.com"]);
-    (renderer as any).showServerBars = true;
+    rendererInternals(renderer).showServerBars = true;
     renderer.update({
       total: 6,
       completed: 2,
@@ -769,7 +834,7 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
     );
 
     const renderer = new ProgressRenderer(6, ["https://server1.com"]);
-    (renderer as any).showServerBars = true;
+    rendererInternals(renderer).showServerBars = true;
     renderer.update({
       total: 6,
       completed: 2,
@@ -805,7 +870,7 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
     );
 
     const renderer = new ProgressRenderer(6, ["https://server1.com"]);
-    (renderer as any).showServerBars = true;
+    rendererInternals(renderer).showServerBars = true;
     renderer.update({
       total: 6,
       completed: 5,
@@ -841,7 +906,7 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
     );
 
     const renderer = new ProgressRenderer(6, ["https://server1.com"]);
-    (renderer as any).showServerBars = true;
+    rendererInternals(renderer).showServerBars = true;
     renderer.update({
       total: 6,
       completed: 6,
@@ -884,8 +949,8 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
     );
 
     const renderer = new ProgressRenderer(3, ["https://server1.com"]);
-    const startTime = (renderer as any).startTime;
-    (renderer as any).showServerBars = true;
+    const startTime = rendererInternals(renderer).startTime;
+    rendererInternals(renderer).showServerBars = true;
     renderer.update({
       total: 3,
       completed: 3,
@@ -925,7 +990,7 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
       "https://server1.com",
       "https://server2.com",
     ]);
-    (renderer as any).showServerBars = true;
+    rendererInternals(renderer).showServerBars = true;
     renderer.update({
       total: 6,
       completed: 3,
@@ -969,7 +1034,7 @@ Deno.test("UI Progress - ProgressRenderer multi-line rendering", async (t) => {
       "https://server1.com",
       "https://server2.com",
     ]);
-    (renderer as any).showServerBars = true;
+    rendererInternals(renderer).showServerBars = true;
 
     const spData = {
       "https://server1.com": {
@@ -1030,7 +1095,7 @@ Deno.test("UI Progress - ProgressRenderer multi-line rendering", async (t) => {
         "https://server1.com",
         "https://server2.com",
       ]);
-      (renderer as any).showServerBars = true;
+      rendererInternals(renderer).showServerBars = true;
 
       // Update to set lastLineCount > 1
       renderer.update({
@@ -1146,7 +1211,7 @@ Deno.test("UI Progress - ProgressRenderer interval clearing", async (t) => {
     const clearIntervalStub = stub(globalThis, "clearInterval", () => {});
 
     const renderer = new ProgressRenderer(5);
-    (renderer as any).intervalId = 42;
+    rendererInternals(renderer).intervalId = 42;
     renderer.stop();
 
     assertEquals(clearIntervalStub.calls.length >= 1, true);
@@ -1162,7 +1227,7 @@ Deno.test("UI Progress - ProgressRenderer interval clearing", async (t) => {
     const clearIntervalStub = stub(globalThis, "clearInterval", () => {});
 
     const renderer = new ProgressRenderer(5);
-    (renderer as any).intervalId = 99;
+    rendererInternals(renderer).intervalId = 99;
     renderer.complete(true, "done");
 
     assertEquals(clearIntervalStub.calls.length >= 1, true);
@@ -1189,7 +1254,7 @@ Deno.test("UI Progress - ProgressRenderer shrinking line count", async (t) => {
         "https://server1.com",
         "https://server2.com",
       ]);
-      (renderer as any).showServerBars = true;
+      rendererInternals(renderer).showServerBars = true;
 
       const spData = {
         "https://server1.com": {
@@ -1217,7 +1282,7 @@ Deno.test("UI Progress - ProgressRenderer shrinking line count", async (t) => {
       });
 
       // Turn off server bars for second render: only 1 line
-      (renderer as any).showServerBars = false;
+      rendererInternals(renderer).showServerBars = false;
       renderer.update({ total: 6, completed: 4, failed: 0, inProgress: 2 });
 
       // Collect all output
@@ -1245,7 +1310,7 @@ Deno.test("UI Progress - ProgressRenderer server bars with zero columns", async 
       });
 
       const renderer = new ProgressRenderer(3, ["https://server1.com"]);
-      (renderer as any).showServerBars = true;
+      rendererInternals(renderer).showServerBars = true;
       renderer.update({
         total: 3,
         completed: 1,
@@ -1284,7 +1349,7 @@ Deno.test("UI Progress - ProgressRenderer server bars with zero columns", async 
     );
 
     const renderer = new ProgressRenderer(3, ["https://server1.com"]);
-    (renderer as any).showServerBars = true;
+    rendererInternals(renderer).showServerBars = true;
     renderer.update({
       total: 3,
       completed: 0,

--- a/tests/unit/upload_existence_test.ts
+++ b/tests/unit/upload_existence_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertExists } from "@std/assert";
+import { assert, assertEquals, assertExists } from "@std/assert";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { processUploads, type Signer } from "../../src/lib/upload.ts";
 import type { FileEntry, NostrEvent, NostrEventTemplate } from "../../src/lib/nostr.ts";
@@ -8,6 +8,29 @@ const originalFetch = globalThis.fetch;
 const originalWebSocket = globalThis.WebSocket;
 let originalSetTimeout: typeof globalThis.setTimeout;
 
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  message: string,
+  timeoutMs = 500,
+): Promise<void> {
+  const startedAt = Date.now();
+
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(message);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+}
+
 describe({
   name: "Upload Module File Existence",
   sanitizeOps: false,
@@ -15,8 +38,8 @@ describe({
 }, () => {
   // Mock signer for testing
   const mockSigner: Signer = {
-    async signEvent(event: NostrEventTemplate): Promise<NostrEvent> {
-      return {
+    signEvent(event: NostrEventTemplate): Promise<NostrEvent> {
+      return Promise.resolve({
         id: "mock-event-id",
         pubkey: "mock-pubkey",
         created_at: event.created_at,
@@ -24,7 +47,7 @@ describe({
         tags: event.tags,
         content: event.content,
         sig: "mock-signature",
-      };
+      });
     },
     getPublicKey(): string {
       return "mock-pubkey";
@@ -56,7 +79,7 @@ describe({
     storedBlobs.add("existing1234567890");
 
     // Setup mock fetch
-    globalThis.fetch = async (
+    globalThis.fetch = (
       url: string | URL | Request,
       options?: RequestInit,
     ): Promise<Response> => {
@@ -67,17 +90,17 @@ describe({
         // Extract hash from auth or just mark all known hashes as stored
         // The upload puts the file on the server; mark test file hash as stored
         storedBlobs.add("abcdef1234567890");
-        return new Response("", { status: 200 });
+        return Promise.resolve(new Response("", { status: 200 }));
       } else if (method === "HEAD") {
         // Check if the blob hash is in our store
         for (const hash of storedBlobs) {
           if (urlStr.includes(hash)) {
-            return new Response("", { status: 200 });
+            return Promise.resolve(new Response("", { status: 200 }));
           }
         }
-        return new Response("", { status: 404 });
+        return Promise.resolve(new Response("", { status: 404 }));
       } else {
-        return new Response("", { status: 404 });
+        return Promise.resolve(new Response("", { status: 404 }));
       }
     };
 
@@ -113,7 +136,7 @@ describe({
         }, 5);
       }
 
-      send(data: string): void {
+      send(_data: string): void {
         // ignore in this simple mock
       }
 
@@ -173,7 +196,7 @@ describe({
 
   it("should correctly mark files that already exist", async () => {
     // Override fetch to specifically test already existing file case
-    globalThis.fetch = async (
+    globalThis.fetch = (
       url: string | URL | Request,
       options?: RequestInit,
     ): Promise<Response> => {
@@ -181,11 +204,11 @@ describe({
       const method = options?.method || "GET";
 
       if (urlStr.includes("existing1234567890") && method === "HEAD") {
-        return new Response("", { status: 200 });
+        return Promise.resolve(new Response("", { status: 200 }));
       } else if (method === "HEAD") {
-        return new Response("", { status: 404 });
+        return Promise.resolve(new Response("", { status: 404 }));
       } else {
-        return new Response("", { status: 200 });
+        return Promise.resolve(new Response("", { status: 200 }));
       }
     };
 
@@ -215,5 +238,135 @@ describe({
       true,
       "Server should report success for already existing file",
     );
+  });
+
+  it("should let each server drain its upload queue independently", async () => {
+    const fastServer = "https://fast-server.test";
+    const slowServer = "https://slow-server.test";
+    const relays = ["wss://test-relay.com"];
+    const files: FileEntry[] = [
+      {
+        path: "/one.txt",
+        data: new TextEncoder().encode("one"),
+        sha256: "hash-one",
+        contentType: "text/plain",
+        size: 3,
+      },
+      {
+        path: "/two.txt",
+        data: new TextEncoder().encode("two"),
+        sha256: "hash-two",
+        contentType: "text/plain",
+        size: 3,
+      },
+      {
+        path: "/three.txt",
+        data: new TextEncoder().encode("three"),
+        sha256: "hash-three",
+        contentType: "text/plain",
+        size: 5,
+      },
+    ];
+    const hashByFileName = new Map(files.map((file) => [
+      file.path.split("/").pop() || file.path,
+      file.sha256,
+    ]));
+    const storedBlobs = new Map<string, Set<string>>([
+      [fastServer, new Set<string>()],
+      [slowServer, new Set<string>()],
+    ]);
+    const slowHeadStarted = createDeferred();
+    const releaseSlowHead = createDeferred();
+    const fastPutOrder: string[] = [];
+    let delayedSlowPreflight = false;
+    let slowFirstHeadResolved = false;
+
+    globalThis.fetch = async (
+      url: string | URL | Request,
+      options?: RequestInit,
+    ): Promise<Response> => {
+      const urlStr = url.toString();
+      const method = options?.method || "GET";
+      const server = urlStr.startsWith(slowServer) ? slowServer : fastServer;
+      const hash = urlStr.slice(urlStr.lastIndexOf("/") + 1);
+      const serverBlobs = storedBlobs.get(server);
+
+      if (method === "HEAD") {
+        if (
+          server === slowServer &&
+          hash === files[0].sha256 &&
+          !delayedSlowPreflight &&
+          !serverBlobs?.has(hash)
+        ) {
+          delayedSlowPreflight = true;
+          slowHeadStarted.resolve();
+          await releaseSlowHead.promise;
+          slowFirstHeadResolved = true;
+        }
+
+        return new Response("", { status: serverBlobs?.has(hash) ? 200 : 404 });
+      }
+
+      if (urlStr.endsWith("/upload") && method === "PUT") {
+        const body = options?.body;
+        assert(body instanceof File, "Upload body should be a File");
+        const uploadedHash = hashByFileName.get(body.name);
+        assertExists(uploadedHash, `Unexpected uploaded file ${body.name}`);
+
+        serverBlobs?.add(uploadedHash);
+        if (server === fastServer) {
+          fastPutOrder.push(uploadedHash);
+        }
+
+        return new Response("", { status: 200 });
+      }
+
+      return new Response("", { status: 404 });
+    };
+
+    const uploadPromise = processUploads(
+      files,
+      "/test",
+      [fastServer, slowServer],
+      mockSigner,
+      relays,
+      1,
+    );
+
+    await slowHeadStarted.promise;
+
+    let regressionError: unknown;
+    try {
+      await waitFor(
+        () => fastPutOrder.length >= 2,
+        "Fast server did not advance past the first file while slow server was blocked",
+      );
+      assertEquals(
+        slowFirstHeadResolved,
+        false,
+        "Fast server should start later files before the slow server releases its first file",
+      );
+    } catch (error) {
+      regressionError = error;
+    } finally {
+      releaseSlowHead.resolve();
+    }
+
+    const results = await uploadPromise;
+    if (regressionError) {
+      throw regressionError;
+    }
+
+    assertEquals(
+      fastPutOrder,
+      files.map((file) => file.sha256),
+      "Fast server should drain its full queue in file order",
+    );
+    assertEquals(results.length, files.length);
+    assertEquals(results.every((result) => result.success), true);
+    for (const result of results) {
+      assertEquals(result.serverResults[fastServer].success, true);
+      assertEquals(result.serverResults[slowServer].success, true);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Upload blobs through independent per-server queues so slow servers do not block fast ones.
- Render skipped blobs separately and clamp transient retry bar segments so progress bars keep a stable width.
- Fix current-Deno compatibility in compile/test setup (`setTimeout` handles and getter-only `Deno.Command`).

## Verification
- `deno test --allow-all --no-check tests/unit/ui_progress_test.ts`
- `deno test --allow-all --no-check tests/unit/secrets_safe_test.ts tests/unit/time_formatter_test.ts`
- `deno lint src/ui/progress.ts tests/unit/ui_progress_test.ts`
- `deno check tests/unit/ui_progress_test.ts tests/test-setup-global.ts`
- `deno task coverage`
- `deno task compile`
- GitHub PR checks pass on `221aa54`: coverage, docs drift, Linux, macOS, Windows