### PR TITLE
Add --prompt-sec flag for runtime secret entry

### DIFF
--- a/docs/usage/commands/announce.md
+++ b/docs/usage/commands/announce.md
@@ -21,6 +21,8 @@ nsyte announce [options]
 - `--all` — Publish all available data
 - `--sec <secret>` — Secret for signing (auto-detects format: nsec, nbunksec,
   bunker:// URL, or 64-char hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of
+  `--sec` (keeps it out of shell history)
 - `--dry-run` — Preview what would be announced without publishing (default:
   false)
 - `--dry-run-output <dir>` — Directory to write dry-run event JSON files

--- a/docs/usage/commands/browse.md
+++ b/docs/usage/commands/browse.md
@@ -18,6 +18,7 @@ nsyte browse [options]
 
 - `-r, --relays <relays>` — Nostr relays to query (comma-separated)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec, bunker://, hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of `--sec` (keeps it out of shell history)
 - `-p, --pubkey <npub>` — Public key to browse (npub, hex, or NIP-05 like name@domain.com)
 - `--use-fallback-relays` — Include default nsyte relays for better discovery
 - `--use-fallbacks` — Enable all fallback options (relays)

--- a/docs/usage/commands/delete.md
+++ b/docs/usage/commands/delete.md
@@ -27,6 +27,8 @@ nsyte delete [options]
 - `--include-blobs` — Also delete blobs from blossom servers (default: false)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec,
   bunker://, hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of
+  `--sec` (keeps it out of shell history)
 - `-d, --name <name>` — Site identifier for named sites. If not provided,
   deletes root site
 - `--dry-run` — Preview delete events without publishing or deleting blobs

--- a/docs/usage/commands/deploy.md
+++ b/docs/usage/commands/deploy.md
@@ -23,6 +23,8 @@ nsyte deploy <folder> [options]
 - `-r, --relays <relays>` — The nostr relays to use (comma-separated)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec,
   bunker://, hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of
+  `--sec` (keeps it out of shell history)
 - `--sync` — Check all servers and upload missing blobs (default: false)
 - `--use-fallback-relays` — Include default nsyte relays in addition to
   configured relays

--- a/docs/usage/commands/download.md
+++ b/docs/usage/commands/download.md
@@ -19,6 +19,7 @@ nsyte download [options]
 - `-r, --relays <relays>` — Nostr relays to query (comma-separated)
 - `-s, --servers <servers>` — Blossom servers to download from (comma-separated)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec, bunker://, hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of `--sec` (keeps it out of shell history)
 - `-p, --pubkey <npub>` — Public key to download files from (npub or hex)
 - `-d, --name <name>` — Site identifier for named sites. If not provided, downloads root site
 - `--overwrite` — Overwrite existing files (default: `false`)

--- a/docs/usage/commands/ls.md
+++ b/docs/usage/commands/ls.md
@@ -28,6 +28,7 @@ nsyte ls   [path] [options]   # alias
 - `-r, --relays <relays>` — The nostr relays to use (comma-separated). If not specified, uses relays
   from project config or default discovery relays
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec, bunker://, hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of `--sec` (keeps it out of shell history)
 - `-p, --pubkey <npub>` — The public key to list files for (npub, hex, or NIP-05)
 - `-d, --name <name>` — Site identifier for named sites. If not provided, lists root site
 - `--use-fallback-relays` — Include default nsyte relays in addition to configured relays

--- a/docs/usage/commands/put.md
+++ b/docs/usage/commands/put.md
@@ -29,6 +29,8 @@ nsyte put <local-file> <remote-path> [options]
 
 - `--sec <secret>` — Secret for signing (auto-detects format: nsec, nbunksec,
   bunker:// URL, or 64-char hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of
+  `--sec` (keeps it out of shell history)
 - `-n, --name <name>` — The site identifier for named sites (kind 35128). If not
   provided, updates the root site (kind 15128)
 - `--dry-run` — Preview the upload and manifest update without uploading or

--- a/docs/usage/commands/run.md
+++ b/docs/usage/commands/run.md
@@ -28,6 +28,7 @@ nsyte run [npub] [options]
 - `-r, --relays <relays>` — Nostr relays to query (comma-separated)
 - `-p, --port <port>` — Port number to run the resolver on (default: 6798)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec, bunker://, hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of `--sec` (keeps it out of shell history)
 - `-c, --cache-dir <dir>` — Directory to cache files (default: `/tmp/nsyte` or `%TEMP%\nsyte`)
 - `--no-cache` — Disable file caching entirely
 - `--use-fallback-relays` — Include default nsyte relays for file discovery

--- a/docs/usage/commands/sites.md
+++ b/docs/usage/commands/sites.md
@@ -17,6 +17,7 @@ nsyte sites [options]
 
 - `-r, --relays <relays>` — Nostr relays to query (comma-separated)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec, bunker://, hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of `--sec` (keeps it out of shell history)
 - `-p, --pubkey <npub>` — Public key to list sites for (npub or hex format)
 - `--use-fallback-relays` — Include default nsyte relays in addition to configured relays
 - `--use-fallbacks` — Enable all fallback options (relays)

--- a/docs/usage/commands/snapshot.md
+++ b/docs/usage/commands/snapshot.md
@@ -23,6 +23,8 @@ nsyte snapshot [options]
 - `-r, --relays <relays>` — The nostr relays to use (comma separated)
 - `--sec <secret>` — Secret for signing (auto-detects format: nsec, nbunksec,
   bunker:// URL, or 64-char hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of
+  `--sec` (keeps it out of shell history)
 - `-d, --name <name>` — The site identifier for named sites (kind 35128). If not
   provided, snapshots the root site (kind 15128)
 - `--dry-run` — Preview the snapshot event without signing or publishing it

--- a/docs/usage/commands/status.md
+++ b/docs/usage/commands/status.md
@@ -27,6 +27,8 @@ nsyte status [path] [options]
 - `-r, --relays <relays>` — The nostr relays to use (comma separated)
 - `--sec <secret>` — Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or
   64-char hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of
+  `--sec` (keeps it out of shell history)
 - `-p, --pubkey <npub>` — The public key to inspect (npub, hex, or NIP-05 identifier like
   `name@domain.com`)
 - `-d, --name <name>` — The site identifier for named sites (kind 35128). If not provided, inspects

--- a/docs/usage/commands/undeploy.md
+++ b/docs/usage/commands/undeploy.md
@@ -22,6 +22,8 @@ nsyte undeploy [options]
   (comma-separated)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec,
   bunker://, hex)
+- `--prompt-sec` — Prompt for the signing secret at runtime instead of
+  `--sec` (keeps it out of shell history)
 - `-d, --name <name>` — Site identifier for named sites. If not provided,
   undeploys root site
 - `--dry-run` — Preview undeploy events without publishing or deleting blobs

--- a/src/commands/announce.ts
+++ b/src/commands/announce.ts
@@ -1,6 +1,7 @@
 import { colors } from "@cliffy/ansi/colors";
 import nsyte from "./root.ts";
 import { createSigner } from "../lib/auth/signer-factory.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { readProjectFile } from "../lib/config.ts";
 import { RELAY_DISCOVERY_RELAYS } from "../lib/constants.ts";
 import {
@@ -27,6 +28,10 @@ export function registerAnnounceCommand(): void {
     .option(
       "--sec <secret:string>",
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
+    )
+    .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
     )
     .option("--dry-run", "Preview what would be announced without publishing.", {
       default: false,
@@ -84,6 +89,9 @@ export function registerAnnounceCommand(): void {
 
           Deno.exit(0);
         }
+
+        // Prompt for the secret at runtime if requested
+        await resolvePromptSec(options, config.bunkerPubkey);
 
         // Initialize signer
         status.update("Initializing signer...");

--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -13,6 +13,7 @@ import { DEFAULT_IGNORE_PATTERNS, type IgnoreRule, parseIgnorePatterns } from ".
 import { createLogger } from "../lib/logger.ts";
 import { pool } from "../lib/nostr.ts";
 import { resolvePubkey, resolveRelays } from "../lib/resolver-utils.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { extractServersFromEvent, extractServersFromManifestEvents } from "../lib/utils.ts";
 import {
   handleAuthInput,
@@ -47,6 +48,10 @@ export function registerBrowseCommand(): void {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-p, --pubkey <npub:string>",
       "The public key to list files for (npub, hex, or NIP-05 identifier like name@domain.com).",
     )
@@ -59,6 +64,9 @@ export function registerBrowseCommand(): void {
       try {
         let useDiscoveryRelays = false;
         let previousPubkey: string | undefined = undefined;
+
+        // Prompt for the secret at runtime if requested
+        await resolvePromptSec(options, readProjectFile(options.config)?.bunkerPubkey);
 
         // Loop to allow identity switching
         while (true) {

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -2,6 +2,7 @@ import { colors } from "@cliffy/ansi/colors";
 import { Confirm } from "@cliffy/prompt";
 import { encodeBase64 } from "@std/encoding/base64";
 import { createSigner } from "../lib/auth/signer-factory.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { readProjectFile } from "../lib/config.ts";
 import { handleDryRunOutput, parseDryRunShowKinds } from "../lib/dry-run/mod.ts";
 import { createLogger } from "../lib/logger.ts";
@@ -153,6 +154,10 @@ export function registerDeleteCommand() {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-d, --name <name:string>",
       "The site identifier for named sites (kind 35128). If not provided, deletes root site (kind 15128).",
     )
@@ -176,6 +181,9 @@ export function registerDeleteCommand() {
 
       log.debug(`Starting deleteCommand with options: ${JSON.stringify(options)}`);
       console.log(colors.bold.magenta("\nnsyte delete\n"));
+
+      // Prompt for the secret at runtime if requested
+      await resolvePromptSec(options, readProjectFile(options.config)?.bunkerPubkey);
 
       // Get config
       log.debug("Reading project file...");

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -6,6 +6,7 @@ import { getOutboxes, naddrEncode, npubEncode, relaySet } from "applesauce-core/
 import { loadAsyncMap } from "applesauce-loaders/helpers";
 import { type ISigner, NostrConnectSigner } from "applesauce-signers";
 import { createSigner as createSignerFromFactory } from "../lib/auth/signer-factory.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import {
   defaultConfig,
   type ProjectConfig,
@@ -84,6 +85,8 @@ export interface DeployCommandOptions {
   relays?: string;
   /** Unified secret parameter (auto-detects format: nsec, nbunksec, bunker URL, or hex) */
   sec?: string;
+  /** When true, prompt for the secret at runtime instead of reading it from --sec */
+  promptSec?: boolean;
   concurrency: number;
   fallback?: string;
   publishAppHandler: boolean;
@@ -184,6 +187,10 @@ export function registerDeployCommand(): void {
     .option(
       "--sec <secret:string>",
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
+    )
+    .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
     )
     .option("--sync", "Check all servers and upload missing blobs.", {
       default: false,
@@ -316,6 +323,13 @@ export async function deployCommand(
   const messageCollector = new MessageCollector(displayManager.isInteractive());
 
   try {
+    // Prompt for the secret at runtime if requested, before resolving auth context
+    const promptConfigPath = typeof options.config === "string" ? options.config : undefined;
+    const configuredBunkerPubkey = options.config === false
+      ? null
+      : readProjectFile(promptConfigPath)?.bunkerPubkey;
+    await resolvePromptSec(options, configuredBunkerPubkey);
+
     const currentWorkingDir = Deno.cwd();
     const targetDir = join(currentWorkingDir, fileOrFolder);
     const context = await resolveContext(options);

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -9,6 +9,7 @@ import {
   type ResolverOptions,
   resolveServers,
 } from "../lib/resolver-utils.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { readProjectFile } from "../lib/config.ts";
 import { getDisplayManager } from "../lib/display-mode.ts";
 import { type DownloadResult, DownloadService } from "../lib/download.ts";
@@ -44,6 +45,10 @@ export function registerDownloadCommand(): void {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-p, --pubkey <npub:string>",
       "The public key to download files from (npub, hex, or NIP-05 identifier like name@domain.com).",
     )
@@ -56,6 +61,9 @@ export function registerDownloadCommand(): void {
     .action(async (options) => {
       const displayManager = getDisplayManager();
       displayManager.configureFromOptions(options);
+
+      // Prompt for the secret at runtime if requested
+      await resolvePromptSec(options, readProjectFile(options.config)?.bunkerPubkey);
 
       // Resolve public key
       const pubkey = await resolvePubkey(options, readProjectFile(options.config), false);

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -5,6 +5,7 @@ import { handleError } from "../lib/error-utils.ts";
 import { getManifestFiles } from "../lib/manifest.ts";
 import { getUserDisplayName } from "../lib/nostr.ts";
 import { resolvePubkey, resolveRelays } from "../lib/resolver-utils.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { fetchTrustedSiteManifestEvent } from "../lib/site-manifest.ts";
 import { buildListTreeItems } from "../ui/file-tree.ts";
 import { formatManifestIdWithAge } from "../ui/time-formatter.ts";
@@ -14,6 +15,7 @@ interface ListCommandOptions {
   config?: string;
   relays?: string;
   sec?: string;
+  promptSec?: boolean;
   pubkey?: string;
   name?: string;
   useFallbackRelays?: boolean;
@@ -59,6 +61,10 @@ export function registerListCommand() {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-p, --pubkey <npub:string>",
       "The public key to list files for (npub, hex, or NIP-05 identifier like name@domain.com).",
     )
@@ -72,6 +78,7 @@ export function registerListCommand() {
     )
     .option("--use-fallbacks", "Enable all fallbacks (currently only relays for this command).")
     .action(async (options: ListCommandOptions, pathFilter?: string) => {
+      await resolvePromptSec(options, readProjectFile(options.config)?.bunkerPubkey);
       const pubkey = await resolvePubkey(options);
       const projectConfig = readProjectFile(options.config);
       const allowFallbackRelays = options.useFallbacks || options.useFallbackRelays || false;

--- a/src/commands/put.ts
+++ b/src/commands/put.ts
@@ -7,6 +7,7 @@ import type { NostrEventTemplate } from "../lib/nostr.ts";
 import nsyte from "./root.ts";
 import { readProjectFile } from "../lib/config.ts";
 import { createSigner } from "../lib/auth/signer-factory.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { getErrorMessage } from "../lib/error-utils.ts";
 import { handleDryRunOutput, parseDryRunShowKinds } from "../lib/dry-run/mod.ts";
 import { createLogger } from "../lib/logger.ts";
@@ -21,6 +22,7 @@ const log = createLogger("put");
 interface PutCommandOptions {
   name?: string;
   sec?: string;
+  promptSec?: boolean;
   config?: string;
   /** Override created_at timestamp for nostr events (from --created-at global option) */
   createdAt?: number;
@@ -142,6 +144,10 @@ export function registerPutCommand(): void {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-n, --name <name:string>",
       "The site identifier for named sites (kind 35128). If not provided, updates the root site (kind 15128).",
     )
@@ -163,6 +169,8 @@ export function registerPutCommand(): void {
         if (!config) {
           throw new Error("No .nsite/config.json found. Run 'nsyte init' first.");
         }
+
+        await resolvePromptSec(options, config.bunkerPubkey);
 
         const signerResult = await createSigner({
           sec: options.sec,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -74,6 +74,10 @@ export function registerRunCommand(): void {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-c, --cache-dir <dir:string>",
       "Directory to cache downloaded files (default: /tmp/nsyte)",
     )

--- a/src/commands/sites.ts
+++ b/src/commands/sites.ts
@@ -16,6 +16,7 @@ import {
 } from "../lib/manifest.ts";
 import { getUserDisplayName, getUserOutboxes, pool, store } from "../lib/nostr.ts";
 import { resolvePubkey, resolveRelays } from "../lib/resolver-utils.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { formatTimestamp } from "../ui/time-formatter.ts";
 import nsyte from "./root.ts";
 
@@ -39,6 +40,7 @@ interface SitesCommandOptions {
   config?: string;
   relays?: string;
   sec?: string;
+  promptSec?: boolean;
   pubkey?: string;
   useFallbackRelays?: boolean;
   useFallbacks?: boolean;
@@ -59,6 +61,10 @@ export function registerSitesCommand() {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-p, --pubkey <npub:string>",
       "The public key to list sites for (npub, hex, or NIP-05 identifier like name@domain.com).",
     )
@@ -68,6 +74,7 @@ export function registerSitesCommand() {
     )
     .option("--use-fallbacks", "Enable all fallbacks (currently only relays for this command).")
     .action(async (options: SitesCommandOptions) => {
+      await resolvePromptSec(options, readProjectFile(options.config)?.bunkerPubkey);
       const pubkey = await resolvePubkey(options);
       const projectConfig = readProjectFile(options.config);
       const allowFallbackRelays = options.useFallbacks || options.useFallbackRelays || false;

--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -1,5 +1,6 @@
 import { colors } from "@cliffy/ansi/colors";
 import { createSigner } from "../lib/auth/signer-factory.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { readProjectFile } from "../lib/config.ts";
 import { NSYTE_BROADCAST_RELAYS } from "../lib/constants.ts";
 import { handleDryRunOutput, parseDryRunShowKinds } from "../lib/dry-run/mod.ts";
@@ -24,6 +25,7 @@ interface SnapshotCommandOptions {
   config?: string | false;
   relays?: string;
   sec?: string;
+  promptSec?: boolean;
   name?: string;
   dryRun?: boolean;
   dryRunOutput?: string;
@@ -45,6 +47,10 @@ export function registerSnapshotCommand(): void {
     .option(
       "--sec <secret:string>",
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
+    )
+    .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
     )
     .option(
       "-d, --name <name:string>",
@@ -84,6 +90,9 @@ export function registerSnapshotCommand(): void {
 export async function snapshotCommand(options: SnapshotCommandOptions): Promise<void> {
   const configPath = typeof options.config === "string" ? options.config : undefined;
   const config = options.config === false ? null : readProjectFile(configPath);
+
+  await resolvePromptSec(options, config?.bunkerPubkey);
+
   const signerResult = await createSigner({
     sec: options.sec,
     bunkerPubkey: config?.bunkerPubkey,

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -11,6 +11,7 @@ import {
   getUserDisplayName,
 } from "../lib/nostr.ts";
 import { resolvePubkey, resolveRelays } from "../lib/resolver-utils.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { resolveSiteIdentifier } from "../lib/site-identifier.ts";
 import {
   fetchTrustedSiteManifestEvent,
@@ -46,6 +47,7 @@ interface StatusCommandOptions {
   config?: string | false;
   relays?: string;
   sec?: string;
+  promptSec?: boolean;
   pubkey?: string;
   name?: string;
   full?: boolean;
@@ -177,6 +179,10 @@ export function registerStatusCommand() {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-p, --pubkey <npub:string>",
       "The public key to inspect (npub, hex, or NIP-05 identifier like name@domain.com).",
     )
@@ -197,6 +203,7 @@ export function registerStatusCommand() {
       const configPath = typeof options.config === "string" ? options.config : undefined;
       const projectConfig = options.config === false ? null : readProjectFile(configPath);
       const siteName = resolveSiteIdentifier(options.name, projectConfig);
+      await resolvePromptSec(options, projectConfig?.bunkerPubkey);
       const pubkey = await resolvePubkey(options, projectConfig);
       const allowFallbackRelays = options.useFallbacks || options.useFallbackRelays || false;
       const configuredRelays = options.relays !== undefined

--- a/src/commands/undeploy.ts
+++ b/src/commands/undeploy.ts
@@ -3,6 +3,7 @@ import { Input } from "@cliffy/prompt";
 import { encodeBase64 } from "@std/encoding/base64";
 import type { ISigner } from "applesauce-signers";
 import { createSigner } from "../lib/auth/signer-factory.ts";
+import { resolvePromptSec } from "../lib/auth/prompt-secret.ts";
 import { readProjectFile } from "../lib/config.ts";
 import { handleDryRunOutput, parseDryRunShowKinds } from "../lib/dry-run/mod.ts";
 import { handleError } from "../lib/error-utils.ts";
@@ -105,6 +106,10 @@ export function registerUndeployCommand() {
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
     )
     .option(
+      "--prompt-sec",
+      "Prompt for the signing secret (nsec/nbunksec) at runtime instead of passing it via --sec (keeps it out of shell history).",
+    )
+    .option(
       "-d, --name <name:string>",
       "The site identifier for named sites (kind 35128). If not provided, undeploys root site (kind 15128).",
     )
@@ -128,6 +133,9 @@ export function registerUndeployCommand() {
         console.log(colors.red("No .nsite/config.json found. Please run 'nsyte init' first."));
         return Deno.exit(1);
       }
+
+      // Prompt for the secret at runtime if requested
+      await resolvePromptSec(options, config.bunkerPubkey);
 
       // Initialize signer
       const signerResult = await createSigner({

--- a/src/lib/auth/prompt-secret.ts
+++ b/src/lib/auth/prompt-secret.ts
@@ -1,0 +1,161 @@
+import { colors } from "@cliffy/ansi/colors";
+import { Confirm, Secret } from "@cliffy/prompt";
+import { PrivateKeySigner } from "applesauce-signers";
+import { getErrorMessage } from "../error-utils.ts";
+import { createLogger } from "../logger.ts";
+import { importFromNbunk } from "../nip46.ts";
+import { createNip46ClientFromUrl } from "../nostr.ts";
+import { detectSecretFormat } from "./secret-detector.ts";
+
+const log = createLogger("prompt-secret");
+
+/**
+ * Options that support resolving the signing secret at runtime.
+ *
+ * Commands expose a `--sec` flag (value passed on the command line) and a
+ * `--prompt-sec` flag (value typed in interactively). Both populate `sec`.
+ */
+export interface PromptSecOptions {
+  /** Unified secret parameter (auto-detects format: nsec, nbunksec, bunker URL, or hex) */
+  sec?: string;
+  /** When true, prompt for the secret at runtime instead of reading it from --sec */
+  promptSec?: boolean;
+}
+
+/** Short, human-readable form of a hex pubkey for display. */
+function shortPubkey(pubkey: string): string {
+  return `${pubkey.slice(0, 8)}...${pubkey.slice(-4)}`;
+}
+
+/**
+ * Prompt the user to enter their secret (nsec / nbunksec / bunker:// URL / hex)
+ * interactively, using a hidden input.
+ *
+ * Keeping the secret off the command line avoids it being captured by shell
+ * history, process listings, or CI logs. The input is validated against the
+ * same format detection used by `--sec`, re-prompting on invalid input.
+ *
+ * @returns the validated secret string
+ */
+export async function promptForSecret(): Promise<string> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const entered = (await Secret.prompt({
+      message: "Enter your nsec or nbunksec:",
+    })).trim();
+
+    if (detectSecretFormat(entered)) {
+      return entered;
+    }
+
+    console.error(
+      colors.red(
+        "Invalid secret format. Expected nsec, nbunksec, bunker:// URL, or 64-character hex string.",
+      ),
+    );
+  }
+
+  throw new Error("Failed to read a valid secret after 3 attempts.");
+}
+
+/**
+ * Derive the public key that a secret resolves to, without leaving any open
+ * connections behind. Returns null if the pubkey can't be determined (e.g. an
+ * unreachable bunker) so callers can skip the check rather than block.
+ */
+async function pubkeyFromSecret(secret: string): Promise<string | null> {
+  const detected = detectSecretFormat(secret);
+  if (!detected) {
+    return null;
+  }
+
+  try {
+    switch (detected.format) {
+      case "nsec":
+      case "hex":
+        return await PrivateKeySigner.fromKey(detected.value).getPublicKey();
+      case "nbunksec": {
+        const signer = await importFromNbunk(detected.value);
+        const pubkey = await signer.getPublicKey();
+        if ("close" in signer && typeof signer.close === "function") {
+          await signer.close();
+        }
+        return pubkey;
+      }
+      case "bunker-url": {
+        const { client } = await createNip46ClientFromUrl(detected.value);
+        const pubkey = await client.getPublicKey();
+        if ("close" in client && typeof client.close === "function") {
+          await client.close();
+        }
+        return pubkey;
+      }
+    }
+  } catch (error) {
+    log.debug(`Could not derive pubkey from entered secret: ${getErrorMessage(error)}`);
+  }
+
+  return null;
+}
+
+/**
+ * Warn (and ask to continue) when the entered key resolves to a different
+ * pubkey than the one the project is configured for. Exits if the user declines.
+ */
+async function confirmPubkeyMatch(secret: string, bunkerPubkey: string): Promise<void> {
+  const pubkey = await pubkeyFromSecret(secret);
+  if (!pubkey || pubkey === bunkerPubkey) {
+    return;
+  }
+
+  console.warn(
+    colors.yellow(
+      `\n⚠️  The entered key belongs to ${shortPubkey(pubkey)}, but this project is ` +
+        `configured for ${shortPubkey(bunkerPubkey)}.`,
+    ),
+  );
+  console.warn(colors.yellow("This might be the wrong key.\n"));
+
+  const proceed = await Confirm.prompt({
+    message: "Continue anyway?",
+    default: false,
+  });
+
+  if (!proceed) {
+    console.error(colors.red("Aborted."));
+    Deno.exit(1);
+  }
+}
+
+/**
+ * If `--prompt-sec` was passed and no `--sec` value is already present, prompt
+ * the user for their secret at runtime and populate `options.sec` in place so
+ * all downstream signer/pubkey resolution works unchanged.
+ *
+ * When `bunkerPubkey` is provided (from the project config), the entered key's
+ * pubkey is compared against it and the user is warned before continuing if they
+ * differ — guarding against accidentally signing with the wrong identity.
+ *
+ * No-op when `--prompt-sec` was not passed, or when `--sec` was already
+ * provided (an explicit value always wins).
+ */
+export async function resolvePromptSec(
+  options: PromptSecOptions,
+  bunkerPubkey?: string | null,
+): Promise<void> {
+  if (!options.promptSec) {
+    return;
+  }
+
+  if (options.sec) {
+    log.debug("Ignoring --prompt-sec because --sec was provided explicitly.");
+    return;
+  }
+
+  const secret = await promptForSecret();
+
+  if (bunkerPubkey) {
+    await confirmPubkeyMatch(secret, bunkerPubkey);
+  }
+
+  options.sec = secret;
+}

--- a/src/lib/resolver-utils.ts
+++ b/src/lib/resolver-utils.ts
@@ -18,6 +18,8 @@ export interface ResolverOptions {
   servers?: string;
   /** Unified secret parameter (auto-detects format: nsec, nbunksec, bunker URL, or hex) */
   sec?: string;
+  /** When true, prompt for the secret at runtime instead of reading it from --sec */
+  promptSec?: boolean;
   pubkey?: string;
 }
 


### PR DESCRIPTION
## Summary

Adds a `--prompt-sec` flag alongside every existing `--sec` flag, letting users enter their `nsec`/`nbunksec` **interactively at runtime** instead of passing it on the command line — keeping the secret out of shell history, process listings, and CI logs.

## What's included

- **New helper `src/lib/auth/prompt-secret.ts`:**
  - `promptForSecret()` — hidden input (`Secret.prompt`) validated against the same `detectSecretFormat()` used by `--sec`, re-prompting up to 3 times on invalid input.
  - `resolvePromptSec(options, bunkerPubkey?)` — when `--prompt-sec` is set and no `--sec` was given, prompts and populates `options.sec` in place so all downstream signer/pubkey resolution works unchanged. Explicit `--sec` always wins.
- **`--prompt-sec` option registered on all 12 commands** that expose `--sec`: `announce`, `browse`, `delete`, `deploy`, `download`, `list`, `put`, `run`, `sites`, `snapshot`, `status`, `undeploy`. The call is wired into the 11 commands that actually sign (`run` is read-only and never consumes the secret, so the flag is inert there for parity, matching the existing `--sec`).
- **Wrong-key guard:** when the project config has a `bunkerPubkey` and the entered key resolves to a different pubkey, the user is warned ("This might be the wrong key.") and asked to confirm before continuing. Aborts if declined. Local key formats are checked without a network call; bunker formats connect briefly and close.

## Verification

- `deno check src/cli.ts` passes
- Existing secret/resolver/signer unit tests pass
- `--prompt-sec` renders correctly in `--help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)