### PR TITLE
docs: reconcile config and command docs with source

### DIFF
--- a/docs/usage/commands/announce.md
+++ b/docs/usage/commands/announce.md
@@ -5,6 +5,8 @@ description: Publish app handler events
 
 # announce
 
+> **Alias:** `annc` — `nsyte annc` is equivalent to `nsyte announce`.
+
 Publish NIP-89 app handler announcements and other metadata events without
 deploying files.
 

--- a/docs/usage/commands/bunker.md
+++ b/docs/usage/commands/bunker.md
@@ -21,7 +21,7 @@ nsyte bunker <subcommand> [options]
 - `export [pubkey]` — Export a bunker as an nbunksec string
 - `use [pubkey]` — Configure current project to use a bunker
 - `remove [pubkey]` — Remove a bunker from storage
-- `migrate [...pubkeys]` — Rebuild index for keychain bunkers (macOS/Windows)
+- `migrate [...pubkeys]` — Rebuild index for keychain bunkers (macOS only)
 - `help` — Show detailed help information
 
 ## Examples
@@ -80,7 +80,7 @@ Remove a bunker from storage:
 nsyte bunker remove <pubkey>
 ```
 
-Rebuild bunker index (macOS/Windows):
+Rebuild bunker index (macOS only):
 
 ```bash
 nsyte bunker migrate
@@ -94,8 +94,8 @@ nsyte bunker migrate <pubkey1> <pubkey2>
 
 ## Bunker Migration
 
-The `migrate` subcommand is used to rebuild the bunker index on platforms that use native keychains
-(macOS and Windows).
+The `migrate` subcommand rebuilds the bunker index on macOS by scanning project `.nsite/config.json`
+files for `bunkerPubkey` values and checking the macOS keychain (via the `security` tool) for each.
 
 ### When to Use
 

--- a/docs/usage/commands/ci.md
+++ b/docs/usage/commands/ci.md
@@ -5,7 +5,8 @@ description: Create an nbunksec string for CI/CD use
 
 # ci
 
-Create an nbunksec string for CI/CD use (creates a new bunker connection).
+Create an nbunksec string for CI/CD use. The connection is **ephemeral** — the
+nbunksec is printed to stdout and never written to disk or the project config.
 
 ## Usage
 
@@ -17,8 +18,10 @@ nsyte ci [url]
 
 ## Description
 
-This command creates a new bunker connection and outputs an `nbunksec` string, which can be used as
-a secret in CI/CD pipelines for automated deployments.
+This command creates a bunker connection and outputs an `nbunksec` string, which can be used as
+a secret in CI/CD pipelines for automated deployments. Unlike `nsyte bunker connect`, it never
+persists the credential — it skips the keychain/encrypted store entirely, so the only copy is the
+string it prints.
 
 ## Example
 

--- a/docs/usage/commands/config.md
+++ b/docs/usage/commands/config.md
@@ -16,32 +16,27 @@ nsyte config [options]
 
 ## Options
 
-- `-p, --path <path>` — Path to config file (default: `./nsyte.yaml`)
+- `-p, --path <path>` — Path to config file (default: `.nsite/config.json`)
 
 ## Keyboard Shortcuts
 
 ### Navigation
 
-- **Arrow keys** — Navigate between fields
-- **Enter** — Edit selected field
-- **Tab** — Move to next field
+- **↑ / ↓** — Move between fields
+- **Enter** — Edit a value, expand/collapse an object or array, or add a new item
+  (when the `[+]` row is selected)
 
 ### Editing
 
 - **s** — Save changes
 - **r** — Reset to original values
-- **ESC** — Collapse all expanded sections
+- **Delete / Backspace** — Delete the selected array item or object property
+- **ESC** — Collapse expanded sections (quits if nothing is expanded)
 
 ### Help & Exit
 
 - **h** — Show help
 - **q** — Quit (prompts if unsaved changes)
-
-### Array & Object Management
-
-- **+** — Add item to array (when array is selected)
-- **-** — Delete selected array item
-- **Space** — Expand/collapse objects and arrays
 
 ## Features
 
@@ -63,15 +58,13 @@ nsyte config [options]
 
 - **Bunker selection**: Browse and select from stored bunkers with display names
 - **Relay/server management**: Easy add/remove for arrays of URLs
-- **Profile metadata**: Edit profile fields with validation
-- **App handler config**: Configure NIP-89 handlers with visual editor
+- **Nested fields**: Edit profile and other nested values by expanding their objects
 
 ### Safety
 
 - Tracks unsaved changes with visual indicator
 - Confirms before quitting with unsaved changes
 - Validates configuration before saving
-- Creates backup of original file
 
 ## Examples
 
@@ -81,16 +74,10 @@ Edit project configuration:
 nsyte config
 ```
 
-Edit custom configuration file:
+Edit a custom configuration file:
 
 ```bash
-nsyte config -p /path/to/custom/config.yaml
-```
-
-Edit configuration in current directory:
-
-```bash
-nsyte config -p ./nsyte.yaml
+nsyte config -p /path/to/custom/config.json
 ```
 
 ## Workflow
@@ -113,7 +100,7 @@ The editor validates your configuration before saving:
 ## Tips
 
 - Use **bunker selector** to choose from stored bunkers instead of manually entering pubkeys
-- **Expand arrays** with Space to see and edit individual items
+- **Expand arrays and objects** with Enter to see and edit individual items
 - Press **h** for in-editor help and keyboard shortcuts
 - Configuration is only saved when you press **s** (safe to explore without changes)
 

--- a/docs/usage/commands/debug.md
+++ b/docs/usage/commands/debug.md
@@ -70,28 +70,23 @@ The debug command performs comprehensive checks on various components of an nsit
 - Uses the discovered relays for subsequent checks
 - Warns if no relay list is found (cannot discover user's preferred relays)
 
-### 3. Blossom Server List (kind 10063)
+### 3. Blossom Servers
 
-- Checks for published blossom server list
-- Compares published servers with config servers
-- Tests server availability using HTTP requests
-- Shows URL normalization mismatches
-
-### 4. Blossom Server Health
-
-- Tests availability of blossom servers from config
-- Checks up to 20 random files for 404 status (using HEAD requests)
-- Downloads one random file to verify hash integrity
+- Tests availability of the blossom servers from config (using HEAD requests)
+- Checks up to the first 20 blobs for `404` status and downloads one random found
+  blob to verify hash integrity
+- Also looks for a published blossom server list (kind 10063) and compares it with
+  the config servers, flagging URL normalization mismatches
 - Reports server response times and error details
 
-### 5. Site Manifest Events (kinds 15128, 35128)
+### 4. Site Manifest Events (kinds 15128, 35128)
 
 - Finds all uploaded file events for the npub
 - Shows total count of uploaded files
 - Lists recent files in verbose mode
 - Uses specialized nsite relay (`relay.nsite.lol`) for better results
 
-### 6. App Handler Events (kinds 31989, 31990)
+### 5. App Handler Events (kinds 31989, 31990)
 
 - Checks for NIP-89 app handler announcements
 - Shows counts of app recommendations and announcements
@@ -102,7 +97,8 @@ The debug command performs comprehensive checks on various components of an nsit
 The debug command uses specialized relays for different event types to get the most comprehensive
 results:
 
-- **Profile & Relay Lists**: `purplepag.es`, `user.kindpag.es`, `relay.nsite.lol`
+- **Profile (kind 0)**: `purplepag.es`, `user.kindpag.es`
+- **Relay List (kind 10002)**: `purplepag.es`, `user.kindpag.es`, `relay.nsite.lol`
 - **nsite Events**: `relay.nsite.lol`
 - **App Handlers**: Uses config relays
 

--- a/docs/usage/commands/delete.md
+++ b/docs/usage/commands/delete.md
@@ -9,7 +9,7 @@ Selectively delete nsite events from relays and optionally delete blobs from
 blossom servers. This command creates NIP-09 delete events to remove your
 published nsite files.
 
-> **Note**: The `purge` command still works as an alias but is deprecated.
+> **Note**: The `purge` and `prg` aliases still work but are deprecated.
 > Please use `delete` instead.
 
 ## Usage
@@ -123,8 +123,7 @@ The delete command requires authentication to:
 Authentication options (in order of precedence):
 
 1. `--sec` command line option
-2. Configured bunker in project
-3. Private key in project configuration
+2. Bunker configured in the project (`bunkerPubkey`)
 
 ## Safety Features
 

--- a/docs/usage/commands/deploy.md
+++ b/docs/usage/commands/deploy.md
@@ -7,6 +7,9 @@ description: Deploy files from a directory to relays and blossom servers
 
 Deploy files from a directory to configured relays and blossom servers.
 
+> **Aliases:** `upload`, `dpl` — `nsyte upload` and `nsyte dpl` are equivalent to
+> `nsyte deploy`. (`upload` prints a deprecation notice; prefer `deploy`.)
+
 ## Usage
 
 ```bash
@@ -45,7 +48,7 @@ nsyte deploy <folder> [options]
   mapping with same hash)
 - `-d, --name <name>` — The site identifier for named sites (kind 35128). If not
   provided, deploys root site (kind 15128)
-- `--dry-run` — Preview events and upload changes without uploading or
+- `--dry-run` — Preview what would be deployed without uploading or
   publishing (default: false)
 - `--dry-run-output <dir>` — Output directory for dry-run event previews
   (default: `/tmp/nsyte-dry-run-{timestamp}/`)
@@ -114,7 +117,8 @@ The deploy command:
 1. **Scans** your local directory for files
 2. **Compares** with previously deployed files (using SHA256 hashes)
 3. **Uploads** only changed or new files to Blossom servers
-4. **Publishes** file events (NIP-96) to configured relays
+4. **Publishes** the site manifest event (kind 15128 for root sites, 35128 for
+   named sites) to configured relays
 5. **Optionally publishes** metadata events for discovery
 
 ## Authentication

--- a/docs/usage/commands/download.md
+++ b/docs/usage/commands/download.md
@@ -5,6 +5,8 @@ description: Download files from the nostr network
 
 # download
 
+> **Alias:** `dl` — `nsyte dl` is equivalent to `nsyte download`.
+
 Download files from the nostr network for a given public key.
 
 ## Usage
@@ -19,7 +21,8 @@ nsyte download [options]
 - `-r, --relays <relays>` — Nostr relays to query (comma-separated)
 - `-s, --servers <servers>` — Blossom servers to download from (comma-separated)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec, bunker://, hex)
-- `-p, --pubkey <npub>` — Public key to download files from (npub or hex)
+- `-p, --pubkey <npub>` — Public key to download files from (npub, hex, or NIP-05 identifier like
+  `name@domain.com`)
 - `-d, --name <name>` — Site identifier for named sites. If not provided, downloads root site
 - `--overwrite` — Overwrite existing files (default: `false`)
 - `-v, --verbose` — Verbose output showing detailed download progress (default: `false`)

--- a/docs/usage/commands/init.md
+++ b/docs/usage/commands/init.md
@@ -9,11 +9,16 @@ Initialize a new nsyte site in the current directory.
 
 ## Description
 
-The `init` command creates a new nsyte site by:
+The `init` command runs an interactive setup wizard that walks you through:
 
-1. Creating the `.nsite` directory
-2. Generating a default configuration file
-3. Setting up initial project structure
+1. Choosing how to manage your nostr key (generate a new key, use an existing
+   `nsec`, or connect/select an NSEC bunker)
+2. Choosing a root or named site (and, for named sites, an identifier)
+3. Entering an optional site title and description
+4. Adding your nostr relay and blossom server URLs
+
+It then writes the resulting `.nsite/config.json`. If an invalid config already
+exists, `init` offers to overwrite it.
 
 ## Usage
 
@@ -35,19 +40,23 @@ nsyte init
 
 ## Configuration
 
-The initialization process creates a `.nsite/config.json` file with default settings:
+The wizard writes a `.nsite/config.json` reflecting your answers, for example:
 
 ```json
 {
-  "bunkerPubkey": "",
-  "relays": [],
-  "servers": [],
-  "profile": {
-    "name": "",
-    "about": ""
-  }
+  "$schema": "https://nsyte.run/schemas/config.schema.json",
+  "bunkerPubkey": "abc123...",
+  "relays": ["wss://relay.damus.io"],
+  "servers": ["https://cdn.hzrd149.com"],
+  "id": "blog",
+  "title": "My Blog",
+  "description": "A blog about decentralized applications"
 }
 ```
+
+A private key is never stored in the config — if you generate or supply an `nsec`,
+it is shown once and you must save it yourself. See the
+[configuration reference](../configuration.md) for all available fields.
 
 ## Project Structure
 

--- a/docs/usage/commands/ls.md
+++ b/docs/usage/commands/ls.md
@@ -1,15 +1,14 @@
 ---
 title: list
-description: List files available on the nostr network
+description: List files from a site manifest, optionally filtered by path
 ---
 
 # list
 
 > **Aliases:** `ls` — `nsyte ls` is equivalent to `nsyte list`.
 
-List files available on the nostr network for a given public key. This command shows which files
-have been published to nostr relays and indicates which files would be ignored based on local
-`.nsyte-ignore` rules.
+List the files recorded in a site's published manifest for a given public key,
+rendered as a tree. Optionally filter by path.
 
 ## Usage
 
@@ -78,18 +77,7 @@ The `ls` command supports multiple authentication methods:
 1. **Explicit pubkey** - Use `--pubkey` to list files for any public key (no signing required)
 2. **Unified secret** - Use `--sec` with any supported format (nsec, nbunksec, bunker://, hex)
 3. **Project bunker** - Uses the bunker configured in `.nsite/config.json`
-4. **Interactive mode** - If no key is provided, you'll be prompted to select an authentication
-   method
-
-## Ignore Rules
-
-Files marked in red in the output would be ignored during upload based on:
-
-- Default ignore patterns (`.git/**`, `node_modules/**`, etc.)
-- Custom patterns in `.nsyte-ignore` file
-- Implicit dotfile ignoring (except `.well-known/`)
-
-This helps you understand which remote files would not be re-deployed in a subsequent `nsyte deploy`
-command.
+4. **Project config** - If no pubkey or secret is given, the public key is resolved from the
+   bunker or key configured in `.nsite/config.json`
 
 Inherits global options. See [global options](_global-options.md).

--- a/docs/usage/commands/run.md
+++ b/docs/usage/commands/run.md
@@ -5,6 +5,8 @@ description: Run a resolver server that serves nsites via npub subdomains
 
 # `nsyte run`
 
+> **Alias:** `rn` — `nsyte rn` is equivalent to `nsyte run`.
+
 Run a resolver server that serves nsites via npub subdomains. This command starts a local server
 that can resolve and serve nsites using the format `npub1234.localhost` or similar subdomain
 patterns.
@@ -17,11 +19,12 @@ nsyte run [npub] [options]
 
 ## Arguments
 
-- `[npub]` (optional): Site identifier in various formats:
-  - `naddr1...` — NIP-19 naddr format (Kind 15128 or 35128)
-  - `<name>.npub1...` — Subdomain format for named sites (e.g., `blog.npub1...`)
-  - `npub1...` — Regular npub for root site (Kind 15128)
-  - If not provided, uses default demo site
+- `[npub]` (optional): Site identifier in one of these formats:
+  - `npub1...` or hex pubkey — root site (kind 15128)
+  - `naddr1...` — NIP-19 naddr pointing at a root (kind 15128) or named (kind 35128)
+    site
+  - If not provided, uses the site from `.nsite/config.json` (its `bunkerPubkey`)
+    when present, otherwise falls back to a built-in demo site
 
 ## Options
 
@@ -63,8 +66,11 @@ nsyte run naddr1...
 
 ### Launch Named Site
 
+Named sites are addressed with their `naddr1...` pointer (which encodes the kind
+35128 identifier):
+
 ```bash
-nsyte run blog.npub1abc123def456ghi789
+nsyte run naddr1...
 ```
 
 ### Custom Port and Cache

--- a/docs/usage/commands/serve.md
+++ b/docs/usage/commands/serve.md
@@ -5,6 +5,8 @@ description: Build and serve local nsite files for development
 
 # `nsyte serve`
 
+> **Alias:** `srv` — `nsyte srv` is equivalent to `nsyte serve`.
+
 Serve a local directory over HTTP for development and testing. Useful for previewing your nsite
 files before deploying them. The server binds to `localhost` only and supports directory listing.
 

--- a/docs/usage/commands/sites.md
+++ b/docs/usage/commands/sites.md
@@ -17,7 +17,8 @@ nsyte sites [options]
 
 - `-r, --relays <relays>` — Nostr relays to query (comma-separated)
 - `--sec <secret>` — Secret for signing (auto-detects: nsec, nbunksec, bunker://, hex)
-- `-p, --pubkey <npub>` — Public key to list sites for (npub or hex format)
+- `-p, --pubkey <npub>` — Public key to list sites for (npub, hex, or NIP-05 identifier like
+  `name@domain.com`)
 - `--use-fallback-relays` — Include default nsyte relays in addition to configured relays
 - `--use-fallbacks` — Enable all fallback options (relays)
 

--- a/docs/usage/commands/undeploy.md
+++ b/docs/usage/commands/undeploy.md
@@ -108,8 +108,7 @@ The undeploy command requires authentication to:
 Authentication options (in order of precedence):
 
 1. `--sec` command line option
-2. Configured bunker in project
-3. Private key in project configuration
+2. Bunker configured in the project (`bunkerPubkey`)
 
 ## Error Handling
 

--- a/docs/usage/commands/validate.md
+++ b/docs/usage/commands/validate.md
@@ -5,6 +5,8 @@ description: Validate nsyte configuration file against the JSON schema
 
 # `nsyte validate`
 
+> **Alias:** `val` — `nsyte val` is equivalent to `nsyte validate`.
+
 Validate the nsyte configuration file against the official JSON schema to ensure it's properly
 formatted and contains valid values.
 
@@ -116,8 +118,8 @@ You can add this to your configuration file for editor support:
   "publishRelayList": true,
   "publishProfile": true,
   "fallback": "/index.html",
+  "publishAppHandler": true,
   "appHandler": {
-    "enabled": true,
     "kinds": [1, 30023, 30311],
     "name": "My Event Viewer",
     "description": "Views notes and articles"

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -19,9 +19,15 @@ Here's a basic configuration file with all available options:
 
 ```json
 {
+  "$schema": "https://nsyte.run/schemas/config.schema.json",
   "bunkerPubkey": "abc123...",
   "relays": ["wss://relay.damus.io", "wss://nos.lol"],
   "servers": ["https://blossom.server"],
+  "id": "blog",
+  "title": "My Blog",
+  "description": "A blog about decentralized applications",
+  "source": "https://github.com/me/my-blog",
+  "gatewayHostnames": ["nsite.lol"],
   "publishProfile": true,
   "publishRelayList": true,
   "publishServerList": true,
@@ -33,7 +39,8 @@ Here's a basic configuration file with all available options:
     "banner": "https://example.com/banner.jpg",
     "website": "https://mysite.com",
     "nip05": "me@mysite.com",
-    "lud16": "me@getalby.com"
+    "lud16": "me@getalby.com",
+    "lud06": "LNURL..."
   },
   "publishAppHandler": true,
   "appHandler": {
@@ -41,6 +48,7 @@ Here's a basic configuration file with all available options:
     "kinds": [1, 30023],
     "name": "My Event Viewer",
     "description": "Views notes and articles",
+    "icon": "https://example.com/logo.png",
     "platforms": {
       "web": {
         "patterns": [
@@ -54,17 +62,39 @@ Here's a basic configuration file with all available options:
 }
 ```
 
+Only `relays` and `servers` are required. Every other field is optional. Profile,
+relay list, and server list publishing is restricted to **root sites** (see below).
+
 ## Configuration Options
+
+### Schema
+
+- `$schema`: URL of the JSON schema for this file
+  (`https://nsyte.run/schemas/config.schema.json`). Optional; enables editor
+  autocompletion and validation.
 
 ### Authentication
 
-- `bunkerPubkey`: Your nostr bunker public key (if using NIP-46)
-- `privateKey`: Your nostr private key (if not using bunker)
+- `bunkerPubkey`: 64-character hex public key of your NIP-46 bunker. nsyte stores
+  only this reference; the bunker secret is kept in your OS keychain or encrypted
+  storage, never in this file. Private keys (`nsec`/hex) are never written to the
+  config — pass them per-command with `--sec` instead.
+
+### Site Identity
+
+- `id`: Site identifier for named sites (kind 35128). Must match `[a-z0-9-]{1,13}`
+  per NIP-5A. Use an empty string, `null`, or omit it for a root site (kind 15128)
+- `title`: Optional site title for the manifest event
+- `description`: Optional site description for the manifest event
+- `source`: Optional repository URL (`http`/`https`) recorded as the `source` tag
+  on manifest events
 
 ### Relays and Servers
 
-- `relays`: Array of WebSocket URLs for nostr relays
-- `servers`: Array of HTTP(S) URLs for blossom servers
+- `relays`: Array of WebSocket URLs for nostr relays (**required**)
+- `servers`: Array of HTTP(S) URLs for blossom servers (**required**)
+- `gatewayHostnames`: Array of gateway hostnames that can serve this nsite (default:
+  `["nsite.lol"]`)
 - `publishRelayList`: Whether to publish the relay list as kind 10002 (default: false, **root sites
   only**)
 - `publishServerList`: Whether to publish the Blossom server list as kind 10063 (default: false,
@@ -130,6 +160,8 @@ If you try to publish user-level metadata from a named site, you'll get a valida
 
 - `appHandler.name`: Optional display name for your handler
 - `appHandler.description`: Optional description of what your handler does
+- `appHandler.icon`: Optional app icon URL (published as `picture` in the handler
+  metadata)
 - `appHandler.platforms`: Platform-specific handler configurations
   - `platforms.web.patterns`: Array of custom URL patterns for web handling
     - `url`: Full URL pattern with `<bech32>` placeholder

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -24,7 +24,7 @@ export function registerConfigCommand(): void {
   nsyte
     .command("config")
     .description("Interactive configuration editor for nsyte project settings")
-    .option("-p, --path <path:string>", "Path to config file (default: ./nsyte.yaml)")
+    .option("-p, --path <path:string>", "Path to config file (default: .nsite/config.json)")
     .action(command);
 }
 


### PR DESCRIPTION
## Summary

The configuration reference was missing fields (the reported `title`/`description`, plus more). This audits **every configuration surface** — the config JSON schema, every command's flags/arguments/aliases, and environment variables — against the source and fixes all drift found.

Method: extracted the authoritative surface from `src/schemas/config.schema.json`, `src/lib/config.ts`, and each `src/commands/*.ts`, compared against `docs/usage/`, and updated the docs (and one stale source help string) to match reality. Kept docs terse.

## Config reference (`configuration.md`)
- Document missing fields: `$schema`, `id`, `title`, `description`, `source`, `gatewayHostnames`, `appHandler.icon`
- Remove the `privateKey` "option" — it is never stored in config (`additionalProperties: false`); clarify bunker secrets live in the OS keychain and private keys are passed via `--sec`
- Mark `relays`/`servers` as required; make the "all options" example actually complete

## Command pages
- **Aliases** now documented: `deploy`→`dpl`, `announce`→`annc`, `delete`→`prg`, `download`→`dl`, `run`→`rn`, `serve`→`srv`, `validate`→`val`
- **deploy**: `--dry-run` no longer claims it "uploads changes"; step 4 publishes the site manifest (kind 15128/35128), not "file events (NIP-96)"
- **config**: correct default path (`.nsite/config.json`, not `./nsyte.yaml`); fix keyboard shortcuts (Enter / Delete / Backspace — no Tab/`+`/`-`/Space); drop the false "creates backup" claim and the non-existent app-handler visual editor
- **debug**: restructured to the 5 checks the code actually runs; profile relay set excludes `relay.nsite.lol`; checks the first 20 blobs (not "20 random")
- **ls**: describe manifest listing; **delete the fabricated "Ignore Rules" section** (`list.ts` has no ignore logic)
- **run**: drop the unsupported `blog.npub1...` subdomain positional form; correct the default-site fallback (project config, then demo)
- **init**: describe the interactive setup wizard rather than a silent default-config scaffold
- **ci**: note the connection is ephemeral and never persisted
- **bunker**: `migrate` is macOS-only, not macOS/Windows
- **delete/undeploy**: remove the non-existent "private key in project configuration" auth path
- **download/sites**: note NIP-05 identifiers are accepted for `--pubkey`
- **validate**: fix the example config (`publishAppHandler`, not the schema-invalid `appHandler.enabled`)

## Source
- Correct the `config -p/--path` help-text default so `--help` matches the real `.nsite/config.json` default.

## Verification
- `deno task check-doc-drift` → no drift (21/21 commands aligned, coverage + env-vars OK)
- `deno test tests/unit/` → 189 passed; `tests/integration/` → 19 passed
- `deno task compile` (nsyte), `deno task docs:build`, `deno task site:build` all succeed