### PR TITLE
feat: napp (NIP-5B) publishing support

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -101,8 +101,8 @@ PATs expire. When `RELEASE_TOKEN` expires, the next release silently fails to tr
 4. Verify with `gh secret list -R sandwichfarm/nsyte` or by triggering a test release.
 
 You do not need to rename the secret — updating the value in place is sufficient. Active workflows
-mid-run that reference `${{ secrets.RELEASE_TOKEN }}` will continue to use the old value until their
-run completes; only new runs pick up the new value.
+mid-run that reference <code v-pre>${{ secrets.RELEASE_TOKEN }}</code> will continue to use the old
+value until their run completes; only new runs pick up the new value.
 
 ---
 
@@ -113,8 +113,9 @@ run completes; only new runs pick up the new value.
 Check in this order:
 
 1. **`release.yml` step still uses `GITHUB_TOKEN`** — verify line 446 of
-   `.github/workflows/release.yml` reads `token: ${{ secrets.RELEASE_TOKEN }}`, not
-   `${{ secrets.GITHUB_TOKEN }}`. This is the most common cause.
+   `.github/workflows/release.yml` reads `token:` followed by
+   <code v-pre>${{ secrets.RELEASE_TOKEN }}</code>, not
+   <code v-pre>${{ secrets.GITHUB_TOKEN }}</code>. This is the most common cause.
 2. **`RELEASE_TOKEN` secret not set** — confirm it is present in Settings → Secrets and variables →
    Actions.
 3. **`RELEASE_TOKEN` expired or revoked** — create a new PAT and update the secret.

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -5,48 +5,56 @@ description: Overview of all nsyte commands
 
 # Command Reference
 
-nsyte provides a comprehensive set of commands for managing nostr sites. Each command is documented
-in detail on its own page.
+nsyte provides a comprehensive set of commands for managing nostr sites. Each
+command is documented in detail on its own page.
 
 ## Core Commands
 
 ### Project Management
 
-- [`nsyte init`](commands/init.md) — Initialize a new nsyte project with configuration
+- [`nsyte init`](commands/init.md) — Initialize a new nsyte project with
+  configuration
 - [`nsyte config`](commands/config.md) — Interactive configuration editor
-- [`nsyte validate`](commands/validate.md) — Validate your nsyte configuration file (alias: `val`)
+- [`nsyte validate`](commands/validate.md) — Validate your nsyte configuration
+  file (alias: `val`)
 
 ### File Operations
 
-- [`nsyte deploy`](commands/deploy.md) — Deploy files to nostr relays and blossom servers (aliases:
-  `upload`, `dpl`)
+- [`nsyte deploy`](commands/deploy.md) — Deploy files to nostr relays and
+  blossom servers (aliases: `upload`, `dpl`)
 - [`nsyte sites`](commands/sites.md) — List all published sites for a pubkey
 - [`nsyte list`](commands/ls.md) — List published files (alias: `ls`)
-- [`nsyte browse`](commands/browse.md) — Interactive TUI browser for managing files
-- [`nsyte download`](commands/download.md) — Download all published files (alias: `dl`)
+- [`nsyte browse`](commands/browse.md) — Interactive TUI browser for managing
+  files
+- [`nsyte download`](commands/download.md) — Download all published files
+  (alias: `dl`)
 - [`nsyte get`](commands/get.md) — Download a single file from a site manifest
-- [`nsyte put`](commands/put.md) — Upload a single file into an existing site manifest
-- [`nsyte delete`](commands/delete.md) — Selectively remove published files (aliases: `purge`,
-  `prg`)
+- [`nsyte put`](commands/put.md) — Upload a single file into an existing site
+  manifest
+- [`nsyte delete`](commands/delete.md) — Selectively remove published files
+  (aliases: `purge`, `prg`)
 - [`nsyte undeploy`](commands/undeploy.md) — Completely remove a deployed site
-- [`nsyte snapshot`](commands/snapshot.md) — Publish an immutable snapshot event for the current
-  site
-- [`nsyte status`](commands/status.md) — Inspect manifest history, relay coverage, and server
-  availability
+- [`nsyte snapshot`](commands/snapshot.md) — Publish an immutable snapshot event
+  for the current site
+- [`nsyte status`](commands/status.md) — Inspect manifest history, relay
+  coverage, and server availability
 
 ### Development
 
-- [`nsyte serve`](commands/serve.md) — Serve files locally for development (alias: `srv`)
-- [`nsyte run`](commands/run.md) — Run resolver server with npub subdomains (alias: `rn`)
-- [`nsyte debug`](commands/debug.md) — Debug nsites by checking relays and servers
-- [`nsyte announce`](commands/announce.md) — Publish app handler announcements and metadata events
-  (alias: `annc`)
+- [`nsyte serve`](commands/serve.md) — Serve files locally for development
+  (alias: `srv`)
+- [`nsyte run`](commands/run.md) — Run resolver server with npub subdomains
+  (alias: `rn`)
+- [`nsyte debug`](commands/debug.md) — Debug nsites by checking relays and
+  servers
+- [`nsyte announce`](commands/announce.md) — Publish app handler announcements
+  and metadata events (alias: `annc`)
 - [`nsyte scan`](commands/scan.md) — Scan files for secrets before deploying
 
 ### App Publishing
 
-- [`nsyte napp`](commands/napp.md) — Manage napp (NIP-5B) discoverable-app publishing
-  (subcommands: `id`, `release`, `init`, `validate`)
+- [`nsyte napp`](commands/napp.md) — Manage napp (NIP-5B) discoverable-app
+  publishing (subcommands: `id`, `release`, `init`, `validate`)
 
 ### Authentication
 
@@ -55,15 +63,16 @@ in detail on its own page.
 
 ## Global Options
 
-Every nsyte subcommand inherits a small set of global options (e.g. `--config`, `--created-at`). See
-[Global Options](commands/_global-options.md) for the complete list.
+Every nsyte subcommand inherits a small set of global options (e.g. `--config`,
+`--created-at`). See [Global Options](commands/_global-options.md) for the
+complete list.
 
 ## Authentication Options
 
 Many commands support unified authentication:
 
-- `--sec <secret>` — Secret for signing (auto-detects format: nsec, nbunksec, bunker://, or 64-char
-  hex)
+- `--sec <secret>` — Secret for signing (auto-detects format: nsec, nbunksec,
+  bunker://, or 64-char hex)
 
 The `--sec` flag automatically detects the format of your secret:
 
@@ -72,8 +81,8 @@ The `--sec` flag automatically detects the format of your secret:
 - `bunker://...` - Bunker URL with relay and optional secret
 - 64-character hex string - Raw private key
 
-If not provided, commands will use the bunker configured in `.nsite/config.json` or prompt for
-authentication.
+If not provided, commands will use the bunker configured in `.nsite/config.json`
+or prompt for authentication.
 
 ## Configuration
 
@@ -84,17 +93,20 @@ nsyte uses a configuration file at `.nsite/config.json` which can store:
 - Bunker connections
 - Project metadata
 
-Use `nsyte init` to create a new configuration or `nsyte validate` to check an existing one.
+Use `nsyte init` to create a new configuration or `nsyte validate` to check an
+existing one.
 
 ## Environment Variables
 
-- `LOG_LEVEL` — Logging level: `none`, `error`, `warn`, `info`, `debug` (default: `info`)
-- `NSITE_DISPLAY_MODE` — Display mode: `interactive`, `non-interactive`, `debug` (default:
-  `interactive`)
-- `NSYTE_DISABLE_KEYCHAIN` — Disable native keychain, use encrypted file storage (set to `true`)
+- `LOG_LEVEL` — Logging level: `none`, `error`, `warn`, `info`, `debug`
+  (default: `info`)
+- `NSITE_DISPLAY_MODE` — Display mode: `interactive`, `non-interactive`, `debug`
+  (default: `interactive`)
+- `NSYTE_DISABLE_KEYCHAIN` — Disable native keychain, use encrypted file storage
+  (set to `true`)
 - `NSYTE_TEST_MODE` — Enable test mode, disables keychain (set to `true`)
-- `NSYTE_FORCE_ENCRYPTED_STORAGE` — Force encrypted file storage instead of OS keychain (set to
-  `true`)
+- `NSYTE_FORCE_ENCRYPTED_STORAGE` — Force encrypted file storage instead of OS
+  keychain (set to `true`)
 
 ## Getting Started
 

--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -43,6 +43,11 @@ in detail on its own page.
   (alias: `annc`)
 - [`nsyte scan`](commands/scan.md) — Scan files for secrets before deploying
 
+### App Publishing
+
+- [`nsyte napp`](commands/napp.md) — Manage napp (NIP-5B) discoverable-app publishing
+  (subcommands: `id`, `release`, `init`, `validate`)
+
 ### Authentication
 
 - [`nsyte bunker`](commands/bunker.md) — Manage NIP-46 bunker connections

--- a/docs/usage/commands/napp.md
+++ b/docs/usage/commands/napp.md
@@ -43,7 +43,7 @@ See the [configuration reference](../configuration.md) for the full schema.
 - `id` — Print the shareable `+` app identifier for this napp.
 - `release` — Publish a kind-39108 changelog for the current app version.
 - `init` — Retrofit a `napp` section onto an existing project's config
-  (interactive).
+  (interactive, or fully scriptable via flags).
 - `validate` — Check napp readiness: required fields, categories, and a NIP-07
   heuristic.
 
@@ -69,7 +69,42 @@ See the [configuration reference](../configuration.md) for the full schema.
 
 ## init Options
 
-`init` is interactive and takes no options beyond the global options.
+`init` retrofits a `napp` section onto an existing project's config. With no
+flags it prompts interactively; flags pre-fill answers (fully-specified flags
+skip prompts entirely), and missing fields are prompted for — or, when
+non-interactive (`--yes` or no TTY), reported as an error and the command exits
+non-zero rather than hanging.
+
+- `--name <name>` — app display name.
+- `--icon <icon>` — app icon: a sha256 hash, a URL, OR a local file path. Local
+  files are uploaded to your configured blossom servers (requiring `--sec` or a
+  stored bunker); the resulting sha256 + MIME are captured.
+- `--icon-mime <mime>` — icon MIME type for hash/URL icon inputs (default
+  `image/png`).
+- `--category <label>` — `napp.<cat>:<sub>` category label (repeatable, max 3; a
+  bare `<cat>:<sub>` is normalized to `napp.<cat>:<sub>`).
+- `--countries <csv>` — comma-separated ISO 3166-1 alpha-2 codes, or `*` for
+  worldwide.
+- `--summary <text>` — short summary.
+- `--description <text>` — long description.
+- `--keyart <keyart>` — key art asset: a sha256 hash, a URL, or a local file
+  path (uploaded like `--icon`).
+- `--screenshot <shot>` — screenshot asset: a sha256 hash, a URL, or a local
+  file path (repeatable; uploaded like `--icon`).
+- `--self <pubkey>` — author pubkey (64-hex).
+- `--tag <tag>` — free-form tag (repeatable).
+- `--indexer-relay <relay>` — indexer relay URL the listing is also published to
+  (repeatable).
+- `--id <id>` — set a named-site identifier. napps need a NAMED site to be
+  discoverable; setting an id republishes the manifest from kind 15128 (root) to
+  kind 35128 (named) and orphans the old root manifest. This is OPT-IN — nsyte
+  never auto-migrates. On a root site with neither `--id` nor an interactive
+  confirmation, the napp section is still written but the id stays unset (and
+  `nsyte napp id` will not work until it is set).
+- `--sec <secret>` — key (nsec/hex, nbunksec, or `bunker://`) used to sign
+  local-file asset uploads. Not needed when all assets are hashes/URLs.
+- `--yes` — non-interactive: never prompt; error and exit non-zero if required
+  fields (`--name`, `--icon`, `--category`) are missing.
 
 ## validate Arguments
 

--- a/docs/usage/commands/napp.md
+++ b/docs/usage/commands/napp.md
@@ -1,0 +1,80 @@
+---
+title: napp
+description: Manage napp (NIP-5B) discoverable-app publishing
+---
+
+# napp
+
+A napp is a [NIP-5A](https://github.com/nostr-protocol/nips) nsite that supports NIP-07
+(`window.nostr`) and is advertised as a discoverable app via a kind-37348 App Listing
+([NIP-5B](https://github.com/nostr-protocol/nips/pull/2282)). The `nsyte napp` command
+manages the napp-specific deltas on top of normal nsite publishing.
+
+## Usage
+
+```bash
+nsyte napp <subcommand> [options]
+```
+
+## Deploy auto-publishes the listing
+
+When `.nsite/config.json` contains a valid `napp` section, `nsyte deploy` prints an info
+line and publishes the kind-37348 App Listing (to the deduped union of your NIP-65 write
+relays and the configured indexer relays) with no extra flags. See
+[`nsyte deploy`](deploy.md).
+
+## Config (`napp` section)
+
+The `napp` section of `.nsite/config.json` describes the listing:
+
+- `name` — display name (`{ value, lang? }`).
+- `icon` — app icon asset (`{ hash, mime }`).
+- `categories` — 1–3 `napp.<cat>:<sub>` labels (validated against the fixed NIP-5B table).
+- `countries` — `*` (worldwide) or a list of ISO 3166-1 alpha-2 codes.
+- Optional: `summary`, `description`, `self`, `keyart`, `screenshots`, `tags`,
+  `indexerRelays`.
+
+See the [configuration reference](../configuration.md) for the full schema.
+
+## Subcommands
+
+- `id` — Print the shareable `+` app identifier for this napp.
+- `release` — Publish a kind-39108 changelog for the current app version.
+- `init` — Retrofit a `napp` section onto an existing project's config (interactive).
+- `validate` — Check napp readiness: required fields, categories, and a NIP-07 heuristic.
+
+## id Arguments
+
+`id` takes no arguments beyond the global options.
+
+## id Options
+
+`id` takes no options beyond the global options.
+
+## release Options
+
+- `--sec <secret>` — key (nsec/hex, nbunksec, or `bunker://`) to sign the release note with.
+- `--relays <relays>` — comma-separated relay URLs (overrides config).
+- `--pubkey <pubkey>` — public key (hex/npub) to resolve the manifest for.
+- `--fix <text>` — bug-fix changelog entry (repeatable).
+- `--add <text>` — added-feature changelog entry (repeatable).
+- `--try <text>` — experimental changelog entry (repeatable).
+- `--cut <text>` — removed-feature changelog entry (repeatable).
+- `--sub <text>` — generic changed/substitute changelog entry (repeatable).
+
+## init Options
+
+`init` is interactive and takes no options beyond the global options.
+
+## validate Arguments
+
+- `[dir]` — optional directory to scan for NIP-07 evidence (default: current directory).
+
+## validate Options
+
+`validate` takes no options beyond the global options.
+
+`validate` semantics: structural errors fail (non-zero exit); a missing NIP-07 signal is
+a WARNING only (exit stays `0`).
+
+Inherits global options. See [global options](_global-options.md).

--- a/docs/usage/commands/napp.md
+++ b/docs/usage/commands/napp.md
@@ -5,10 +5,11 @@ description: Manage napp (NIP-5B) discoverable-app publishing
 
 # napp
 
-A napp is a [NIP-5A](https://github.com/nostr-protocol/nips) nsite that supports NIP-07
-(`window.nostr`) and is advertised as a discoverable app via a kind-37348 App Listing
-([NIP-5B](https://github.com/nostr-protocol/nips/pull/2282)). The `nsyte napp` command
-manages the napp-specific deltas on top of normal nsite publishing.
+A napp is a [NIP-5A](https://github.com/nostr-protocol/nips) nsite that supports
+NIP-07 (`window.nostr`) and is advertised as a discoverable app via a kind-37348
+App Listing ([NIP-5B](https://github.com/nostr-protocol/nips/pull/2282)). The
+`nsyte napp` command manages the napp-specific deltas on top of normal nsite
+publishing.
 
 ## Usage
 
@@ -18,10 +19,10 @@ nsyte napp <subcommand> [options]
 
 ## Deploy auto-publishes the listing
 
-When `.nsite/config.json` contains a valid `napp` section, `nsyte deploy` prints an info
-line and publishes the kind-37348 App Listing (to the deduped union of your NIP-65 write
-relays and the configured indexer relays) with no extra flags. See
-[`nsyte deploy`](deploy.md).
+When `.nsite/config.json` contains a valid `napp` section, `nsyte deploy` prints
+an info line and publishes the kind-37348 App Listing (to the deduped union of
+your NIP-65 write relays and the configured indexer relays) with no extra flags.
+See [`nsyte deploy`](deploy.md).
 
 ## Config (`napp` section)
 
@@ -29,7 +30,8 @@ The `napp` section of `.nsite/config.json` describes the listing:
 
 - `name` — display name (`{ value, lang? }`).
 - `icon` — app icon asset (`{ hash, mime }`).
-- `categories` — 1–3 `napp.<cat>:<sub>` labels (validated against the fixed NIP-5B table).
+- `categories` — 1–3 `napp.<cat>:<sub>` labels (validated against the fixed
+  NIP-5B table).
 - `countries` — `*` (worldwide) or a list of ISO 3166-1 alpha-2 codes.
 - Optional: `summary`, `description`, `self`, `keyart`, `screenshots`, `tags`,
   `indexerRelays`.
@@ -40,8 +42,10 @@ See the [configuration reference](../configuration.md) for the full schema.
 
 - `id` — Print the shareable `+` app identifier for this napp.
 - `release` — Publish a kind-39108 changelog for the current app version.
-- `init` — Retrofit a `napp` section onto an existing project's config (interactive).
-- `validate` — Check napp readiness: required fields, categories, and a NIP-07 heuristic.
+- `init` — Retrofit a `napp` section onto an existing project's config
+  (interactive).
+- `validate` — Check napp readiness: required fields, categories, and a NIP-07
+  heuristic.
 
 ## id Arguments
 
@@ -53,7 +57,8 @@ See the [configuration reference](../configuration.md) for the full schema.
 
 ## release Options
 
-- `--sec <secret>` — key (nsec/hex, nbunksec, or `bunker://`) to sign the release note with.
+- `--sec <secret>` — key (nsec/hex, nbunksec, or `bunker://`) to sign the
+  release note with.
 - `--relays <relays>` — comma-separated relay URLs (overrides config).
 - `--pubkey <pubkey>` — public key (hex/npub) to resolve the manifest for.
 - `--fix <text>` — bug-fix changelog entry (repeatable).
@@ -68,13 +73,14 @@ See the [configuration reference](../configuration.md) for the full schema.
 
 ## validate Arguments
 
-- `[dir]` — optional directory to scan for NIP-07 evidence (default: current directory).
+- `[dir]` — optional directory to scan for NIP-07 evidence (default: current
+  directory).
 
 ## validate Options
 
 `validate` takes no options beyond the global options.
 
-`validate` semantics: structural errors fail (non-zero exit); a missing NIP-07 signal is
-a WARNING only (exit stays `0`).
+`validate` semantics: structural errors fail (non-zero exit); a missing NIP-07
+signal is a WARNING only (exit stays `0`).
 
 Inherits global options. See [global options](_global-options.md).

--- a/docs/usage/commands/napp.md
+++ b/docs/usage/commands/napp.md
@@ -53,7 +53,10 @@ See the [configuration reference](../configuration.md) for the full schema.
 
 ## id Options
 
-`id` takes no options beyond the global options.
+- `--sec <secret>` — key (nsec/hex, nbunksec, or `bunker://`) to derive the
+  pubkey from (read-only; nothing is signed or stored).
+- `--pubkey <pubkey>` — public key (hex/npub) to encode into the identifier,
+  without a configured signer.
 
 ## release Options
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,7 @@ import { createLogger } from "./lib/logger.ts";
 import { pool } from "./lib/nostr.ts";
 
 import { registerBunkerCommand } from "./commands/bunker.ts";
+import { registerNappCommand } from "./commands/napp.ts";
 import { registerScanCommand } from "./commands/scan.ts";
 
 const log = createLogger("cli");
@@ -65,6 +66,7 @@ registerDebugCommand();
 registerAnnounceCommand();
 registerConfigCommand();
 registerBunkerCommand();
+registerNappCommand();
 registerScanCommand();
 
 /**

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -2,7 +2,13 @@ import { colors } from "@cliffy/ansi/colors";
 import { Confirm, Input, Select } from "@cliffy/prompt";
 import { hexToBytes } from "@noble/hashes/utils";
 import { join } from "@std/path";
-import { getOutboxes, naddrEncode, npubEncode, relaySet } from "applesauce-core/helpers";
+import {
+  type EventTemplate,
+  getOutboxes,
+  naddrEncode,
+  npubEncode,
+  relaySet,
+} from "applesauce-core/helpers";
 import { loadAsyncMap } from "applesauce-loaders/helpers";
 import { type ISigner, NostrConnectSigner } from "applesauce-signers";
 import { createSigner as createSignerFromFactory } from "../lib/auth/signer-factory.ts";
@@ -25,6 +31,13 @@ import {
   NSITE_NAME_SITE_KIND,
 } from "../lib/manifest.ts";
 import { MessageCategory, MessageCollector } from "../lib/message-collector.ts";
+import { isNapp } from "../lib/napp/detect.ts";
+import {
+  createAppListingEvent,
+  createAppListingTemplate,
+  deriveListingDTag,
+  NSITE_APP_LISTING_KIND,
+} from "../lib/napp/listing.ts";
 import { publishMetadata } from "../lib/metadata/publisher.ts";
 import { getNbunkString, importFromNbunk, initiateNostrConnect } from "../lib/nip46.ts";
 import { encodePubkeyBase36, validateDTag } from "../lib/nip5a.ts";
@@ -532,6 +545,14 @@ export async function deployCommand(
       includedFiles,
     );
     await maybePublishMetadata(state as DeploymentState, publisherPubkey);
+
+    // Napp App Listing (kind 37348) — published AFTER the manifest (NAPP-LST-02).
+    // Gated on isNapp(config): a plain deploy never enters this branch (NAPP-LST-03).
+    await maybePublishAppListing(
+      state as DeploymentState,
+      publisherPubkey,
+      deployResult?.manifestResult ?? null,
+    );
 
     if (includedFiles.length === 0 && toDelete.length === 0 && toTransfer.length === 0) {
       log.info("No effective operations performed.");
@@ -2067,6 +2088,75 @@ async function uploadFiles(
 /**
  * Publish metadata to relays (app handler, etc.)
  */
+/**
+ * Pure, signer-free core of the napp deploy branch: returns the kind-37348 App Listing
+ * TEMPLATE for a napp config, or null for a non-napp config. Isolating the napp decision
+ * + tag mapping from network/signer code makes the zero-regression boundary (NAPP-LST-03)
+ * directly unit-testable: a non-napp config returns null, so the network branch in
+ * `maybePublishAppListing` is never entered.
+ */
+export function buildDeployListing(
+  config: ProjectConfig,
+  publisherPubkey: string,
+  manifestDTag: string,
+  createdAt?: number,
+): EventTemplate | null {
+  if (!isNapp(config)) return null;
+  return createAppListingTemplate(publisherPubkey, config.napp, manifestDTag, createdAt);
+}
+
+/**
+ * Publish the napp App Listing (kind 37348) AFTER the manifest, gated on isNapp(config).
+ * A plain (non-napp) deploy never enters this function body — the hard zero-regression
+ * boundary (NAPP-LST-03). A listing publish failure is non-fatal (the manifest already
+ * succeeded), mirroring the metadata publishers which swallow per-event errors.
+ */
+async function maybePublishAppListing(
+  state: DeploymentState,
+  publisherPubkey: string,
+  _manifestResult: ManifestPublishResult | null,
+): Promise<void> {
+  const { statusDisplay, signer, config, options, resolvedRelays, messageCollector } = state;
+
+  if (!isNapp(config)) return;
+
+  // Shared d tag — MUST equal the manifest's d tag (d-tag rule, T-21-01). Derived from
+  // config.id here (root -> "", named -> config.id) so it matches the manifest builder.
+  const manifestDTag = deriveListingDTag({ id: config.id });
+
+  console.log(formatSectionHeader("App Listing (napp)"));
+  console.log(colors.cyan("napp detected — publishing app listing (kind 37348)"));
+  statusDisplay.update("Publishing app listing (kind 37348)...");
+
+  try {
+    const listingEvent = await createAppListingEvent(
+      signer,
+      publisherPubkey,
+      config.napp,
+      manifestDTag,
+      options.createdAt,
+    );
+
+    // Publish to the SAME relay set the manifest used (NIP-65 write/resolved relays).
+    // Phase 22: also publish to configured indexer relays.
+    const result = await publishEventsToRelaysDetailed(resolvedRelays, [listingEvent]);
+
+    if (result.allEventsPublished) {
+      statusDisplay.success(`App listing published (kind ${NSITE_APP_LISTING_KIND})`);
+      messageCollector.addEventSuccess("app listing", listingEvent.id);
+    } else {
+      statusDisplay.error("Failed to publish app listing");
+      log.error(
+        `App listing publish failed on ${result.totalFailedEvents} event(s); deploy continues (manifest already published)`,
+      );
+    }
+  } catch (e) {
+    // Non-fatal: the manifest already succeeded; a listing failure must not abort deploy.
+    statusDisplay.error("Failed to publish app listing");
+    log.error(`App listing publish error (non-fatal): ${getErrorMessage(e)}`);
+  }
+}
+
 async function maybePublishMetadata(
   state: DeploymentState,
   publisherPubkey: string,

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -32,6 +32,7 @@ import {
 } from "../lib/manifest.ts";
 import { MessageCategory, MessageCollector } from "../lib/message-collector.ts";
 import { isNapp } from "../lib/napp/detect.ts";
+import { resolveIndexerRelays } from "../lib/napp/identifier.ts";
 import {
   createAppListingEvent,
   createAppListingTemplate,
@@ -2124,8 +2125,12 @@ async function maybePublishAppListing(
   // config.id here (root -> "", named -> config.id) so it matches the manifest builder.
   const manifestDTag = deriveListingDTag({ id: config.id });
 
+  // Indexer relays (NAPP-ID-03): config override or DEFAULT_NAPP_INDEXER_RELAYS.
+  const indexerRelays = resolveIndexerRelays(config);
+
   console.log(formatSectionHeader("App Listing (napp)"));
   console.log(colors.cyan("napp detected — publishing app listing (kind 37348)"));
+  console.log(colors.cyan(`indexer relays: ${indexerRelays.join(", ")}`));
   statusDisplay.update("Publishing app listing (kind 37348)...");
 
   try {
@@ -2137,9 +2142,11 @@ async function maybePublishAppListing(
       options.createdAt,
     );
 
-    // Publish to the SAME relay set the manifest used (NIP-65 write/resolved relays).
-    // Phase 22: also publish to configured indexer relays.
-    const result = await publishEventsToRelaysDetailed(resolvedRelays, [listingEvent]);
+    // Publish to the deduped UNION of the manifest's relay set (NIP-65 write/resolved
+    // relays) and the configured indexer relays — so the listing reaches both the
+    // author's normal relays and the NIP-5B indexers. A relay in both appears once.
+    const publishRelays = Array.from(new Set([...resolvedRelays, ...indexerRelays]));
+    const result = await publishEventsToRelaysDetailed(publishRelays, [listingEvent]);
 
     if (result.allEventsPublished) {
       statusDisplay.success(`App listing published (kind ${NSITE_APP_LISTING_KIND})`);

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -24,7 +24,11 @@ import { NSYTE_BROADCAST_RELAYS } from "../lib/constants.ts";
 import { type DisplayManager, getDisplayManager } from "../lib/display-mode.ts";
 import { getErrorMessage, handleError } from "../lib/error-utils.ts";
 import { compareFiles, getLocalFiles, loadFileData } from "../lib/files.ts";
-import { createLogger, flushQueuedLogs, setProgressMode } from "../lib/logger.ts";
+import {
+  createLogger,
+  flushQueuedLogs,
+  setProgressMode,
+} from "../lib/logger.ts";
 import {
   buildManifestFileMappings,
   findFallbackFile,
@@ -40,7 +44,11 @@ import {
   NSITE_APP_LISTING_KIND,
 } from "../lib/napp/listing.ts";
 import { publishMetadata } from "../lib/metadata/publisher.ts";
-import { getNbunkString, importFromNbunk, initiateNostrConnect } from "../lib/nip46.ts";
+import {
+  getNbunkString,
+  importFromNbunk,
+  initiateNostrConnect,
+} from "../lib/nip46.ts";
 import { encodePubkeyBase36, validateDTag } from "../lib/nip5a.ts";
 import {
   createSiteManifestEvent,
@@ -53,10 +61,17 @@ import {
   type RelayPublishResult,
 } from "../lib/nostr.ts";
 import { SecretsManager } from "../lib/secrets/mod.ts";
-import { normalizeSiteIdentifier, resolveSiteIdentifier } from "../lib/site-identifier.ts";
+import {
+  normalizeSiteIdentifier,
+  resolveSiteIdentifier,
+} from "../lib/site-identifier.ts";
 import { listTrustedRemoteFiles } from "../lib/site-manifest.ts";
 import { processUploads, type UploadResponse } from "../lib/upload.ts";
-import { detectSourceUrl, parseRelayInput, truncateString } from "../lib/utils.ts";
+import {
+  detectSourceUrl,
+  parseRelayInput,
+  truncateString,
+} from "../lib/utils.ts";
 import {
   formatConfigValue,
   formatFilePath,
@@ -190,11 +205,21 @@ export function registerDeployCommand(): void {
     .alias("dpl")
     .description("Deploy files from a directory")
     .arguments("<folder:string>")
-    .option("-f, --force", "Force re-upload all files, bypassing server preflight checks.", {
-      default: false,
-    })
-    .option("-s, --servers <servers:string>", "The blossom servers to use (comma separated).")
-    .option("-r, --relays <relays:string>", "The nostr relays to use (comma separated).")
+    .option(
+      "-f, --force",
+      "Force re-upload all files, bypassing server preflight checks.",
+      {
+        default: false,
+      },
+    )
+    .option(
+      "-s, --servers <servers:string>",
+      "The blossom servers to use (comma separated).",
+    )
+    .option(
+      "-r, --relays <relays:string>",
+      "The nostr relays to use (comma separated).",
+    )
     .option(
       "--sec <secret:string>",
       "Secret for signing (auto-detects format: nsec, nbunksec, bunker:// URL, or 64-char hex).",
@@ -218,20 +243,36 @@ export function registerDeployCommand(): void {
       { default: false },
     )
     .option("-v, --verbose", "Verbose output.", { default: false })
-    .option("-c, --concurrency <number:number>", "Number of parallel uploads.", { default: 4 })
-    .option("--publish-app-handler", "Publish NIP-89 app handler announcement (Kind 31990).", {
-      default: false,
-    })
+    .option(
+      "-c, --concurrency <number:number>",
+      "Number of parallel uploads.",
+      { default: 4 },
+    )
+    .option(
+      "--publish-app-handler",
+      "Publish NIP-89 app handler announcement (Kind 31990).",
+      {
+        default: false,
+      },
+    )
     .option(
       "--handler-kinds <kinds:string>",
       "Event kinds this nsite can handle (comma separated).",
     )
-    .option("--publish-profile", "Publish profile metadata (Kind 0) - root sites only.", {
-      default: false,
-    })
-    .option("--publish-relay-list", "Publish relay list (Kind 10002) - root sites only.", {
-      default: false,
-    })
+    .option(
+      "--publish-profile",
+      "Publish profile metadata (Kind 0) - root sites only.",
+      {
+        default: false,
+      },
+    )
+    .option(
+      "--publish-relay-list",
+      "Publish relay list (Kind 10002) - root sites only.",
+      {
+        default: false,
+      },
+    )
     .option(
       "--publish-server-list",
       "Publish Blossom server list (Kind 10063) - root sites only.",
@@ -285,7 +326,9 @@ export function registerDeployCommand(): void {
       const cmdName = Deno.args[0];
       if (cmdName === "upload") {
         console.log(
-          colors.yellow("⚠️  The 'upload' command is deprecated. Please use 'deploy' instead.\n"),
+          colors.yellow(
+            "⚠️  The 'upload' command is deprecated. Please use 'deploy' instead.\n",
+          ),
         );
       }
       await deployCommand(folder, options);
@@ -333,7 +376,9 @@ export async function deployCommand(
     const currentWorkingDir = Deno.cwd();
     const targetDir = join(currentWorkingDir, fileOrFolder);
     const context = await resolveContext(options);
-    const configPath = typeof options.config === "string" ? options.config : undefined;
+    const configPath = typeof options.config === "string"
+      ? options.config
+      : undefined;
 
     if (context.error) {
       statusDisplay.error(context.error);
@@ -344,8 +389,12 @@ export async function deployCommand(
     const { authKeyHex, config } = context;
 
     if (!config) {
-      statusDisplay.error("Critical error: Project data could not be resolved.");
-      log.error("Critical error: Project data is null after context resolution.");
+      statusDisplay.error(
+        "Critical error: Project data could not be resolved.",
+      );
+      log.error(
+        "Critical error: Project data is null after context resolution.",
+      );
       return Deno.exit(1);
     }
 
@@ -393,8 +442,16 @@ export async function deployCommand(
 
       // Assemble manifest file mappings via the same helpers the real deploy
       // path uses — guarantees dry-run and real runs emit identical manifests.
-      const fallbackFileEntry = resolveFallbackFile(options, config, includedFiles);
-      const manifestFiles = buildManifestFileMappings(includedFiles, [], fallbackFileEntry);
+      const fallbackFileEntry = resolveFallbackFile(
+        options,
+        config,
+        includedFiles,
+      );
+      const manifestFiles = buildManifestFileMappings(
+        includedFiles,
+        [],
+        fallbackFileEntry,
+      );
 
       // Collect event templates (no signing)
       const events = collectDeployEvents(config, manifestFiles, {
@@ -409,7 +466,8 @@ export async function deployCommand(
 
       // Parse --dry-run-show-kinds
       const showKinds = options.dryRunShowKinds
-        ? options.dryRunShowKinds.split(",").map((k) => parseInt(k.trim())).filter((k) => !isNaN(k))
+        ? options.dryRunShowKinds.split(",").map((k) => parseInt(k.trim()))
+          .filter((k) => !isNaN(k))
         : undefined;
 
       // Handle output (banner, files, optional stdout)
@@ -424,7 +482,12 @@ export async function deployCommand(
       return Deno.exit(0);
     }
 
-    const signerResult = await initSigner(authKeyHex, config, options, configPath);
+    const signerResult = await initSigner(
+      authKeyHex,
+      config,
+      options,
+      configPath,
+    );
 
     if ("error" in signerResult) {
       statusDisplay.error(`Signer: ${signerResult.error}`);
@@ -436,9 +499,12 @@ export async function deployCommand(
     const publisherPubkey = await signer.getPublicKey();
 
     // Get config values for manifest metadata (these are recommendations for others)
-    const manifestRelays = options.relays?.split(",").filter((r) => r.trim()) || config.relays ||
+    const manifestRelays = options.relays?.split(",").filter((r) => r.trim()) ||
+      config.relays ||
       [];
-    const manifestServers = options.servers?.split(",").filter((s) => s.trim()) || config.servers ||
+    const manifestServers = options.servers?.split(",").filter((s) =>
+      s.trim()
+    ) || config.servers ||
       [];
 
     // Fetch kind 10002 and 10063 to get user's preferred relays/servers for operations
@@ -468,14 +534,22 @@ export async function deployCommand(
       signer,
       config,
       options,
-      resolvedRelays: resolvedRelays.length > 0 ? resolvedRelays : manifestRelays,
-      resolvedServers: resolvedServers.length > 0 ? resolvedServers : manifestServers,
+      resolvedRelays: resolvedRelays.length > 0
+        ? resolvedRelays
+        : manifestRelays,
+      resolvedServers: resolvedServers.length > 0
+        ? resolvedServers
+        : manifestServers,
       targetDir,
       progressRenderer: new ProgressRenderer(0), // Will be updated later
       fallbackFileEntry: null,
     };
 
-    displayConfig(state as DeploymentState, publisherPubkey, userPreferences.displayName);
+    displayConfig(
+      state as DeploymentState,
+      publisherPubkey,
+      userPreferences.displayName,
+    );
 
     const includedFiles = await scanLocalFiles(state as DeploymentState);
 
@@ -531,9 +605,16 @@ export async function deployCommand(
     // --- End secrets scan pre-check ---
 
     // Find fallback file in scanned files if configured
-    state.fallbackFileEntry = resolveFallbackFile(options, config, includedFiles);
+    state.fallbackFileEntry = resolveFallbackFile(
+      options,
+      config,
+      includedFiles,
+    );
 
-    const remoteFileEntries = await fetchRemoteFiles(state as DeploymentState, publisherPubkey);
+    const remoteFileEntries = await fetchRemoteFiles(
+      state as DeploymentState,
+      publisherPubkey,
+    );
     const { toTransfer, toDelete } = await compareAndPrepareFiles(
       state as DeploymentState,
       includedFiles,
@@ -555,7 +636,10 @@ export async function deployCommand(
       deployResult?.manifestResult ?? null,
     );
 
-    if (includedFiles.length === 0 && toDelete.length === 0 && toTransfer.length === 0) {
+    if (
+      includedFiles.length === 0 && toDelete.length === 0 &&
+      toTransfer.length === 0
+    ) {
       log.info("No effective operations performed.");
     }
 
@@ -591,7 +675,13 @@ export async function deployCommand(
 function formatServerSummary(
   serverStats: Record<
     string,
-    { success: number; total: number; failed: number; retries: number; errors: Map<string, number> }
+    {
+      success: number;
+      total: number;
+      failed: number;
+      retries: number;
+      errors: Map<string, number>;
+    }
   >,
   serverTimings?: Record<string, number | undefined>,
 ): string {
@@ -604,7 +694,9 @@ function formatServerSummary(
   if (displayManager.isNonInteractive()) {
     return Object.entries(serverStats)
       .map(([server, stats]) => {
-        const pct = stats.total === 0 ? 100 : Math.round((stats.success / stats.total) * 100);
+        const pct = stats.total === 0
+          ? 100
+          : Math.round((stats.success / stats.total) * 100);
         const failStr = stats.failed > 0 ? `, ${stats.failed} failed` : "";
         const retryStr = stats.retries > 0 ? `, ${stats.retries} retries` : "";
         return `${server}: ${stats.success}/${stats.total} (${pct}%)${failStr}${retryStr}`;
@@ -642,15 +734,23 @@ function formatServerSummary(
     // Collect error breakdown lines per row
     const rowErrors: string[] = [];
     if (stats.errors.size > 1) {
-      const sortedErrors = [...stats.errors.entries()].sort((a, b) => b[1] - a[1]);
+      const sortedErrors = [...stats.errors.entries()].sort((a, b) =>
+        b[1] - a[1]
+      );
       for (const [errMsg, count] of sortedErrors) {
-        const truncated = errMsg.length > 60 ? errMsg.substring(0, 57) + "..." : errMsg;
-        rowErrors.push(`     ${colors.yellow(`${count}×`)} ${colors.gray(truncated)}`);
+        const truncated = errMsg.length > 60
+          ? errMsg.substring(0, 57) + "..."
+          : errMsg;
+        rowErrors.push(
+          `     ${colors.yellow(`${count}×`)} ${colors.gray(truncated)}`,
+        );
       }
     } else if (stats.errors.size === 1) {
       const [[errMsg]] = stats.errors;
       if (errMsg !== "unknown error") {
-        const truncated = errMsg.length > 50 ? errMsg.substring(0, 47) + "..." : errMsg;
+        const truncated = errMsg.length > 50
+          ? errMsg.substring(0, 47) + "..."
+          : errMsg;
         rowErrors.push(`     ${colors.gray(truncated)}`);
       }
     }
@@ -680,7 +780,9 @@ function computeExitCode(result: DeployPhaseResult): number {
 
   // Total upload failure: files needed uploading but none succeeded
   if (result.filesRequiringUpload > 0 && result.filesUploaded === 0) {
-    console.log(colors.red("\nDeploy failed: no files were uploaded successfully."));
+    console.log(
+      colors.red("\nDeploy failed: no files were uploaded successfully."),
+    );
     return 1;
   }
 
@@ -702,7 +804,9 @@ function computeExitCode(result: DeployPhaseResult): number {
 
     // Manifest published to zero relays
     if (mr.successCount === 0) {
-      console.log(colors.red("\nDeploy failed: manifest was not accepted by any relay."));
+      console.log(
+        colors.red("\nDeploy failed: manifest was not accepted by any relay."),
+      );
       return 1;
     }
   }
@@ -720,17 +824,28 @@ function computeExitCode(result: DeployPhaseResult): number {
 /**
  * Display gateway URLs where the deployed site is available
  */
-function displayGatewayUrl(config: ProjectConfig, publisherPubkey: string): void {
+function displayGatewayUrl(
+  config: ProjectConfig,
+  publisherPubkey: string,
+): void {
   const npub = npubEncode(publisherPubkey);
   const pubkeyB36 = encodePubkeyBase36(hexToBytes(publisherPubkey));
   const { gatewayHostnames, id } = config;
   const siteId = normalizeSiteIdentifier(id);
   const isNamedSite = !!siteId;
 
-  console.log(colors.green(`\nThe nsite is now available on any nsite gateway, for example:`));
+  console.log(
+    colors.green(
+      `\nThe nsite is now available on any nsite gateway, for example:`,
+    ),
+  );
   for (const gatewayHostname of gatewayHostnames || []) {
     if (isNamedSite) {
-      console.log(colors.blue.underline(`https://${pubkeyB36}${siteId}.${gatewayHostname}/`));
+      console.log(
+        colors.blue.underline(
+          `https://${pubkeyB36}${siteId}.${gatewayHostname}/`,
+        ),
+      );
     } else {
       console.log(colors.blue.underline(`https://${npub}.${gatewayHostname}/`));
     }
@@ -757,16 +872,22 @@ async function resolveContext(
 ): Promise<ProjectContext> {
   let config: ProjectConfig | null = null;
   let authKeyHex: string | null | undefined = options.sec || undefined;
-  const configPath = typeof options.config === "string" ? options.config : undefined;
+  const configPath = typeof options.config === "string"
+    ? options.config
+    : undefined;
 
   // --no-config: ignore config file entirely, build config from CLI args only
   if (options.config === false) {
-    log.debug("Resolving project context with --no-config (ignoring config file).");
+    log.debug(
+      "Resolving project context with --no-config (ignoring config file).",
+    );
     config = {
       servers: options.servers
         ? options.servers.split(",").map((s) => s.trim()).filter(Boolean)
         : [],
-      relays: options.relays ? options.relays.split(",").map((r) => r.trim()).filter(Boolean) : [],
+      relays: options.relays
+        ? options.relays.split(",").map((r) => r.trim()).filter(Boolean)
+        : [],
       fallback: options.fallback,
       gatewayHostnames: ["nsite.lol"],
     };
@@ -775,7 +896,8 @@ async function resolveContext(
       return {
         config,
         authKeyHex,
-        error: "Missing signing key: --no-config requires --sec for authentication.",
+        error:
+          "Missing signing key: --no-config requires --sec for authentication.",
       };
     }
   } else if (options.nonInteractive) {
@@ -786,9 +908,13 @@ async function resolveContext(
       existingProjectData = readProjectFile(configPath);
     } catch {
       // Configuration exists but is invalid
-      console.error(colors.red("\nConfiguration file exists but contains errors."));
       console.error(
-        colors.yellow("Please fix the errors above or delete .nsite/config.json to start fresh.\n"),
+        colors.red("\nConfiguration file exists but contains errors."),
+      );
+      console.error(
+        colors.yellow(
+          "Please fix the errors above or delete .nsite/config.json to start fresh.\n",
+        ),
       );
       return {
         config: defaultConfig,
@@ -803,21 +929,25 @@ async function resolveContext(
 
     if (
       !options.servers &&
-      (!existingProjectData?.servers || existingProjectData.servers.length === 0)
+      (!existingProjectData?.servers ||
+        existingProjectData.servers.length === 0)
     ) {
       return {
         config: existingProjectData,
         authKeyHex,
-        error: "Missing servers: Provide --servers or configure in .nsite/config.json.",
+        error:
+          "Missing servers: Provide --servers or configure in .nsite/config.json.",
       };
     }
     if (
-      !options.relays && (!existingProjectData?.relays || existingProjectData.relays.length === 0)
+      !options.relays &&
+      (!existingProjectData?.relays || existingProjectData.relays.length === 0)
     ) {
       return {
         config: existingProjectData,
         authKeyHex,
-        error: "Missing relays: Provide --relays or configure in .nsite/config.json.",
+        error:
+          "Missing relays: Provide --relays or configure in .nsite/config.json.",
       };
     }
 
@@ -860,9 +990,13 @@ async function resolveContext(
       currentProjectData = readProjectFile(configPath);
     } catch {
       // Configuration exists but is invalid
-      console.error(colors.red("\nConfiguration file exists but contains errors."));
       console.error(
-        colors.yellow("Please fix the errors above or delete .nsite/config.json to start fresh.\n"),
+        colors.red("\nConfiguration file exists but contains errors."),
+      );
+      console.error(
+        colors.yellow(
+          "Please fix the errors above or delete .nsite/config.json to start fresh.\n",
+        ),
       );
       return {
         config: defaultConfig,
@@ -908,10 +1042,14 @@ async function resolveContext(
 
     // Apply CLI flag overrides to config (interactive mode)
     if (options.servers) {
-      config.servers = options.servers.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+      config.servers = options.servers.split(",").map((s) => s.trim()).filter((
+        s,
+      ) => s.length > 0);
     }
     if (options.relays) {
-      config.relays = options.relays.split(",").map((r) => r.trim()).filter((r) => r.length > 0);
+      config.relays = options.relays.split(",").map((r) => r.trim()).filter((
+        r,
+      ) => r.length > 0);
     }
     if (options.fallback) {
       config.fallback = options.fallback;
@@ -925,10 +1063,18 @@ async function resolveContext(
   }
 
   if (!config || !config.servers || config.servers.length === 0) {
-    return { config, authKeyHex, error: "Servers configuration is missing or empty." };
+    return {
+      config,
+      authKeyHex,
+      error: "Servers configuration is missing or empty.",
+    };
   }
   if (!config.relays || config.relays.length === 0) {
-    return { config, authKeyHex, error: "Relays configuration is missing or empty." };
+    return {
+      config,
+      authKeyHex,
+      error: "Relays configuration is missing or empty.",
+    };
   }
 
   return { config, authKeyHex };
@@ -974,11 +1120,17 @@ async function initSigner(
         // Add timeout to getPublicKey as it might hang too
         const getPublicKeyPromise = bunkerSigner.getPublicKey();
         const timeoutPromise = new Promise((_, reject) => {
-          setTimeout(() => reject(new Error("getPublicKey timeout after 15s")), 15000);
+          setTimeout(
+            () => reject(new Error("getPublicKey timeout after 15s")),
+            15000,
+          );
         });
 
         log.debug("Waiting for getPublicKey or timeout...");
-        const pubkey = await Promise.race([getPublicKeyPromise, timeoutPromise]) as string;
+        const pubkey = await Promise.race([
+          getPublicKeyPromise,
+          timeoutPromise,
+        ]) as string;
         log.debug(`getPublicKey completed: ${truncateString(pubkey)}`);
         return bunkerSigner;
       } catch (e: unknown) {
@@ -998,9 +1150,10 @@ async function initSigner(
         }
       }
     } else {
-      const baseMsg = `No stored secret (nbunksec) found for configured bunker: ${
-        config.bunkerPubkey.substring(0, 8)
-      }...`;
+      const baseMsg =
+        `No stored secret (nbunksec) found for configured bunker: ${
+          config.bunkerPubkey.substring(0, 8)
+        }...`;
 
       if (options.nonInteractive) {
         return {
@@ -1079,7 +1232,10 @@ async function reconnectToBunker(
       });
 
       let chosenRelays: string[];
-      if (relayInput.trim() === "" || relayInput.trim() === defaultRelays.join(", ")) {
+      if (
+        relayInput.trim() === "" ||
+        relayInput.trim() === defaultRelays.join(", ")
+      ) {
         chosenRelays = defaultRelays;
       } else {
         chosenRelays = parseRelayInput(relayInput);
@@ -1092,7 +1248,9 @@ async function reconnectToBunker(
 
       console.log(
         colors.cyan(
-          `Initiating Nostr Connect as '${appName}' on relays: ${chosenRelays.join(", ")}`,
+          `Initiating Nostr Connect as '${appName}' on relays: ${
+            chosenRelays.join(", ")
+          }`,
         ),
       );
       signer = await initiateNostrConnect(appName, chosenRelays);
@@ -1146,15 +1304,23 @@ async function reconnectToBunker(
     const nbunkString = getNbunkString(signer);
     await secretsManager.storeNbunk(connectedPubkey, nbunkString);
 
-    console.log(colors.green("✓ Successfully reconnected to bunker and saved credentials."));
-    log.info(`Reconnected to bunker with pubkey: ${truncateString(connectedPubkey)}`);
+    console.log(
+      colors.green(
+        "✓ Successfully reconnected to bunker and saved credentials.",
+      ),
+    );
+    log.info(
+      `Reconnected to bunker with pubkey: ${truncateString(connectedPubkey)}`,
+    );
 
     return signer;
   } catch (error) {
     log.error(`Failed to reconnect to bunker: ${error}`);
     console.error(
       colors.red(
-        `Failed to reconnect to bunker: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to reconnect to bunker: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       ),
     );
 
@@ -1178,7 +1344,8 @@ function displayConfig(
   publisherPubkey: string,
   displayName?: string,
 ): void {
-  const { displayManager, config, options, resolvedRelays, resolvedServers } = state;
+  const { displayManager, config, options, resolvedRelays, resolvedServers } =
+    state;
   const userDisplay = displayName || publisherPubkey;
 
   if (displayManager.isInteractive()) {
@@ -1204,9 +1371,19 @@ function displayConfig(
         !options.servers && !config.servers,
       ),
     );
-    console.log(formatConfigValue("Force Upload", options.force, options.force === false));
-    console.log(formatConfigValue("Sync Servers", options.sync, options.sync === false));
-    console.log(formatConfigValue("Concurrency", options.concurrency, options.concurrency === 4));
+    console.log(
+      formatConfigValue("Force Upload", options.force, options.force === false),
+    );
+    console.log(
+      formatConfigValue("Sync Servers", options.sync, options.sync === false),
+    );
+    console.log(
+      formatConfigValue(
+        "Concurrency",
+        options.concurrency,
+        options.concurrency === 4,
+      ),
+    );
     console.log(
       formatConfigValue(
         "404 Fallback",
@@ -1239,7 +1416,9 @@ function displayConfig(
     );
     console.log(
       colors.cyan(
-        `Concurrency: ${options.concurrency}${options.concurrency === 4 ? " (default)" : ""}`,
+        `Concurrency: ${options.concurrency}${
+          options.concurrency === 4 ? " (default)" : ""
+        }`,
       ),
     );
     if (options.force) console.log(colors.yellow("Force Upload: true"));
@@ -1259,7 +1438,9 @@ function displayConfig(
       console.log(
         colors.cyan(
           `Publish App Handler: true${
-            !options.publishAppHandler && !config.publishAppHandler ? " (default)" : ""
+            !options.publishAppHandler && !config.publishAppHandler
+              ? " (default)"
+              : ""
           } (kinds: ${kinds.join(", ") || "none"})`,
         ),
       );
@@ -1329,14 +1510,17 @@ async function scanLocalFiles(state: DeploymentState): Promise<FileEntry[]> {
     if (displayManager.isInteractive()) statusDisplay.success(noFilesMsg);
     else console.log(colors.yellow(noFilesMsg));
     if (shouldPublishAny) {
-      log.info("Proceeding with publish operations as requested despite no files to upload.");
+      log.info(
+        "Proceeding with publish operations as requested despite no files to upload.",
+      );
     } else {
       return Deno.exit(0);
     }
   }
 
   if (includedFiles.length > 0) {
-    const foundFilesMsg = `Found ${includedFiles.length} files to process for upload.`;
+    const foundFilesMsg =
+      `Found ${includedFiles.length} files to process for upload.`;
     if (displayManager.isInteractive()) statusDisplay.update(foundFilesMsg);
     else console.log(colors.green(foundFilesMsg));
   }
@@ -1351,17 +1535,21 @@ async function fetchRemoteFiles(
   state: DeploymentState,
   publisherPubkey: string,
 ): Promise<FileEntry[]> {
-  const { statusDisplay, displayManager, options, resolvedRelays, config } = state;
+  const { statusDisplay, displayManager, options, resolvedRelays, config } =
+    state;
   let remoteFileEntries: FileEntry[] = [];
 
   // Must match publishSiteManifest / createSiteManifestEvent: named sites use kind 35128 + #d.
   // Omitting this always fetched the root (15128) manifest and reused root path hashes on
   // named-site deploys (e.g. /index.html from root on a named site).
-  const manifestSiteId = config.id === null || config.id === "" ? undefined : config.id;
+  const manifestSiteId = config.id === null || config.id === ""
+    ? undefined
+    : config.id;
 
   // We need remote file info for sync mode, and when not forcing uploads
   const shouldFetchRemote = !options.force || options.sync;
-  const allowFallbackRelays = options.useFallbacks || options.useFallbackRelays || false;
+  const allowFallbackRelays = options.useFallbacks ||
+    options.useFallbackRelays || false;
 
   if (shouldFetchRemote) {
     // Prefer configured relays but fall back to broadcast relays for reliability
@@ -1370,8 +1558,12 @@ async function fetchRemoteFiles(
       : (allowFallbackRelays ? NSYTE_BROADCAST_RELAYS : []);
 
     if (primaryRelays.length > 0) {
-      const reason = options.force && options.sync ? " (required for sync)" : "";
-      const remoteLabel = manifestSiteId ? `named site "${manifestSiteId}"` : "root site";
+      const reason = options.force && options.sync
+        ? " (required for sync)"
+        : "";
+      const remoteLabel = manifestSiteId
+        ? `named site "${manifestSiteId}"`
+        : "root site";
       statusDisplay.update(
         `Checking for existing files on remote relays (${remoteLabel})${reason}...`,
       );
@@ -1383,8 +1575,14 @@ async function fetchRemoteFiles(
         );
 
         // If nothing found on the configured relays, retry with a broader relay set
-        if (remoteFileEntries.length === 0 && resolvedRelays.length > 0 && allowFallbackRelays) {
-          const fallbackRelays = relaySet(resolvedRelays, NSYTE_BROADCAST_RELAYS);
+        if (
+          remoteFileEntries.length === 0 && resolvedRelays.length > 0 &&
+          allowFallbackRelays
+        ) {
+          const fallbackRelays = relaySet(
+            resolvedRelays,
+            NSYTE_BROADCAST_RELAYS,
+          );
           statusDisplay.update(
             `No files found on configured relays, retrying with default broadcast relays...`,
           );
@@ -1412,18 +1610,22 @@ async function fetchRemoteFiles(
         const errMsg = `Could not fetch remote file list: ${
           getErrorMessage(e)
         }. Proceeding as if no files exist remotely.`;
-        if (displayManager.isInteractive()) statusDisplay.update(colors.yellow(errMsg));
-        else console.log(colors.yellow(errMsg));
+        if (displayManager.isInteractive()) {
+          statusDisplay.update(colors.yellow(errMsg));
+        } else console.log(colors.yellow(errMsg));
         log.warn(errMsg);
       }
     } else {
       const noRelayWarn =
         "No relays configured. Cannot check for existing remote files. Will upload all local files.";
-      if (displayManager.isInteractive()) statusDisplay.update(colors.yellow(noRelayWarn));
-      else console.log(colors.yellow(noRelayWarn));
+      if (displayManager.isInteractive()) {
+        statusDisplay.update(colors.yellow(noRelayWarn));
+      } else console.log(colors.yellow(noRelayWarn));
     }
   } else {
-    log.debug("Skipping remote file check because --force was provided without --sync");
+    log.debug(
+      "Skipping remote file check because --force was provided without --sync",
+    );
   }
   return remoteFileEntries;
 }
@@ -1449,12 +1651,18 @@ async function compareAndPrepareFiles(
   let unchanged = existing;
 
   if (options.force && existing.length > 0) {
-    log.info(`--force enabled: re-uploading ${existing.length} unchanged files.`);
+    log.info(
+      `--force enabled: re-uploading ${existing.length} unchanged files.`,
+    );
     toTransfer.push(...existing);
     unchanged = [];
   }
 
-  const compareMsg = formatFileSummary(toTransfer.length, unchanged.length, toDelete.length);
+  const compareMsg = formatFileSummary(
+    toTransfer.length,
+    unchanged.length,
+    toDelete.length,
+  );
 
   if (displayManager.isInteractive()) {
     statusDisplay.success(compareMsg);
@@ -1474,7 +1682,9 @@ async function compareAndPrepareFiles(
   // Handle --sync: move existing files to toTransfer so they get uploaded.
   // HEAD preflight stays active, so servers that already have the blob will skip.
   if (options.sync && existing.length > 0) {
-    log.info(`--sync enabled: checking ${existing.length} existing files across all servers.`);
+    log.info(
+      `--sync enabled: checking ${existing.length} existing files across all servers.`,
+    );
     toTransfer.push(...existing);
     unchanged = [];
   }
@@ -1486,7 +1696,10 @@ async function compareAndPrepareFiles(
       const action = await Select.prompt({
         message: "No new files detected. What would you like to do?",
         options: [
-          { name: "Sync to all servers (backfill missing blobs)", value: "sync" },
+          {
+            name: "Sync to all servers (backfill missing blobs)",
+            value: "sync",
+          },
           { name: "Force re-upload everything", value: "force" },
           { name: "Cancel", value: "cancel" },
         ],
@@ -1521,7 +1734,9 @@ async function compareAndPrepareFiles(
         await flushQueuedLogs();
         return Deno.exit(1);
       } else {
-        log.info("Continuing with metadata publishing operations despite no files to upload.");
+        log.info(
+          "Continuing with metadata publishing operations despite no files to upload.",
+        );
       }
     }
   }
@@ -1545,7 +1760,9 @@ async function prepareFilesForUpload(
       preparedFiles.push(fileWithData);
     } catch (error: unknown) {
       const errorMessage = getErrorMessage(error);
-      console.error(colors.red(`Failed to load file ${file.path}: ${errorMessage}`));
+      console.error(
+        colors.red(`Failed to load file ${file.path}: ${errorMessage}`),
+      );
       messageCollector.addFileError(file.path, errorMessage);
     }
   }
@@ -1578,8 +1795,12 @@ async function maybeProcessFiles(
         includedFiles,
       );
 
-      filesUploaded = uploadResult.uploadResponses.filter((r) => r.success).length;
-      filesFailed = uploadResult.uploadResponses.filter((r) => !r.success).length;
+      filesUploaded = uploadResult.uploadResponses.filter((r) =>
+        r.success
+      ).length;
+      filesFailed = uploadResult.uploadResponses.filter((r) =>
+        !r.success
+      ).length;
       manifestResult = uploadResult.manifestResult;
     } catch (e: unknown) {
       const errMsg = `Error during upload process: ${getErrorMessage(e)}`;
@@ -1651,9 +1872,12 @@ async function publishSiteManifest(
 
     // Prepare metadata - use config values (these are recommendations for others)
     // Operational relays/servers (from kind 10002/10063) are used for publishing, not in metadata
-    const manifestRelays = options.relays?.split(",").filter((r) => r.trim()) || config.relays ||
+    const manifestRelays = options.relays?.split(",").filter((r) => r.trim()) ||
+      config.relays ||
       [];
-    const manifestServers = options.servers?.split(",").filter((s) => s.trim()) || config.servers ||
+    const manifestServers = options.servers?.split(",").filter((s) =>
+      s.trim()
+    ) || config.servers ||
       [];
 
     // Detect source URL (config > git remote auto-detect)
@@ -1717,10 +1941,13 @@ async function publishSiteManifest(
 
     // Publish manifest event using discovered relays (from kind 10002) with detailed results
     statusDisplay.update("Publishing site manifest event...");
-    const publishResult = await publishEventsToRelaysDetailed(resolvedRelays, [manifestEvent]);
+    const publishResult = await publishEventsToRelaysDetailed(resolvedRelays, [
+      manifestEvent,
+    ]);
 
     // Extract per-relay results from the first (only) event result
-    const eventResult: EventPublishResult | undefined = publishResult.eventResults[0];
+    const eventResult: EventPublishResult | undefined =
+      publishResult.eventResults[0];
     const relayResults = eventResult?.relayResults ?? [];
     const successCount = eventResult?.successCount ?? 0;
     const failureCount = eventResult?.failureCount ?? 0;
@@ -1733,7 +1960,9 @@ async function publishSiteManifest(
     }
 
     if (publishResult.allEventsPublished) {
-      console.log(colors.green(`✓ Site manifest event successfully published to relays`));
+      console.log(
+        colors.green(`✓ Site manifest event successfully published to relays`),
+      );
       if (siteId) {
         console.log(colors.cyan(`  Site: ${siteId} (named site)`));
       } else {
@@ -1754,12 +1983,18 @@ async function publishSiteManifest(
       };
     } else {
       statusDisplay.error("Failed to publish site manifest event");
-      console.log(colors.red(`✗ Failed to publish site manifest event to relays`));
       console.log(
-        colors.yellow("Files are uploaded but may not be immediately visible in the nsite."),
+        colors.red(`✗ Failed to publish site manifest event to relays`),
       );
       console.log(
-        colors.yellow("Try running the deploy command again to republish the manifest."),
+        colors.yellow(
+          "Files are uploaded but may not be immediately visible in the nsite.",
+        ),
+      );
+      console.log(
+        colors.yellow(
+          "Try running the deploy command again to republish the manifest.",
+        ),
       );
       console.log("");
 
@@ -1849,7 +2084,10 @@ async function uploadFiles(
 
   if (uploadResponses.length > 0) {
     const uploadedCount = uploadResponses.filter((r) => r.success).length;
-    const uploadedSize = uploadResponses.reduce((sum, r) => sum + (r.file.size || 0), 0);
+    const uploadedSize = uploadResponses.reduce(
+      (sum, r) => sum + (r.file.size || 0),
+      0,
+    );
 
     for (const result of uploadResponses) {
       if (result.success) {
@@ -1865,12 +2103,15 @@ async function uploadFiles(
     const allSucceeded = uploadedCount === preparedFiles.length &&
       uploadResponses.length === preparedFiles.length;
     if (allSucceeded) {
-      const msg = `${uploadedCount} files uploaded successfully (${formatFileSize(uploadedSize)})`;
-      progressRenderer.complete(true, msg);
-    } else if (uploadedCount > 0) {
-      const msg = `${uploadedCount}/${preparedFiles.length} files uploaded successfully (${
+      const msg = `${uploadedCount} files uploaded successfully (${
         formatFileSize(uploadedSize)
       })`;
+      progressRenderer.complete(true, msg);
+    } else if (uploadedCount > 0) {
+      const msg =
+        `${uploadedCount}/${preparedFiles.length} files uploaded successfully (${
+          formatFileSize(uploadedSize)
+        })`;
       progressRenderer.complete(false, msg);
     } else {
       const msg = "Failed to upload any files";
@@ -1895,7 +2136,9 @@ async function uploadFiles(
     if (uploadedCount > 0) {
       console.log(formatSectionHeader("Blobs Upload Results (Blossom)"));
       if (allSucceeded) {
-        console.log(colors.green(`✓ All ${uploadedCount} files successfully uploaded`));
+        console.log(
+          colors.green(`✓ All ${uploadedCount} files successfully uploaded`),
+        );
       } else {
         const failedCount = preparedFiles.length - uploadedCount;
         console.log(
@@ -1920,8 +2163,12 @@ async function uploadFiles(
       console.log("");
 
       // Separate uploaded, skipped, and failed responses
-      const uploadedResponses = uploadResponses.filter((r) => r.success && !r.skipped);
-      const skippedResponses = uploadResponses.filter((r) => r.success && r.skipped);
+      const uploadedResponses = uploadResponses.filter((r) =>
+        r.success && !r.skipped
+      );
+      const skippedResponses = uploadResponses.filter((r) =>
+        r.success && r.skipped
+      );
       const failedResponses = uploadResponses.filter((r) => !r.success);
 
       // Print uploaded files with server indicators, type, and size
@@ -1945,7 +2192,9 @@ async function uploadFiles(
 
         const size = formatFileSize(result.file.size);
         console.log(
-          `  ${indicators} ${result.file.path} ${colors.gray(fileType)} ${colors.gray(size)}`,
+          `  ${indicators} ${result.file.path} ${colors.gray(fileType)} ${
+            colors.gray(size)
+          }`,
         );
       }
 
@@ -1958,9 +2207,11 @@ async function uploadFiles(
           : contentType;
         const size = formatFileSize(result.file.size);
         console.log(
-          `  ${indicators} ${colors.red(result.file.path)} ${colors.gray(fileType)} ${
-            colors.gray(size)
-          } ${colors.red("✗ " + (result.error || "failed"))}`,
+          `  ${indicators} ${colors.red(result.file.path)} ${
+            colors.gray(fileType)
+          } ${colors.gray(size)} ${
+            colors.red("✗ " + (result.error || "failed"))
+          }`,
         );
       }
       console.log("");
@@ -1982,9 +2233,9 @@ async function uploadFiles(
             : contentType;
           const size = formatFileSize(result.file.size);
           console.log(
-            `  ${colors.gray("⊘")} ${colors.gray(result.file.path)} ${colors.gray(fileType)} ${
-              colors.gray(size)
-            }`,
+            `  ${colors.gray("⊘")} ${colors.gray(result.file.path)} ${
+              colors.gray(fileType)
+            } ${colors.gray(size)}`,
           );
         }
         console.log("");
@@ -2003,12 +2254,24 @@ async function uploadFiles(
       }
     > = {};
     for (const server of resolvedServers) {
-      serverStats[server] = { success: 0, total: 0, failed: 0, retries: 0, errors: new Map() };
+      serverStats[server] = {
+        success: 0,
+        total: 0,
+        failed: 0,
+        retries: 0,
+        errors: new Map(),
+      };
     }
     for (const result of uploadResponses) {
       for (const [server, status] of Object.entries(result.serverResults)) {
         if (!serverStats[server]) {
-          serverStats[server] = { success: 0, total: 0, failed: 0, retries: 0, errors: new Map() };
+          serverStats[server] = {
+            success: 0,
+            total: 0,
+            failed: 0,
+            retries: 0,
+            errors: new Map(),
+          };
         }
         serverStats[server].total++;
         serverStats[server].retries += status.retries || 0;
@@ -2029,7 +2292,9 @@ async function uploadFiles(
     for (const server of resolvedServers) {
       const sp = lastServerProgress[server];
       if (sp?.finishedAt) {
-        serverTimings[server] = Math.floor((sp.finishedAt - uploadStartTime) / 1000);
+        serverTimings[server] = Math.floor(
+          (sp.finishedAt - uploadStartTime) / 1000,
+        );
       }
     }
     console.log(formatServerSummary(serverStats, serverTimings));
@@ -2038,20 +2303,32 @@ async function uploadFiles(
     const successBlobs = uploadResponses.filter((r) => r.success).length;
     const skippedBlobs = uploadResponses.filter((r) => r.skipped).length;
     const backfilledBlobs = successBlobs - skippedBlobs;
-    const pct = totalBlobs === 0 ? 100 : Math.round((successBlobs / totalBlobs) * 100);
-    const colorFn = pct === 100 ? colors.green : pct > 0 ? colors.yellow : colors.red;
+    const pct = totalBlobs === 0
+      ? 100
+      : Math.round((successBlobs / totalBlobs) * 100);
+    const colorFn = pct === 100
+      ? colors.green
+      : pct > 0
+      ? colors.yellow
+      : colors.red;
     console.log(
-      colorFn(`Overall: ${successBlobs}/${totalBlobs} blobs on at least one server (${pct}%)`),
+      colorFn(
+        `Overall: ${successBlobs}/${totalBlobs} blobs on at least one server (${pct}%)`,
+      ),
     );
 
     // Show sync/force specific summary
     if (options.sync && !options.force) {
       console.log(
-        colors.cyan(`Sync: ${skippedBlobs} already on all servers, ${backfilledBlobs} backfilled`),
+        colors.cyan(
+          `Sync: ${skippedBlobs} already on all servers, ${backfilledBlobs} backfilled`,
+        ),
       );
     } else if (options.force) {
       console.log(
-        colors.cyan(`Force: ${totalBlobs} files re-uploaded to ${resolvedServers.length} servers`),
+        colors.cyan(
+          `Force: ${totalBlobs} files re-uploaded to ${resolvedServers.length} servers`,
+        ),
       );
     }
     console.log("");
@@ -2078,7 +2355,9 @@ async function uploadFiles(
         MessageCategory.SERVER,
       )
     ) {
-      const prefix = type === "error" ? colors.red("Error") : colors.yellow("Warning");
+      const prefix = type === "error"
+        ? colors.red("Error")
+        : colors.yellow("Warning");
       log.info(`${prefix} from ${target}: ${content}`);
     }
   }
@@ -2103,7 +2382,12 @@ export function buildDeployListing(
   createdAt?: number,
 ): EventTemplate | null {
   if (!isNapp(config)) return null;
-  return createAppListingTemplate(publisherPubkey, config.napp, manifestDTag, createdAt);
+  return createAppListingTemplate(
+    publisherPubkey,
+    config.napp,
+    manifestDTag,
+    createdAt,
+  );
 }
 
 /**
@@ -2117,7 +2401,14 @@ async function maybePublishAppListing(
   publisherPubkey: string,
   _manifestResult: ManifestPublishResult | null,
 ): Promise<void> {
-  const { statusDisplay, signer, config, options, resolvedRelays, messageCollector } = state;
+  const {
+    statusDisplay,
+    signer,
+    config,
+    options,
+    resolvedRelays,
+    messageCollector,
+  } = state;
 
   if (!isNapp(config)) return;
 
@@ -2129,7 +2420,9 @@ async function maybePublishAppListing(
   const indexerRelays = resolveIndexerRelays(config);
 
   console.log(formatSectionHeader("App Listing (napp)"));
-  console.log(colors.cyan("napp detected — publishing app listing (kind 37348)"));
+  console.log(
+    colors.cyan("napp detected — publishing app listing (kind 37348)"),
+  );
   console.log(colors.cyan(`indexer relays: ${indexerRelays.join(", ")}`));
   statusDisplay.update("Publishing app listing (kind 37348)...");
 
@@ -2145,11 +2438,17 @@ async function maybePublishAppListing(
     // Publish to the deduped UNION of the manifest's relay set (NIP-65 write/resolved
     // relays) and the configured indexer relays — so the listing reaches both the
     // author's normal relays and the NIP-5B indexers. A relay in both appears once.
-    const publishRelays = Array.from(new Set([...resolvedRelays, ...indexerRelays]));
-    const result = await publishEventsToRelaysDetailed(publishRelays, [listingEvent]);
+    const publishRelays = Array.from(
+      new Set([...resolvedRelays, ...indexerRelays]),
+    );
+    const result = await publishEventsToRelaysDetailed(publishRelays, [
+      listingEvent,
+    ]);
 
     if (result.allEventsPublished) {
-      statusDisplay.success(`App listing published (kind ${NSITE_APP_LISTING_KIND})`);
+      statusDisplay.success(
+        `App listing published (kind ${NSITE_APP_LISTING_KIND})`,
+      );
       messageCollector.addEventSuccess("app listing", listingEvent.id);
     } else {
       statusDisplay.error("Failed to publish app listing");
@@ -2168,7 +2467,14 @@ async function maybePublishMetadata(
   state: DeploymentState,
   publisherPubkey: string,
 ): Promise<void> {
-  const { statusDisplay, signer, config, options, resolvedRelays, messageCollector } = state;
+  const {
+    statusDisplay,
+    signer,
+    config,
+    options,
+    resolvedRelays,
+    messageCollector,
+  } = state;
 
   log.debug("maybePublishMetadata called");
 
@@ -2198,10 +2504,15 @@ async function maybePublishMetadata(
   // Get relays from the user's 10002 list if present
   let discoveredRelayList: string[] = [];
   try {
-    const relayListEvent = await fetchUserRelayList(usermeta_relays, publisherPubkey);
+    const relayListEvent = await fetchUserRelayList(
+      usermeta_relays,
+      publisherPubkey,
+    );
     if (relayListEvent) {
       discoveredRelayList = getOutboxes(relayListEvent);
-      log.debug(`Discovered ${discoveredRelayList.length} relays from user's relay list`);
+      log.debug(
+        `Discovered ${discoveredRelayList.length} relays from user's relay list`,
+      );
     }
   } catch (e) {
     log.debug(`Failed to fetch relay list: ${getErrorMessage(e)}`);
@@ -2216,8 +2527,10 @@ async function maybePublishMetadata(
   await publishMetadata(config, signer, publishToRelays, statusDisplay, {
     publishAppHandler: shouldPublishAppHandler,
     publishProfile: options.publishProfile || config.publishProfile || false,
-    publishRelayList: options.publishRelayList || config.publishRelayList || false,
-    publishServerList: options.publishServerList || config.publishServerList || false,
+    publishRelayList: options.publishRelayList || config.publishRelayList ||
+      false,
+    publishServerList: options.publishServerList || config.publishServerList ||
+      false,
     handlerKinds: options.handlerKinds,
     createdAt: options.createdAt,
   });
@@ -2226,7 +2539,9 @@ async function maybePublishMetadata(
     log.info(formatSectionHeader("Relay Messages"));
 
     const relayResults: Record<string, { success: number; total: number }> = {};
-    const relayMessages = messageCollector.getMessagesByCategory(MessageCategory.RELAY);
+    const relayMessages = messageCollector.getMessagesByCategory(
+      MessageCategory.RELAY,
+    );
 
     for (const message of relayMessages) {
       const relayUrl = message.target;
@@ -2246,7 +2561,9 @@ async function maybePublishMetadata(
         : result.success === 0
         ? colors.red("✗")
         : colors.yellow("⚠");
-      log.info(`  ${status} ${relay}: ${result.success}/${result.total} events`);
+      log.info(
+        `  ${status} ${relay}: ${result.success}/${result.total} events`,
+      );
     }
   }
 }

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -12,6 +12,7 @@
 import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
 import { Input, Select } from "@cliffy/prompt";
+import { walk } from "@std/fs";
 import type { NostrEvent } from "applesauce-core/helpers";
 import {
   buildNappConfigFromAnswers,
@@ -368,6 +369,127 @@ async function nappInitAction(options: { config?: string | boolean }): Promise<v
   );
 }
 
+// ---------------------------------------------------------------------------
+// `napp validate` — structural validation (hard-fail) + NIP-07 heuristic (warn-only)
+// ---------------------------------------------------------------------------
+
+/** Evidence tokens (lowercased) that indicate NIP-07 (`window.nostr`) support. */
+const NIP07_TOKENS = ["window.nostr", "nostr-login", "nip07", "getpublickey"] as const;
+
+/** True iff `text` contains any NIP-07 evidence token (case-insensitive). */
+export function detectNip07InText(text: string): boolean {
+  const lower = text.toLowerCase();
+  return NIP07_TOKENS.some((t) => lower.includes(t));
+}
+
+/**
+ * Recursively scan `dir` for built JS/HTML files containing NIP-07 evidence. Read-only
+ * over a fixed extension allow-list; walks ONLY the given dir (T-24-04). A missing dir
+ * returns false without throwing (T-24-05) — the heuristic is advisory.
+ */
+export async function scanDirForNip07Evidence(dir: string): Promise<boolean> {
+  try {
+    for await (
+      const entry of walk(dir, {
+        exts: ["js", "mjs", "html", "htm"],
+        includeDirs: false,
+      })
+    ) {
+      const text = await Deno.readTextFile(entry.path);
+      if (detectNip07InText(text)) return true;
+    }
+  } catch {
+    // Missing/unreadable dir => no evidence (advisory, never blocks).
+    return false;
+  }
+  return false;
+}
+
+/** Structured result of `napp validate`. Structural errors drive `ok`; NIP-07 is advisory. */
+export interface NappValidateReport {
+  ok: boolean;
+  structuralErrors: { path: string; message: string }[];
+  nip07: "pass" | "warn";
+}
+
+/**
+ * Assemble the validate report. Structural errors are the ONLY hard failure; the NIP-07
+ * signal sets a pass/warn note and NEVER flips `ok` to false.
+ */
+export function assembleValidateReport(input: {
+  structuralErrors: { path: string; message: string }[];
+  nip07Found: boolean;
+}): NappValidateReport {
+  return {
+    ok: input.structuralErrors.length === 0,
+    structuralErrors: input.structuralErrors,
+    nip07: input.nip07Found ? "pass" : "warn",
+  };
+}
+
+/**
+ * `napp validate` action: structural `validateNappConfig` errors (hard-fail) plus a
+ * best-effort NIP-07 heuristic over the optional `[dir]` (warn-only). Surfaces the `+`
+ * identifier informationally (root sites have none — skip silently).
+ */
+async function nappValidateAction(
+  dir: string | undefined,
+  options: { config?: string | boolean },
+): Promise<void> {
+  const configPath = typeof options.config === "string" ? options.config : undefined;
+  const projectConfig = readProjectFile(configPath);
+
+  if (!projectConfig) {
+    console.error(colors.red("No .nsite/config.json found."));
+    Deno.exit(1);
+  }
+
+  if (!isNapp(projectConfig)) {
+    console.error(
+      colors.red(
+        "This project is not a napp — run `nsyte napp init` to add a `napp` section.",
+      ),
+    );
+    Deno.exit(1);
+  }
+
+  const structuralErrors = validateNappConfig(projectConfig.napp);
+
+  const scanDir = dir ?? ".";
+  const nip07Found = await scanDirForNip07Evidence(scanDir);
+
+  const report = assembleValidateReport({ structuralErrors, nip07Found });
+
+  if (report.structuralErrors.length > 0) {
+    for (const e of report.structuralErrors) {
+      console.error(colors.red(`  ${e.path}: ${e.message}`));
+    }
+  } else {
+    console.log(colors.green("✓ napp config is structurally valid."));
+  }
+
+  if (report.nip07 === "pass") {
+    console.log(colors.green(`✓ NIP-07 usage detected in ${scanDir}.`));
+  } else {
+    console.log(
+      colors.yellow(
+        `⚠ NIP-07 support not detected in ${scanDir} — a napp SHOULD support NIP-07 (window.nostr). This is a heuristic; verify manually.`,
+      ),
+    );
+  }
+
+  // Informational identifier (best-effort; root sites have none).
+  try {
+    const pubkey = await resolvePubkey(options as ResolverOptions, projectConfig);
+    const id = resolveNappIdentifier(projectConfig, pubkey);
+    console.log(colors.gray(`App identifier: ${id}`));
+  } catch {
+    // Root sites / unresolvable pubkey — informational only, never a validate failure.
+  }
+
+  if (!report.ok) Deno.exit(1);
+}
+
 /** Register the `napp` command (and its subcommands) on the root program. */
 export function registerNappCommand(): void {
   const napp = new Command()
@@ -422,6 +544,13 @@ export function registerNappCommand(): void {
     .command("init", "Retrofit a napp section onto this project's config")
     .action(async (options) => {
       await nappInitAction(options as unknown as { config?: string | boolean });
+    })
+    // validate subcommand (LAST — no trailing .reset()). Positional [dir] only, NO `.option`.
+    .reset()
+    .command("validate", "Check napp readiness: required fields, categories, and a NIP-07 heuristic")
+    .arguments("[dir:string]")
+    .action(async (options, dir) => {
+      await nappValidateAction(dir, options as unknown as { config?: string | boolean });
     });
 
   nsyte.command("napp", napp);

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -11,12 +11,19 @@
  */
 import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
+import { Input } from "@cliffy/prompt";
+import type { NostrEvent } from "applesauce-core/helpers";
 import { type ProjectConfig, readProjectFile } from "../lib/config.ts";
 import { getErrorMessage } from "../lib/error-utils.ts";
 import { createLogger } from "../lib/logger.ts";
 import { isNapp } from "../lib/napp/detect.ts";
-import { nappIdentifier } from "../lib/napp/identifier.ts";
-import { type ResolverOptions, resolvePubkey } from "../lib/resolver-utils.ts";
+import { nappIdentifier, resolveIndexerRelays } from "../lib/napp/identifier.ts";
+import { createReleaseNoteEvent, type ReleaseChanges } from "../lib/napp/release.ts";
+import { getManifestIdentifier } from "../lib/manifest.ts";
+import { fetchSiteManifestEvent, publishEventsToRelaysDetailed } from "../lib/nostr.ts";
+import { createSigner } from "../lib/auth/signer-factory.ts";
+import { type ResolverOptions, resolvePubkey, resolveRelays } from "../lib/resolver-utils.ts";
+import { getDisplayManager } from "../lib/display-mode.ts";
 import nsyte from "./root.ts";
 
 const log = createLogger("napp");
@@ -79,6 +86,183 @@ async function nappIdAction(options: { config?: string | boolean }): Promise<voi
   }
 }
 
+// ---------------------------------------------------------------------------
+// `napp release` — pure, signer-free, network-free core (unit-testable)
+// ---------------------------------------------------------------------------
+
+/** The five changelog flag arrays, as they arrive from Cliffy's `collect:true`. */
+interface ReleaseFlags {
+  fix?: string[];
+  add?: string[];
+  try?: string[];
+  cut?: string[];
+  sub?: string[];
+}
+
+/**
+ * Build a {@link ReleaseChanges} object from the repeatable changelog flags, including a
+ * category ONLY when its array is present and non-empty. Entries are kept as-is.
+ */
+export function buildReleaseChangesFromFlags(flags: ReleaseFlags): ReleaseChanges {
+  const changes: ReleaseChanges = {};
+  const categories = ["fix", "add", "try", "cut", "sub"] as const;
+  for (const category of categories) {
+    const entries = flags[category];
+    if (Array.isArray(entries) && entries.length > 0) {
+      changes[category] = entries;
+    }
+  }
+  return changes;
+}
+
+/** True iff any change category has at least one entry. */
+export function hasAnyChange(changes: ReleaseChanges): boolean {
+  const categories = ["fix", "add", "try", "cut", "sub"] as const;
+  return categories.some((c) => (changes[c]?.length ?? 0) > 0);
+}
+
+/**
+ * Pin the app version from the fetched site manifest. The release note's `d` = this
+ * manifest's EVENT id; `D` = its `d` tag (empty for a root site, which has no d tag).
+ */
+export function resolveManifestVersion(
+  manifest: NostrEvent,
+): { manifestId: string; manifestDTag: string; manifestCreatedAt: number } {
+  return {
+    manifestId: manifest.id,
+    manifestDTag: getManifestIdentifier(manifest) ?? "",
+    manifestCreatedAt: manifest.created_at,
+  };
+}
+
+/**
+ * `napp release` action: resolve config + author pubkey + signer, fetch the current site
+ * manifest to pin the app version, collect change entries (flags and/or interactive
+ * prompt), sign the kind-39108 event, and publish to dedupe(write ∪ indexer) relays.
+ *
+ * This command SIGNS + PUBLISHES (unlike `napp id`, which only prints). It is NOT
+ * unit-tested directly (it fetches/signs/publishes); the unit tests cover the pure
+ * helpers above.
+ */
+async function nappReleaseAction(
+  options: {
+    config?: string | boolean;
+    sec?: string;
+    pubkey?: string;
+    relays?: string;
+    createdAt?: number;
+    fix?: string[];
+    add?: string[];
+    try?: string[];
+    cut?: string[];
+    sub?: string[];
+  },
+): Promise<void> {
+  const configPath = typeof options.config === "string" ? options.config : undefined;
+  const projectConfig = readProjectFile(configPath);
+  if (!projectConfig) {
+    console.error(colors.red("No .nsite/config.json found."));
+    Deno.exit(1);
+  }
+
+  // Gate on napp: release notes are a napp-only concept.
+  if (!isNapp(projectConfig)) {
+    console.error(
+      colors.red(
+        "This project is not a napp — add a `napp` section to .nsite/config.json (see `nsyte napp init`).",
+      ),
+    );
+    Deno.exit(1);
+  }
+
+  // Resolve author pubkey (for the manifest FETCH) and write relays.
+  const pubkey = await resolvePubkey(options as ResolverOptions, projectConfig);
+  const resolvedRelays = resolveRelays(options as ResolverOptions, projectConfig);
+
+  // Build the signer via the same factory deploy uses (sec > stored bunkerPubkey).
+  const signerResult = await createSigner({
+    sec: options.sec,
+    bunkerPubkey: projectConfig.bunkerPubkey,
+  });
+  if ("error" in signerResult) {
+    console.error(colors.red(signerResult.error));
+    Deno.exit(1);
+  }
+  const signer = signerResult.signer;
+
+  // Fetch the CURRENT manifest (app version). Named sites query by config.id; root sites
+  // (no id) fetch the root manifest (kind 15128).
+  const identifier = typeof projectConfig.id === "string" && projectConfig.id
+    ? projectConfig.id
+    : undefined;
+  const manifest = await fetchSiteManifestEvent(resolvedRelays, pubkey, identifier);
+  if (!manifest) {
+    console.error(
+      colors.red(
+        "No site manifest found for this pubkey on the configured relays. Deploy your site first (`nsyte deploy`) before publishing a release note.",
+      ),
+    );
+    Deno.exit(1);
+  }
+  const version = resolveManifestVersion(manifest);
+
+  // Collect changes from flags; fall back to a simple interactive prompt.
+  let changes = buildReleaseChangesFromFlags(options);
+  if (!hasAnyChange(changes)) {
+    if (getDisplayManager().isInteractive()) {
+      // Simple prompt collects GENERIC `sub` entries; flag users get fine-grained
+      // fix/add/try/cut. Loop until the author submits a blank line.
+      const collected: string[] = [];
+      while (true) {
+        const entry = await Input.prompt({ message: "Changelog entry (blank to finish):" });
+        if (!entry || entry.trim().length === 0) break;
+        collected.push(entry.trim());
+      }
+      if (collected.length > 0) {
+        changes = { sub: collected };
+      }
+    }
+    if (!hasAnyChange(changes)) {
+      console.error(
+        colors.red(
+          "No changelog entries. Provide at least one of --fix/--add/--try/--cut/--sub, or run interactively.",
+        ),
+      );
+      Deno.exit(1);
+    }
+  }
+
+  // Build + sign the kind-39108 event.
+  const releaseEvent = await createReleaseNoteEvent(signer, {
+    ...version,
+    changes,
+    createdAt: options.createdAt,
+  });
+
+  // Publish to the deduped UNION of write relays and indexer relays (mirror deploy).
+  const indexerRelays = resolveIndexerRelays(projectConfig);
+  const publishRelays = Array.from(new Set([...resolvedRelays, ...indexerRelays]));
+  console.log(colors.gray(`Indexer relays: ${indexerRelays.join(", ")}`));
+  const result = await publishEventsToRelaysDetailed(publishRelays, [releaseEvent]);
+
+  const eventResult = result.eventResults[0];
+  const relayResults = eventResult?.relayResults ?? [];
+  for (const r of relayResults) {
+    if (r.ok) {
+      console.log(colors.green(`  ✓ ${r.relay}`));
+    } else {
+      console.log(colors.red(`  ✗ ${r.relay}${r.message ? ` (${r.message})` : ""}`));
+    }
+  }
+
+  if (result.allEventsPublished) {
+    console.log(colors.green(`Release note published (kind 39108): ${releaseEvent.id}`));
+  } else {
+    console.error(colors.red("Failed to publish release note to all relays."));
+    Deno.exit(1);
+  }
+}
+
 /** Register the `napp` command (and its subcommands) on the root program. */
 export function registerNappCommand(): void {
   const napp = new Command()
@@ -87,16 +271,46 @@ export function registerNappCommand(): void {
       // Show help when no subcommand is provided.
       await napp.showHelp();
     })
-    // Future phases append `release`/`init`/`validate` here as
-    //   .reset().command("...", "...").action(...)
-    // chains BEFORE the final subcommand (the last one omits `.reset()`).
-    // id subcommand (LAST/only — no trailing .reset()).
-    // The global `-c/--config` (+ resolver flags) live on the parent program, so the
+    // id subcommand — followed by `.reset()` so `release` can be appended below.
+    // The global `-c/--config` (+ `--created-at`) live on the parent program, so the
     // action's options object carries them at runtime even though this standalone
-    // Command's generics don't surface them — read them via a cast.
+    // Command's generics don't surface them — read them via a cast. `--sec/--relays/
+    // --pubkey` are NOT globals, so the `release` subcommand declares its own below.
     .command("id", "Print the shareable + app identifier for this napp")
     .action(async (options) => {
       await nappIdAction(options as unknown as { config?: string | boolean });
+    })
+    // Future phases append `init`/`validate` here as
+    //   .reset().command("...", "...").action(...)
+    // chains BEFORE the final subcommand (the last one omits `.reset()`).
+    // release subcommand (LAST — no trailing .reset()).
+    .reset()
+    .command("release", "Publish a kind-39108 changelog for the current app version")
+    .option("--sec <secret:string>", "Private key (nsec/hex), nbunksec, or bunker:// URL to sign with")
+    .option("--relays <relays:string>", "Comma-separated relay URLs (overrides config)")
+    .option("--pubkey <pubkey:string>", "Public key (hex/npub) to resolve the manifest for")
+    .option("--fix <text:string>", "Bug-fix changelog entry (repeatable)", { collect: true })
+    .option("--add <text:string>", "Added-feature changelog entry (repeatable)", { collect: true })
+    .option("--try <text:string>", "Experimental changelog entry (repeatable)", { collect: true })
+    .option("--cut <text:string>", "Removed-feature changelog entry (repeatable)", { collect: true })
+    .option("--sub <text:string>", "Generic changed/substitute changelog entry (repeatable)", {
+      collect: true,
+    })
+    .action(async (options) => {
+      await nappReleaseAction(
+        options as unknown as {
+          config?: string | boolean;
+          sec?: string;
+          pubkey?: string;
+          relays?: string;
+          createdAt?: number;
+          fix?: string[];
+          add?: string[];
+          try?: string[];
+          cut?: string[];
+          sub?: string[];
+        },
+      );
     });
 
   nsyte.command("napp", napp);

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -11,12 +11,19 @@
  */
 import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
-import { Input } from "@cliffy/prompt";
+import { Input, Select } from "@cliffy/prompt";
 import type { NostrEvent } from "applesauce-core/helpers";
-import { type ProjectConfig, readProjectFile } from "../lib/config.ts";
+import {
+  buildNappConfigFromAnswers,
+  categoryLabel,
+  type ProjectConfig,
+  readProjectFile,
+  writeProjectFile,
+} from "../lib/config.ts";
 import { getErrorMessage } from "../lib/error-utils.ts";
 import { createLogger } from "../lib/logger.ts";
-import { isNapp } from "../lib/napp/detect.ts";
+import { NAPP_CATEGORIES } from "../lib/napp/categories.ts";
+import { isNapp, validateNappConfig } from "../lib/napp/detect.ts";
 import { nappIdentifier, resolveIndexerRelays } from "../lib/napp/identifier.ts";
 import { createReleaseNoteEvent, type ReleaseChanges } from "../lib/napp/release.ts";
 import { getManifestIdentifier } from "../lib/manifest.ts";
@@ -263,6 +270,104 @@ async function nappReleaseAction(
   }
 }
 
+// ---------------------------------------------------------------------------
+// `napp init` — retrofit a napp section onto an existing project config
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect napp listing answers via the SAME prompt sequence as the init wizard, then
+ * shape them with the SINGLE assembly helper. Interactive (not unit-tested); the pure
+ * assembly/validation it feeds is covered by the wizard + init tests.
+ */
+async function collectNappAnswers(): Promise<ReturnType<typeof buildNappConfigFromAnswers>> {
+  const name = await Input.prompt({
+    message: "App name:",
+    validate: (v: string) => v.trim().length > 0 || "Name is required",
+  });
+  const iconHash = await Input.prompt({
+    message: "Icon (sha256 hash or URL):",
+    validate: (v: string) => v.trim().length > 0 || "Icon is required",
+  });
+  const iconMime = await Input.prompt({ message: "Icon MIME type:", default: "image/png" });
+
+  const category = await Select.prompt<string>({
+    message: "Category",
+    options: Object.keys(NAPP_CATEGORIES).map((c) => ({ name: c, value: c })),
+  });
+  const subcategory = await Select.prompt<string>({
+    message: "Subcategory",
+    options: NAPP_CATEGORIES[category].map((s) => ({ name: s, value: s })),
+  });
+  const label = categoryLabel(category, subcategory);
+
+  const countriesInput = await Input.prompt({
+    message: "Countries (comma-separated ISO codes, or * for worldwide):",
+    default: "*",
+  });
+  const countries = countriesInput.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+
+  const summary = await Input.prompt({ message: "Summary (optional):" });
+  const description = await Input.prompt({ message: "Description (optional):" });
+
+  return buildNappConfigFromAnswers({
+    name,
+    iconHash,
+    iconMime,
+    categories: [label],
+    countries: (countries.length === 0 || (countries.length === 1 && countries[0] === "*"))
+      ? ["*"]
+      : countries,
+    summary,
+    description,
+  });
+}
+
+/**
+ * `napp init` action: read the existing project config, refuse to overwrite an existing
+ * napp, collect listing answers, validate, and write `{ ...projectConfig, napp }` back —
+ * the spread preserves all unrelated keys (T-24-01).
+ */
+async function nappInitAction(options: { config?: string | boolean }): Promise<void> {
+  const configPath = typeof options.config === "string" ? options.config : undefined;
+  const projectConfig = readProjectFile(configPath);
+
+  if (!projectConfig) {
+    console.error(
+      colors.red(
+        "No .nsite/config.json found — run `nsyte init` first to create a project, then `nsyte napp init` to retrofit a napp section.",
+      ),
+    );
+    Deno.exit(1);
+  }
+
+  if (isNapp(projectConfig)) {
+    console.log(
+      colors.yellow(
+        "This project is already a napp. Edit the `napp` section in .nsite/config.json directly, or remove it and re-run.",
+      ),
+    );
+    return;
+  }
+
+  const napp = await collectNappAnswers();
+  const errors = validateNappConfig(napp);
+  if (errors.length > 0) {
+    for (const e of errors) {
+      console.error(colors.red(`  ${e.path}: ${e.message}`));
+    }
+    console.error(colors.red("napp section is invalid; not written. Fix the inputs and re-run."));
+    Deno.exit(1);
+  }
+
+  const updated: ProjectConfig = { ...projectConfig, napp };
+  writeProjectFile(updated, configPath);
+  console.log(
+    colors.green(
+      "Added `napp` section to .nsite/config.json. Run `nsyte napp validate` to check readiness.",
+    ),
+  );
+}
+
 /** Register the `napp` command (and its subcommands) on the root program. */
 export function registerNappCommand(): void {
   const napp = new Command()
@@ -311,6 +416,12 @@ export function registerNappCommand(): void {
           sub?: string[];
         },
       );
+    })
+    // init subcommand — interactive retrofit; NO `.option` (honors only global -c/--config).
+    .reset()
+    .command("init", "Retrofit a napp section onto this project's config")
+    .action(async (options) => {
+      await nappInitAction(options as unknown as { config?: string | boolean });
     });
 
   nsyte.command("napp", napp);

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -1,0 +1,103 @@
+/**
+ * `nsyte napp` command — Manage napp (NIP-5B) operations.
+ *
+ * Modeled on `registerBunkerCommand` (src/commands/bunker.ts): a nested Cliffy
+ * `Command` whose parent shows help and whose subcommands are chained with
+ * `.command(...).action(...).reset()` (the LAST subcommand omits `.reset()`).
+ *
+ * Currently exposes a single `id` subcommand that prints the shareable `+` app
+ * identifier for this napp. Future phases append `release`/`init`/`validate` by
+ * inserting more `.reset().command(...).action(...)` chains before the final one.
+ */
+import { colors } from "@cliffy/ansi/colors";
+import { Command } from "@cliffy/command";
+import { type ProjectConfig, readProjectFile } from "../lib/config.ts";
+import { getErrorMessage } from "../lib/error-utils.ts";
+import { createLogger } from "../lib/logger.ts";
+import { isNapp } from "../lib/napp/detect.ts";
+import { nappIdentifier } from "../lib/napp/identifier.ts";
+import { type ResolverOptions, resolvePubkey } from "../lib/resolver-utils.ts";
+import nsyte from "./root.ts";
+
+const log = createLogger("napp");
+
+/**
+ * PURE, signer-free core of `napp id`: build the shareable `+` identifier from a
+ * resolved project config and the author pubkey.
+ *
+ * Throws (with a clear, actionable message) when:
+ *  - the project is not a napp (no/invalid `napp` section), or
+ *  - the project is a ROOT site (empty/missing `config.id`) — root sites have no `d`
+ *    tag and cannot be encoded into a `+` identifier.
+ *
+ * Relay hints are OPTIONAL: the first up to 2 configured relays become type-1 TLV
+ * hints. Decoding tolerates zero relays, so a config with no relays is fine.
+ */
+export function resolveNappIdentifier(config: ProjectConfig, pubkey: string): string {
+  if (!isNapp(config)) {
+    throw new Error(
+      "This project is not a napp — add a `napp` section to .nsite/config.json (see `nsyte napp init`).",
+    );
+  }
+
+  // Read config.id from the original ProjectConfig binding (isNapp narrows to
+  // `{ napp: NappConfig }`, which lacks `id`).
+  const dTag = typeof config.id === "string" ? config.id : "";
+  if (!dTag) {
+    throw new Error(
+      "napp identifiers require a named site — set `id` in .nsite/config.json (root sites have no d tag and cannot be encoded).",
+    );
+  }
+
+  // Optional relay hints: first up to 2 configured relays. Decoding tolerates zero.
+  const relays = (config.relays ?? []).slice(0, 2);
+
+  return nappIdentifier({ dTag, pubkey, relays });
+}
+
+/** `napp id` action: resolve config + author pubkey (no signing) and print the identifier. */
+async function nappIdAction(options: { config?: string | boolean }): Promise<void> {
+  const configPath = typeof options.config === "string" ? options.config : undefined;
+  const projectConfig = readProjectFile(configPath);
+
+  if (!projectConfig) {
+    console.error(colors.red("No .nsite/config.json found."));
+    Deno.exit(1);
+  }
+
+  // Resolve the author pubkey WITHOUT signing (cheapest correct path — same as status.ts).
+  const pubkey = await resolvePubkey(options as ResolverOptions, projectConfig);
+
+  try {
+    const id = resolveNappIdentifier(projectConfig, pubkey);
+    // Keep stdout clean and pipe-friendly: just the +... identifier on its own line.
+    console.log(id);
+  } catch (e) {
+    log.debug(`napp id failed: ${getErrorMessage(e)}`);
+    console.error(colors.red(getErrorMessage(e)));
+    Deno.exit(1);
+  }
+}
+
+/** Register the `napp` command (and its subcommands) on the root program. */
+export function registerNappCommand(): void {
+  const napp = new Command()
+    .description("Manage napp (NIP-5B) operations")
+    .action(async () => {
+      // Show help when no subcommand is provided.
+      await napp.showHelp();
+    })
+    // Future phases append `release`/`init`/`validate` here as
+    //   .reset().command("...", "...").action(...)
+    // chains BEFORE the final subcommand (the last one omits `.reset()`).
+    // id subcommand (LAST/only — no trailing .reset()).
+    // The global `-c/--config` (+ resolver flags) live on the parent program, so the
+    // action's options object carries them at runtime even though this standalone
+    // Command's generics don't surface them — read them via a cast.
+    .command("id", "Print the shareable + app identifier for this napp")
+    .action(async (options) => {
+      await nappIdAction(options as unknown as { config?: string | boolean });
+    });
+
+  nsyte.command("napp", napp);
+}

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -25,25 +25,12 @@ import { getErrorMessage } from "../lib/error-utils.ts";
 import { createLogger } from "../lib/logger.ts";
 import { NAPP_CATEGORIES } from "../lib/napp/categories.ts";
 import { isNapp, validateNappConfig } from "../lib/napp/detect.ts";
-import {
-  nappIdentifier,
-  resolveIndexerRelays,
-} from "../lib/napp/identifier.ts";
-import {
-  createReleaseNoteEvent,
-  type ReleaseChanges,
-} from "../lib/napp/release.ts";
+import { nappIdentifier, resolveIndexerRelays } from "../lib/napp/identifier.ts";
+import { createReleaseNoteEvent, type ReleaseChanges } from "../lib/napp/release.ts";
 import { getManifestIdentifier } from "../lib/manifest.ts";
-import {
-  fetchSiteManifestEvent,
-  publishEventsToRelaysDetailed,
-} from "../lib/nostr.ts";
+import { fetchSiteManifestEvent, publishEventsToRelaysDetailed } from "../lib/nostr.ts";
 import { createSigner } from "../lib/auth/signer-factory.ts";
-import {
-  resolvePubkey,
-  resolveRelays,
-  type ResolverOptions,
-} from "../lib/resolver-utils.ts";
+import { resolvePubkey, resolveRelays, type ResolverOptions } from "../lib/resolver-utils.ts";
 import { getDisplayManager } from "../lib/display-mode.ts";
 import nsyte from "./root.ts";
 
@@ -88,11 +75,13 @@ export function resolveNappIdentifier(
 
 /** `napp id` action: resolve config + author pubkey (no signing) and print the identifier. */
 async function nappIdAction(
-  options: { config?: string | boolean },
+  options: {
+    config?: string | boolean;
+    sec?: string;
+    pubkey?: string;
+  },
 ): Promise<void> {
-  const configPath = typeof options.config === "string"
-    ? options.config
-    : undefined;
+  const configPath = typeof options.config === "string" ? options.config : undefined;
   const projectConfig = readProjectFile(configPath);
 
   if (!projectConfig) {
@@ -188,9 +177,7 @@ async function nappReleaseAction(
     sub?: string[];
   },
 ): Promise<void> {
-  const configPath = typeof options.config === "string"
-    ? options.config
-    : undefined;
+  const configPath = typeof options.config === "string" ? options.config : undefined;
   const projectConfig = readProjectFile(configPath);
   if (!projectConfig) {
     console.error(colors.red("No .nsite/config.json found."));
@@ -351,9 +338,7 @@ async function collectNappAnswers(): Promise<
     message: "Countries (comma-separated ISO codes, or * for worldwide):",
     default: "*",
   });
-  const countries = countriesInput.split(",").map((c) => c.trim()).filter((c) =>
-    c.length > 0
-  );
+  const countries = countriesInput.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
 
   const summary = await Input.prompt({ message: "Summary (optional):" });
   const description = await Input.prompt({
@@ -382,9 +367,7 @@ async function collectNappAnswers(): Promise<
 async function nappInitAction(
   options: { config?: string | boolean },
 ): Promise<void> {
-  const configPath = typeof options.config === "string"
-    ? options.config
-    : undefined;
+  const configPath = typeof options.config === "string" ? options.config : undefined;
   const projectConfig = readProjectFile(configPath);
 
   if (!projectConfig) {
@@ -500,9 +483,7 @@ async function nappValidateAction(
   dir: string | undefined,
   options: { config?: string | boolean },
 ): Promise<void> {
-  const configPath = typeof options.config === "string"
-    ? options.config
-    : undefined;
+  const configPath = typeof options.config === "string" ? options.config : undefined;
   const projectConfig = readProjectFile(configPath);
 
   if (!projectConfig) {
@@ -545,10 +526,13 @@ async function nappValidateAction(
   }
 
   // Informational identifier (best-effort; root sites have none).
+  // interactive=false: validate must never prompt for key setup — if no pubkey can be
+  // resolved non-interactively, silently skip the identifier line.
   try {
     const pubkey = await resolvePubkey(
       options as ResolverOptions,
       projectConfig,
+      false,
     );
     const id = resolveNappIdentifier(projectConfig, pubkey);
     console.log(colors.gray(`App identifier: ${id}`));
@@ -571,10 +555,27 @@ export function registerNappCommand(): void {
     // The global `-c/--config` (+ `--created-at`) live on the parent program, so the
     // action's options object carries them at runtime even though this standalone
     // Command's generics don't surface them — read them via a cast. `--sec/--relays/
-    // --pubkey` are NOT globals, so the `release` subcommand declares its own below.
+    // --pubkey` are NOT globals, so each subcommand that needs them declares its own.
+    // `id` is read-only (no signing): `--pubkey` lets a user print the identifier without
+    // a configured signer; `--sec` derives the pubkey from a key without storing it.
+    // (Relay hints come from config.relays inside resolveNappIdentifier.)
     .command("id", "Print the shareable + app identifier for this napp")
+    .option(
+      "--sec <secret:string>",
+      "Private key (nsec/hex), nbunksec, or bunker:// URL to derive the pubkey from",
+    )
+    .option(
+      "--pubkey <pubkey:string>",
+      "Public key (hex/npub) to encode into the identifier",
+    )
     .action(async (options) => {
-      await nappIdAction(options as unknown as { config?: string | boolean });
+      await nappIdAction(
+        options as unknown as {
+          config?: string | boolean;
+          sec?: string;
+          pubkey?: string;
+        },
+      );
     })
     // Future phases append `init`/`validate` here as
     //   .reset().command("...", "...").action(...)

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -15,15 +15,24 @@ import { Input, Select } from "@cliffy/prompt";
 import { walk } from "@std/fs";
 import type { NostrEvent } from "applesauce-core/helpers";
 import {
-  buildNappConfigFromAnswers,
-  categoryLabel,
+  collectNappListing,
+  type NappAssetResolver,
+  type NappListingPrefill,
   type ProjectConfig,
   readProjectFile,
   writeProjectFile,
 } from "../lib/config.ts";
 import { getErrorMessage } from "../lib/error-utils.ts";
 import { createLogger } from "../lib/logger.ts";
-import { NAPP_CATEGORIES } from "../lib/napp/categories.ts";
+import {
+  classifyAssetInput,
+  deriveAssetMime,
+  isRootSite,
+  parseCategoriesInput,
+  parseCountriesInput,
+  rootSiteMigrationNotice,
+  uploadNappAsset,
+} from "../lib/napp/assets.ts";
 import { isNapp, validateNappConfig } from "../lib/napp/detect.ts";
 import { nappIdentifier, resolveIndexerRelays } from "../lib/napp/identifier.ts";
 import { createReleaseNoteEvent, type ReleaseChanges } from "../lib/napp/release.ts";
@@ -303,69 +312,112 @@ async function nappReleaseAction(
 // `napp init` — retrofit a napp section onto an existing project config
 // ---------------------------------------------------------------------------
 
+/** Raw `napp init` flags as they arrive from Cliffy (repeatables are `collect:true`). */
+export interface NappInitFlags {
+  name?: string;
+  icon?: string;
+  iconMime?: string;
+  category?: string[];
+  countries?: string;
+  summary?: string;
+  description?: string;
+  keyart?: string;
+  screenshot?: string[];
+  self?: string;
+  tag?: string[];
+  indexerRelay?: string[];
+  id?: string;
+  yes?: boolean;
+}
+
+/** The result of parsing `napp init` flags into a listing prefill + control bits. */
+export interface NappInitPlan {
+  prefill: NappListingPrefill;
+  id?: string;
+  yes: boolean;
+  missingRequired: string[];
+}
+
 /**
- * Collect napp listing answers via the SAME prompt sequence as the init wizard, then
- * shape them with the SINGLE assembly helper. Interactive (not unit-tested); the pure
- * assembly/validation it feeds is covered by the wizard + init tests.
+ * PURE: parse `napp init` flags into a {@link NappListingPrefill} + control bits. Asset
+ * fields stay as raw input strings (the resolver turns them into NappAssets later).
+ * `missingRequired` is the subset of `name`/`icon`/`category` that flags did not supply.
+ * No prompting, no IO.
  */
-async function collectNappAnswers(): Promise<
-  ReturnType<typeof buildNappConfigFromAnswers>
-> {
-  const name = await Input.prompt({
-    message: "App name:",
-    validate: (v: string) => v.trim().length > 0 || "Name is required",
-  });
-  const iconHash = await Input.prompt({
-    message: "Icon (sha256 hash or URL):",
-    validate: (v: string) => v.trim().length > 0 || "Icon is required",
-  });
-  const iconMime = await Input.prompt({
-    message: "Icon MIME type:",
-    default: "image/png",
-  });
+export function planNappInitFromFlags(flags: NappInitFlags): NappInitPlan {
+  const categories = flags.category && flags.category.length > 0
+    ? parseCategoriesInput(flags.category)
+    : undefined;
+  const countries = flags.countries !== undefined
+    ? parseCountriesInput(flags.countries)
+    : undefined;
 
-  const category = await Select.prompt<string>({
-    message: "Category",
-    options: Object.keys(NAPP_CATEGORIES).map((c) => ({ name: c, value: c })),
-  });
-  const subcategory = await Select.prompt<string>({
-    message: "Subcategory",
-    options: NAPP_CATEGORIES[category].map((s) => ({ name: s, value: s })),
-  });
-  const label = categoryLabel(category, subcategory);
+  const prefill: NappListingPrefill = {};
+  if (flags.name !== undefined) prefill.name = flags.name;
+  if (flags.icon !== undefined) prefill.icon = flags.icon;
+  if (flags.iconMime !== undefined) prefill.iconMime = flags.iconMime;
+  if (categories !== undefined) prefill.categories = categories;
+  if (countries !== undefined) prefill.countries = countries;
+  if (flags.summary !== undefined) prefill.summary = flags.summary;
+  if (flags.description !== undefined) prefill.description = flags.description;
+  if (flags.self !== undefined) prefill.self = flags.self;
+  if (flags.keyart !== undefined) prefill.keyart = flags.keyart;
+  if (flags.screenshot !== undefined) prefill.screenshots = flags.screenshot;
+  if (flags.tag !== undefined) prefill.tags = flags.tag;
+  if (flags.indexerRelay !== undefined) prefill.indexerRelays = flags.indexerRelay;
 
-  const countriesInput = await Input.prompt({
-    message: "Countries (comma-separated ISO codes, or * for worldwide):",
-    default: "*",
-  });
-  const countries = countriesInput.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+  const missingRequired: string[] = [];
+  if (!flags.name || !flags.name.trim()) missingRequired.push("name");
+  if (!flags.icon || !flags.icon.trim()) missingRequired.push("icon");
+  if (!categories || categories.length === 0) missingRequired.push("category");
 
-  const summary = await Input.prompt({ message: "Summary (optional):" });
-  const description = await Input.prompt({
-    message: "Description (optional):",
-  });
+  return { prefill, id: flags.id, yes: flags.yes === true, missingRequired };
+}
 
-  return buildNappConfigFromAnswers({
-    name,
-    iconHash,
-    iconMime,
-    categories: [label],
-    countries: (countries.length === 0 ||
-        (countries.length === 1 && countries[0] === "*"))
-      ? ["*"]
-      : countries,
-    summary,
-    description,
-  });
+/** Inputs to the pure root-site id decision. */
+export interface RootSiteIdInput {
+  isRoot: boolean;
+  idFlag?: string;
+  interactive: boolean;
+  confirmed?: boolean;
+  confirmedValue?: string;
+}
+
+/** Output of the pure root-site id decision. */
+export interface RootSiteIdDecision {
+  setId?: string;
+  printNotice: boolean;
+}
+
+/**
+ * PURE: decide whether to set an id on a root site, never auto-migrating. An id is set
+ * ONLY when `--id` is passed OR (interactive) the user explicitly confirmed and supplied
+ * a value. With neither, the napp section is still written without an id. Non-root sites
+ * get no notice and no id change.
+ */
+export function decideRootSiteId(input: RootSiteIdInput): RootSiteIdDecision {
+  if (!input.isRoot) return { printNotice: false };
+  if (input.idFlag && input.idFlag.trim()) {
+    return { setId: input.idFlag.trim(), printNotice: true };
+  }
+  if (
+    input.interactive && input.confirmed &&
+    input.confirmedValue && input.confirmedValue.trim()
+  ) {
+    return { setId: input.confirmedValue.trim(), printNotice: true };
+  }
+  return { printNotice: true };
 }
 
 /**
  * `napp init` action: read the existing project config, refuse to overwrite an existing
- * napp, collect listing answers, validate, and write `{ ...projectConfig, napp }` back —
- * the spread preserves all unrelated keys (T-24-01).
+ * napp, parse flags, apply root-site guidance, collect listing answers (prompting only for
+ * what flags didn't supply, or erroring non-interactively when required fields are missing),
+ * validate, and write `{ ...projectConfig, napp }` back — the spread preserves all
+ * unrelated keys (T-24-01).
  */
 async function nappInitAction(
-  options: { config?: string | boolean },
+  options: NappInitFlags & { config?: string | boolean; sec?: string },
 ): Promise<void> {
   const configPath = typeof options.config === "string" ? options.config : undefined;
   const projectConfig = readProjectFile(configPath);
@@ -388,7 +440,112 @@ async function nappInitAction(
     return;
   }
 
-  const napp = await collectNappAnswers();
+  const plan = planNappInitFromFlags(options);
+  const interactive = getDisplayManager().isInteractive() && !plan.yes;
+
+  // Root-site guidance: warn + opt-in id (never auto-migrate). With --id, set it directly.
+  // Interactive without --id: print the notice and offer to set an id. Non-interactive
+  // without --id: print the notice and leave id unset.
+  if (isRootSite(projectConfig)) {
+    const flagDecision = decideRootSiteId({
+      isRoot: true,
+      idFlag: plan.id,
+      interactive,
+    });
+    if (flagDecision.printNotice) {
+      console.log(colors.yellow(rootSiteMigrationNotice()));
+    }
+    if (flagDecision.setId !== undefined) {
+      projectConfig.id = flagDecision.setId;
+    } else if (interactive) {
+      const setIdNow = await Select.prompt<string>({
+        message: "Set a site identifier now? (required for `nsyte napp id`)",
+        options: [
+          { name: "No — leave as a root site for now", value: "no" },
+          { name: "Yes — set a named site identifier", value: "yes" },
+        ],
+        default: "no",
+      });
+      let confirmedValue: string | undefined;
+      if (setIdNow === "yes") {
+        confirmedValue = (await Input.prompt({
+          message: "Enter site identifier (lowercase, max 13 chars):",
+          validate: (v: string) => v.trim().length > 0 || "Identifier is required",
+        })).trim();
+      }
+      const decision = decideRootSiteId({
+        isRoot: true,
+        interactive: true,
+        confirmed: setIdNow === "yes",
+        confirmedValue,
+      });
+      if (decision.setId !== undefined) {
+        projectConfig.id = decision.setId;
+      } else {
+        console.log(
+          colors.yellow(
+            "Leaving this as a root site — `nsyte napp id` will not work until you set an id.",
+          ),
+        );
+      }
+    } else {
+      console.log(
+        colors.yellow(
+          "Leaving this as a root site — `nsyte napp id` will not work until you set an id.",
+        ),
+      );
+    }
+  }
+
+  // Non-interactive with missing required fields: error clearly and exit non-zero (never hang).
+  if (!interactive && plan.missingRequired.length > 0) {
+    console.error(
+      colors.red(
+        `Missing required napp fields: ${
+          plan.missingRequired.join(", ")
+        }. Provide --name, --icon, and at least one --category (or run interactively).`,
+      ),
+    );
+    Deno.exit(1);
+  }
+
+  // Asset resolver: hash/URL pass through; a local path is uploaded via a lazily-created
+  // signer + the configured servers/relays. Hash/URL inputs never construct a signer.
+  let cachedSigner: import("applesauce-signers").ISigner | undefined;
+  const resolveAsset: NappAssetResolver = async (value: string) => {
+    if (classifyAssetInput(value) !== "path") {
+      return { hash: value, mime: deriveAssetMime(value) };
+    }
+    if (!projectConfig.servers || projectConfig.servers.length === 0) {
+      throw new Error(
+        `Cannot upload "${value}": configure blossom servers (or paste a sha256 hash / URL).`,
+      );
+    }
+    if (!cachedSigner) {
+      const signerResult = await createSigner({
+        sec: options.sec,
+        bunkerPubkey: projectConfig.bunkerPubkey,
+      });
+      if ("error" in signerResult) {
+        throw new Error(
+          `Cannot upload "${value}": ${signerResult.error} (pass --sec, or paste a sha256 hash / URL).`,
+        );
+      }
+      cachedSigner = signerResult.signer;
+    }
+    return await uploadNappAsset(value, {
+      servers: projectConfig.servers,
+      relays: projectConfig.relays,
+      signer: cachedSigner,
+    });
+  };
+
+  const napp = await collectNappListing({
+    prefill: plan.prefill,
+    interactive,
+    resolveAsset,
+  });
+
   const errors = validateNappConfig(napp);
   if (errors.length > 0) {
     for (const e of errors) {
@@ -639,11 +796,67 @@ export function registerNappCommand(): void {
         },
       );
     })
-    // init subcommand — interactive retrofit; NO `.option` (honors only global -c/--config).
+    // init subcommand — scriptable retrofit. Flags fully specify the listing (skip
+    // prompts) or partially specify it (prompt for the rest, or error non-interactively).
     .reset()
     .command("init", "Retrofit a napp section onto this project's config")
+    .option("--name <name:string>", "App display name")
+    .option(
+      "--icon <icon:string>",
+      "App icon: sha256 hash, URL, or local file path (local files are uploaded)",
+    )
+    .option(
+      "--icon-mime <mime:string>",
+      "Icon MIME type (used for hash/URL icon inputs; default image/png)",
+    )
+    .option(
+      "--category <label:string>",
+      "Category label napp.<cat>:<sub> (repeatable, max 3)",
+      { collect: true },
+    )
+    .option(
+      "--countries <csv:string>",
+      "Comma-separated ISO 3166-1 alpha-2 codes, or * for worldwide",
+    )
+    .option("--summary <text:string>", "Short summary")
+    .option("--description <text:string>", "Long description")
+    .option(
+      "--keyart <keyart:string>",
+      "Key art: sha256 hash, URL, or local file path",
+    )
+    .option(
+      "--screenshot <shot:string>",
+      "Screenshot: sha256 hash, URL, or local file path (repeatable)",
+      { collect: true },
+    )
+    .option("--self <pubkey:string>", "Author pubkey (64-hex)")
+    .option("--tag <tag:string>", "Free-form tag (repeatable)", {
+      collect: true,
+    })
+    .option(
+      "--indexer-relay <relay:string>",
+      "Indexer relay URL the listing is also published to (repeatable)",
+      { collect: true },
+    )
+    .option(
+      "--id <id:string>",
+      "Set a named-site identifier (opt-in root-site migration; never automatic)",
+    )
+    .option(
+      "--sec <secret:string>",
+      "Private key (nsec/hex), nbunksec, or bunker:// URL to sign asset uploads with",
+    )
+    .option(
+      "--yes",
+      "Non-interactive: never prompt; error if required fields are missing",
+    )
     .action(async (options) => {
-      await nappInitAction(options as unknown as { config?: string | boolean });
+      await nappInitAction(
+        options as unknown as NappInitFlags & {
+          config?: string | boolean;
+          sec?: string;
+        },
+      );
     })
     // validate subcommand (LAST — no trailing .reset()). Positional [dir] only, NO `.option`.
     .reset()

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -25,12 +25,25 @@ import { getErrorMessage } from "../lib/error-utils.ts";
 import { createLogger } from "../lib/logger.ts";
 import { NAPP_CATEGORIES } from "../lib/napp/categories.ts";
 import { isNapp, validateNappConfig } from "../lib/napp/detect.ts";
-import { nappIdentifier, resolveIndexerRelays } from "../lib/napp/identifier.ts";
-import { createReleaseNoteEvent, type ReleaseChanges } from "../lib/napp/release.ts";
+import {
+  nappIdentifier,
+  resolveIndexerRelays,
+} from "../lib/napp/identifier.ts";
+import {
+  createReleaseNoteEvent,
+  type ReleaseChanges,
+} from "../lib/napp/release.ts";
 import { getManifestIdentifier } from "../lib/manifest.ts";
-import { fetchSiteManifestEvent, publishEventsToRelaysDetailed } from "../lib/nostr.ts";
+import {
+  fetchSiteManifestEvent,
+  publishEventsToRelaysDetailed,
+} from "../lib/nostr.ts";
 import { createSigner } from "../lib/auth/signer-factory.ts";
-import { type ResolverOptions, resolvePubkey, resolveRelays } from "../lib/resolver-utils.ts";
+import {
+  resolvePubkey,
+  resolveRelays,
+  type ResolverOptions,
+} from "../lib/resolver-utils.ts";
 import { getDisplayManager } from "../lib/display-mode.ts";
 import nsyte from "./root.ts";
 
@@ -48,7 +61,10 @@ const log = createLogger("napp");
  * Relay hints are OPTIONAL: the first up to 2 configured relays become type-1 TLV
  * hints. Decoding tolerates zero relays, so a config with no relays is fine.
  */
-export function resolveNappIdentifier(config: ProjectConfig, pubkey: string): string {
+export function resolveNappIdentifier(
+  config: ProjectConfig,
+  pubkey: string,
+): string {
   if (!isNapp(config)) {
     throw new Error(
       "This project is not a napp — add a `napp` section to .nsite/config.json (see `nsyte napp init`).",
@@ -71,8 +87,12 @@ export function resolveNappIdentifier(config: ProjectConfig, pubkey: string): st
 }
 
 /** `napp id` action: resolve config + author pubkey (no signing) and print the identifier. */
-async function nappIdAction(options: { config?: string | boolean }): Promise<void> {
-  const configPath = typeof options.config === "string" ? options.config : undefined;
+async function nappIdAction(
+  options: { config?: string | boolean },
+): Promise<void> {
+  const configPath = typeof options.config === "string"
+    ? options.config
+    : undefined;
   const projectConfig = readProjectFile(configPath);
 
   if (!projectConfig) {
@@ -111,7 +131,9 @@ interface ReleaseFlags {
  * Build a {@link ReleaseChanges} object from the repeatable changelog flags, including a
  * category ONLY when its array is present and non-empty. Entries are kept as-is.
  */
-export function buildReleaseChangesFromFlags(flags: ReleaseFlags): ReleaseChanges {
+export function buildReleaseChangesFromFlags(
+  flags: ReleaseFlags,
+): ReleaseChanges {
   const changes: ReleaseChanges = {};
   const categories = ["fix", "add", "try", "cut", "sub"] as const;
   for (const category of categories) {
@@ -166,7 +188,9 @@ async function nappReleaseAction(
     sub?: string[];
   },
 ): Promise<void> {
-  const configPath = typeof options.config === "string" ? options.config : undefined;
+  const configPath = typeof options.config === "string"
+    ? options.config
+    : undefined;
   const projectConfig = readProjectFile(configPath);
   if (!projectConfig) {
     console.error(colors.red("No .nsite/config.json found."));
@@ -185,7 +209,10 @@ async function nappReleaseAction(
 
   // Resolve author pubkey (for the manifest FETCH) and write relays.
   const pubkey = await resolvePubkey(options as ResolverOptions, projectConfig);
-  const resolvedRelays = resolveRelays(options as ResolverOptions, projectConfig);
+  const resolvedRelays = resolveRelays(
+    options as ResolverOptions,
+    projectConfig,
+  );
 
   // Build the signer via the same factory deploy uses (sec > stored bunkerPubkey).
   const signerResult = await createSigner({
@@ -203,7 +230,11 @@ async function nappReleaseAction(
   const identifier = typeof projectConfig.id === "string" && projectConfig.id
     ? projectConfig.id
     : undefined;
-  const manifest = await fetchSiteManifestEvent(resolvedRelays, pubkey, identifier);
+  const manifest = await fetchSiteManifestEvent(
+    resolvedRelays,
+    pubkey,
+    identifier,
+  );
   if (!manifest) {
     console.error(
       colors.red(
@@ -222,7 +253,9 @@ async function nappReleaseAction(
       // fix/add/try/cut. Loop until the author submits a blank line.
       const collected: string[] = [];
       while (true) {
-        const entry = await Input.prompt({ message: "Changelog entry (blank to finish):" });
+        const entry = await Input.prompt({
+          message: "Changelog entry (blank to finish):",
+        });
         if (!entry || entry.trim().length === 0) break;
         collected.push(entry.trim());
       }
@@ -249,9 +282,13 @@ async function nappReleaseAction(
 
   // Publish to the deduped UNION of write relays and indexer relays (mirror deploy).
   const indexerRelays = resolveIndexerRelays(projectConfig);
-  const publishRelays = Array.from(new Set([...resolvedRelays, ...indexerRelays]));
+  const publishRelays = Array.from(
+    new Set([...resolvedRelays, ...indexerRelays]),
+  );
   console.log(colors.gray(`Indexer relays: ${indexerRelays.join(", ")}`));
-  const result = await publishEventsToRelaysDetailed(publishRelays, [releaseEvent]);
+  const result = await publishEventsToRelaysDetailed(publishRelays, [
+    releaseEvent,
+  ]);
 
   const eventResult = result.eventResults[0];
   const relayResults = eventResult?.relayResults ?? [];
@@ -259,12 +296,16 @@ async function nappReleaseAction(
     if (r.ok) {
       console.log(colors.green(`  ✓ ${r.relay}`));
     } else {
-      console.log(colors.red(`  ✗ ${r.relay}${r.message ? ` (${r.message})` : ""}`));
+      console.log(
+        colors.red(`  ✗ ${r.relay}${r.message ? ` (${r.message})` : ""}`),
+      );
     }
   }
 
   if (result.allEventsPublished) {
-    console.log(colors.green(`Release note published (kind 39108): ${releaseEvent.id}`));
+    console.log(
+      colors.green(`Release note published (kind 39108): ${releaseEvent.id}`),
+    );
   } else {
     console.error(colors.red("Failed to publish release note to all relays."));
     Deno.exit(1);
@@ -280,7 +321,9 @@ async function nappReleaseAction(
  * shape them with the SINGLE assembly helper. Interactive (not unit-tested); the pure
  * assembly/validation it feeds is covered by the wizard + init tests.
  */
-async function collectNappAnswers(): Promise<ReturnType<typeof buildNappConfigFromAnswers>> {
+async function collectNappAnswers(): Promise<
+  ReturnType<typeof buildNappConfigFromAnswers>
+> {
   const name = await Input.prompt({
     message: "App name:",
     validate: (v: string) => v.trim().length > 0 || "Name is required",
@@ -289,7 +332,10 @@ async function collectNappAnswers(): Promise<ReturnType<typeof buildNappConfigFr
     message: "Icon (sha256 hash or URL):",
     validate: (v: string) => v.trim().length > 0 || "Icon is required",
   });
-  const iconMime = await Input.prompt({ message: "Icon MIME type:", default: "image/png" });
+  const iconMime = await Input.prompt({
+    message: "Icon MIME type:",
+    default: "image/png",
+  });
 
   const category = await Select.prompt<string>({
     message: "Category",
@@ -305,17 +351,22 @@ async function collectNappAnswers(): Promise<ReturnType<typeof buildNappConfigFr
     message: "Countries (comma-separated ISO codes, or * for worldwide):",
     default: "*",
   });
-  const countries = countriesInput.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+  const countries = countriesInput.split(",").map((c) => c.trim()).filter((c) =>
+    c.length > 0
+  );
 
   const summary = await Input.prompt({ message: "Summary (optional):" });
-  const description = await Input.prompt({ message: "Description (optional):" });
+  const description = await Input.prompt({
+    message: "Description (optional):",
+  });
 
   return buildNappConfigFromAnswers({
     name,
     iconHash,
     iconMime,
     categories: [label],
-    countries: (countries.length === 0 || (countries.length === 1 && countries[0] === "*"))
+    countries: (countries.length === 0 ||
+        (countries.length === 1 && countries[0] === "*"))
       ? ["*"]
       : countries,
     summary,
@@ -328,8 +379,12 @@ async function collectNappAnswers(): Promise<ReturnType<typeof buildNappConfigFr
  * napp, collect listing answers, validate, and write `{ ...projectConfig, napp }` back —
  * the spread preserves all unrelated keys (T-24-01).
  */
-async function nappInitAction(options: { config?: string | boolean }): Promise<void> {
-  const configPath = typeof options.config === "string" ? options.config : undefined;
+async function nappInitAction(
+  options: { config?: string | boolean },
+): Promise<void> {
+  const configPath = typeof options.config === "string"
+    ? options.config
+    : undefined;
   const projectConfig = readProjectFile(configPath);
 
   if (!projectConfig) {
@@ -356,7 +411,11 @@ async function nappInitAction(options: { config?: string | boolean }): Promise<v
     for (const e of errors) {
       console.error(colors.red(`  ${e.path}: ${e.message}`));
     }
-    console.error(colors.red("napp section is invalid; not written. Fix the inputs and re-run."));
+    console.error(
+      colors.red(
+        "napp section is invalid; not written. Fix the inputs and re-run.",
+      ),
+    );
     Deno.exit(1);
   }
 
@@ -374,7 +433,12 @@ async function nappInitAction(options: { config?: string | boolean }): Promise<v
 // ---------------------------------------------------------------------------
 
 /** Evidence tokens (lowercased) that indicate NIP-07 (`window.nostr`) support. */
-const NIP07_TOKENS = ["window.nostr", "nostr-login", "nip07", "getpublickey"] as const;
+const NIP07_TOKENS = [
+  "window.nostr",
+  "nostr-login",
+  "nip07",
+  "getpublickey",
+] as const;
 
 /** True iff `text` contains any NIP-07 evidence token (case-insensitive). */
 export function detectNip07InText(text: string): boolean {
@@ -436,7 +500,9 @@ async function nappValidateAction(
   dir: string | undefined,
   options: { config?: string | boolean },
 ): Promise<void> {
-  const configPath = typeof options.config === "string" ? options.config : undefined;
+  const configPath = typeof options.config === "string"
+    ? options.config
+    : undefined;
   const projectConfig = readProjectFile(configPath);
 
   if (!projectConfig) {
@@ -480,7 +546,10 @@ async function nappValidateAction(
 
   // Informational identifier (best-effort; root sites have none).
   try {
-    const pubkey = await resolvePubkey(options as ResolverOptions, projectConfig);
+    const pubkey = await resolvePubkey(
+      options as ResolverOptions,
+      projectConfig,
+    );
     const id = resolveNappIdentifier(projectConfig, pubkey);
     console.log(colors.gray(`App identifier: ${id}`));
   } catch {
@@ -512,17 +581,47 @@ export function registerNappCommand(): void {
     // chains BEFORE the final subcommand (the last one omits `.reset()`).
     // release subcommand (LAST — no trailing .reset()).
     .reset()
-    .command("release", "Publish a kind-39108 changelog for the current app version")
-    .option("--sec <secret:string>", "Private key (nsec/hex), nbunksec, or bunker:// URL to sign with")
-    .option("--relays <relays:string>", "Comma-separated relay URLs (overrides config)")
-    .option("--pubkey <pubkey:string>", "Public key (hex/npub) to resolve the manifest for")
-    .option("--fix <text:string>", "Bug-fix changelog entry (repeatable)", { collect: true })
-    .option("--add <text:string>", "Added-feature changelog entry (repeatable)", { collect: true })
-    .option("--try <text:string>", "Experimental changelog entry (repeatable)", { collect: true })
-    .option("--cut <text:string>", "Removed-feature changelog entry (repeatable)", { collect: true })
-    .option("--sub <text:string>", "Generic changed/substitute changelog entry (repeatable)", {
+    .command(
+      "release",
+      "Publish a kind-39108 changelog for the current app version",
+    )
+    .option(
+      "--sec <secret:string>",
+      "Private key (nsec/hex), nbunksec, or bunker:// URL to sign with",
+    )
+    .option(
+      "--relays <relays:string>",
+      "Comma-separated relay URLs (overrides config)",
+    )
+    .option(
+      "--pubkey <pubkey:string>",
+      "Public key (hex/npub) to resolve the manifest for",
+    )
+    .option("--fix <text:string>", "Bug-fix changelog entry (repeatable)", {
       collect: true,
     })
+    .option(
+      "--add <text:string>",
+      "Added-feature changelog entry (repeatable)",
+      { collect: true },
+    )
+    .option(
+      "--try <text:string>",
+      "Experimental changelog entry (repeatable)",
+      { collect: true },
+    )
+    .option(
+      "--cut <text:string>",
+      "Removed-feature changelog entry (repeatable)",
+      { collect: true },
+    )
+    .option(
+      "--sub <text:string>",
+      "Generic changed/substitute changelog entry (repeatable)",
+      {
+        collect: true,
+      },
+    )
     .action(async (options) => {
       await nappReleaseAction(
         options as unknown as {
@@ -547,10 +646,16 @@ export function registerNappCommand(): void {
     })
     // validate subcommand (LAST — no trailing .reset()). Positional [dir] only, NO `.option`.
     .reset()
-    .command("validate", "Check napp readiness: required fields, categories, and a NIP-07 heuristic")
+    .command(
+      "validate",
+      "Check napp readiness: required fields, categories, and a NIP-07 heuristic",
+    )
     .arguments("[dir:string]")
     .action(async (options, dir) => {
-      await nappValidateAction(dir, options as unknown as { config?: string | boolean });
+      await nappValidateAction(
+        dir,
+        options as unknown as { config?: string | boolean },
+      );
     });
 
   nsyte.command("napp", napp);

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -5,9 +5,10 @@
  * `Command` whose parent shows help and whose subcommands are chained with
  * `.command(...).action(...).reset()` (the LAST subcommand omits `.reset()`).
  *
- * Currently exposes a single `id` subcommand that prints the shareable `+` app
- * identifier for this napp. Future phases append `release`/`init`/`validate` by
- * inserting more `.reset().command(...).action(...)` chains before the final one.
+ * Exposes the subcommands `id` (print the shareable `+` app identifier),
+ * `release` (publish a kind-39108 changelog), `init` (retrofit/convert a project to a
+ * napp), and `validate` (check napp readiness). They are chained in that order;
+ * `validate` is the final subcommand (the only one without a trailing `.reset()`).
  */
 import { colors } from "@cliffy/ansi/colors";
 import { Command } from "@cliffy/command";
@@ -734,10 +735,7 @@ export function registerNappCommand(): void {
         },
       );
     })
-    // Future phases append `init`/`validate` here as
-    //   .reset().command("...", "...").action(...)
-    // chains BEFORE the final subcommand (the last one omits `.reset()`).
-    // release subcommand (LAST — no trailing .reset()).
+    // release subcommand — `.reset()` first so `init`/`validate` can be chained after it.
     .reset()
     .command(
       "release",

--- a/src/lib/config-validator.ts
+++ b/src/lib/config-validator.ts
@@ -93,7 +93,10 @@ export function validateConfig(config: unknown): ValidationResult {
     }
 
     // Custom validation: profile object required when publishProfile is enabled
-    if (cfg.publishProfile && (!cfg.profile || Object.keys(cfg.profile).length === 0)) {
+    if (
+      cfg.publishProfile &&
+      (!cfg.profile || Object.keys(cfg.profile).length === 0)
+    ) {
       errors.push({
         path: "/profile",
         message:
@@ -168,19 +171,27 @@ export function suggestConfigFixes(errors: ValidationError[]): string[] {
       if (field === "relays") {
         suggestions.push("Add at least one relay URL to the 'relays' array");
       } else if (field === "servers") {
-        suggestions.push("Add at least one Blossom server URL to the 'servers' array");
+        suggestions.push(
+          "Add at least one Blossom server URL to the 'servers' array",
+        );
       }
     }
 
     // Platform enum values
-    if (error.path.includes("/platforms/") && error.message.includes("must be equal to one of")) {
-      suggestions.push("Valid platforms are: web, linux, windows, macos, android, ios");
+    if (
+      error.path.includes("/platforms/") &&
+      error.message.includes("must be equal to one of")
+    ) {
+      suggestions.push(
+        "Valid platforms are: web, linux, windows, macos, android, ios",
+      );
     }
 
     // Event kinds range
     if (
       error.path.includes("/kinds/") &&
-      (error.message.includes("must be <=") || error.message.includes("must be >="))
+      (error.message.includes("must be <=") ||
+        error.message.includes("must be >="))
     ) {
       suggestions.push("Event kinds must be between 0 and 65535");
     }

--- a/src/lib/config-validator.ts
+++ b/src/lib/config-validator.ts
@@ -1,6 +1,7 @@
 import Ajv from "ajv";
 import addFormats from "ajv-formats";
 import configSchema from "../schemas/config.schema.json" with { type: "json" };
+import { validateNappConfig } from "./napp/detect.ts";
 const AjvConstructor = Ajv as unknown as typeof Ajv.default;
 const addFormatsFunction = addFormats as unknown as typeof addFormats.default;
 
@@ -58,6 +59,7 @@ export function validateConfig(config: unknown): ValidationResult {
       publishServerList?: boolean;
       appHandler?: { id?: string };
       profile?: Record<string, unknown>;
+      napp?: unknown;
     };
     const isRootSite = cfg.id === null || cfg.id === "" || cfg.id === undefined;
     const hasAppHandler = cfg.appHandler && cfg.publishAppHandler === true;
@@ -97,6 +99,13 @@ export function validateConfig(config: unknown): ValidationResult {
         message:
           "is required when 'publishProfile' is true. Add a 'profile' object with at least one field (name, about, picture, etc.).",
       });
+    }
+
+    // Custom validation: napp structural validation (deep NIP-5B table + countries rule).
+    // Runs ONLY when a napp section is present, so the non-napp path is byte-for-byte
+    // unchanged (zero-regression foundation for the hybrid napp model).
+    if (cfg.napp !== undefined) {
+      errors.push(...validateNappConfig(cfg.napp));
     }
   }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,7 +3,10 @@ import { Input, Secret, Select } from "@cliffy/prompt";
 import { ensureDirSync } from "@std/fs/ensure-dir";
 import { dirname, isAbsolute, join, resolve } from "@std/path";
 import { NostrConnectSigner } from "applesauce-signers";
-import { formatValidationErrors, validateConfigWithFeedback } from "./config-validator.ts";
+import {
+  formatValidationErrors,
+  validateConfigWithFeedback,
+} from "./config-validator.ts";
 import { createLogger } from "./logger.ts";
 import { suggestIdentifier, validateDTag } from "./nip5a.ts";
 import { getNbunkString, initiateNostrConnect } from "./nip46.ts";
@@ -110,7 +113,9 @@ export const defaultConfig: ProjectConfig = {
 function resolveConfigPath(customPath?: string): string {
   if (customPath) {
     // If custom path is provided, resolve it relative to CWD
-    return isAbsolute(customPath) ? customPath : resolve(Deno.cwd(), customPath);
+    return isAbsolute(customPath)
+      ? customPath
+      : resolve(Deno.cwd(), customPath);
   }
   // Default: .nsite/config.json in CWD
   return join(Deno.cwd(), configDir, projectFile);
@@ -137,7 +142,8 @@ function sanitizeBunkerUrl(url: string): string {
 
     // Append relay parameters
     const relays = parsedUrl.searchParams.getAll("relay");
-    const relayParams = relays.map((r) => `relay=${encodeURIComponent(r)}`).join("&");
+    const relayParams = relays.map((r) => `relay=${encodeURIComponent(r)}`)
+      .join("&");
 
     return relayParams ? `${sanitized}?${relayParams}` : sanitized;
   } catch (error) {
@@ -151,7 +157,10 @@ function sanitizeBunkerUrl(url: string): string {
  * @param config - The project configuration to write
  * @param configPath - Optional custom path to config file
  */
-export function writeProjectFile(config: ProjectConfig, configPath?: string): void {
+export function writeProjectFile(
+  config: ProjectConfig,
+  configPath?: string,
+): void {
   const cwd = Deno.cwd();
 
   // Prevent tests from ever writing to the real project config.
@@ -164,7 +173,8 @@ export function writeProjectFile(config: ProjectConfig, configPath?: string): vo
     hasDenoTestingEnv = false;
   }
   const isTestEnv = hasDenoTestingEnv ||
-    cwd.includes("nsyte-test-") || cwd.includes("/tmp/") || cwd.includes("/var/folders/");
+    cwd.includes("nsyte-test-") || cwd.includes("/tmp/") ||
+    cwd.includes("/var/folders/");
 
   if (isTestEnv && !configPath) {
     return;
@@ -172,7 +182,9 @@ export function writeProjectFile(config: ProjectConfig, configPath?: string): vo
 
   // If a configPath is provided but resolves to the real project .nsite dir, block in tests
   if (isTestEnv && configPath) {
-    const resolved = isAbsolute(configPath) ? configPath : resolve(cwd, configPath);
+    const resolved = isAbsolute(configPath)
+      ? configPath
+      : resolve(cwd, configPath);
     // Block if the resolved path is inside the actual nsyte project directory
     if (
       !resolved.includes("nsyte-test-") && !resolved.startsWith("/tmp/") &&
@@ -188,7 +200,9 @@ export function writeProjectFile(config: ProjectConfig, configPath?: string): vo
   try {
     // Validate the file extension to prevent accidental YAML file creation
     if (!projectPath.endsWith(".json")) {
-      throw new Error(`Invalid config file path: ${projectPath}. Config must be a .json file.`);
+      throw new Error(
+        `Invalid config file path: ${projectPath}. Config must be a .json file.`,
+      );
     }
 
     ensureDirSync(dirname(projectPath));
@@ -206,7 +220,9 @@ export function writeProjectFile(config: ProjectConfig, configPath?: string): vo
 
     // Sanitize bunker URL if present to remove secrets
     if (sanitizedData.bunkerPubkey) {
-      sanitizedData.bunkerPubkey = sanitizeBunkerUrl(sanitizedData.bunkerPubkey);
+      sanitizedData.bunkerPubkey = sanitizeBunkerUrl(
+        sanitizedData.bunkerPubkey,
+      );
     }
 
     // Create backup of existing config if it exists
@@ -233,7 +249,10 @@ export function writeProjectFile(config: ProjectConfig, configPath?: string): vo
  * @param validateSchema - Whether to validate the config against the schema (default: true)
  * @returns The project configuration or null if not found
  */
-export function readProjectFile(configPath?: string, validateSchema = true): ProjectConfig | null {
+export function readProjectFile(
+  configPath?: string,
+  validateSchema = true,
+): ProjectConfig | null {
   const projectPath = resolveConfigPath(configPath);
   const cwd = Deno.cwd();
 
@@ -245,11 +264,17 @@ export function readProjectFile(configPath?: string, validateSchema = true): Pro
     const ymlPath = join(configDirPath, "config.yml");
 
     if (fileExists(yamlPath) || fileExists(ymlPath)) {
-      console.error(colors.red("\n⚠️  Found config.yaml/yml file in .nsite directory!"));
       console.error(
-        colors.yellow("nsyte uses config.json, not YAML. The YAML file may be from another tool."),
+        colors.red("\n⚠️  Found config.yaml/yml file in .nsite directory!"),
       );
-      console.error(colors.yellow("Please remove the YAML file to avoid confusion.\n"));
+      console.error(
+        colors.yellow(
+          "nsyte uses config.json, not YAML. The YAML file may be from another tool.",
+        ),
+      );
+      console.error(
+        colors.yellow("Please remove the YAML file to avoid confusion.\n"),
+      );
     }
   }
 
@@ -266,8 +291,14 @@ export function readProjectFile(configPath?: string, validateSchema = true): Pro
       config = JSON.parse(fileContent);
     } catch (e) {
       console.error(colors.red("\nFailed to parse configuration file:"));
-      console.error(colors.red(`  ${e instanceof Error ? e.message : String(e)}`));
-      console.error(colors.yellow("\nPlease ensure .nsite/config.json contains valid JSON."));
+      console.error(
+        colors.red(`  ${e instanceof Error ? e.message : String(e)}`),
+      );
+      console.error(
+        colors.yellow(
+          "\nPlease ensure .nsite/config.json contains valid JSON.",
+        ),
+      );
       throw new Error("Invalid JSON in configuration file");
     }
 
@@ -276,7 +307,11 @@ export function readProjectFile(configPath?: string, validateSchema = true): Pro
       const validation = validateConfigWithFeedback(config);
 
       if (!validation.valid) {
-        console.error(colors.red("\nConfiguration validation failed in .nsite/config.json:"));
+        console.error(
+          colors.red(
+            "\nConfiguration validation failed in .nsite/config.json:",
+          ),
+        );
         console.error(formatValidationErrors(validation.errors));
 
         if (validation.suggestions.length > 0) {
@@ -285,7 +320,9 @@ export function readProjectFile(configPath?: string, validateSchema = true): Pro
         }
 
         console.log(
-          colors.dim("\nYou can run 'nsyte validate' for more detailed validation information."),
+          colors.dim(
+            "\nYou can run 'nsyte validate' for more detailed validation information.",
+          ),
         );
 
         throw new Error("Invalid configuration format");
@@ -366,11 +403,17 @@ export async function setupProject(
         relays: [],
         servers: [],
       };
-      log.debug("Running in non-interactive mode with no existing configuration");
+      log.debug(
+        "Running in non-interactive mode with no existing configuration",
+      );
       return { config, privateKey: undefined };
     }
 
-    console.log(colors.cyan("No existing project configuration found. Setting up a new one:"));
+    console.log(
+      colors.cyan(
+        "No existing project configuration found. Setting up a new one:",
+      ),
+    );
     const setupResult = await interactiveSetup();
     config = setupResult.config;
     privateKey = setupResult.privateKey;
@@ -410,10 +453,14 @@ async function connectToBunkerWithQR(): Promise<NostrConnectSigner> {
   });
 
   let chosenRelays: string[];
-  if (relayInput.trim() === "" || relayInput.trim() === defaultRelays.join(", ")) {
+  if (
+    relayInput.trim() === "" || relayInput.trim() === defaultRelays.join(", ")
+  ) {
     chosenRelays = defaultRelays;
   } else {
-    chosenRelays = relayInput.split(",").map((r) => r.trim()).filter((r) => r.length > 0);
+    chosenRelays = relayInput.split(",").map((r) => r.trim()).filter((r) =>
+      r.length > 0
+    );
   }
 
   if (chosenRelays.length === 0) {
@@ -422,7 +469,11 @@ async function connectToBunkerWithQR(): Promise<NostrConnectSigner> {
   }
 
   console.log(
-    colors.cyan(`Initiating Nostr Connect as '${appName}' on relays: ${chosenRelays.join(", ")}`),
+    colors.cyan(
+      `Initiating Nostr Connect as '${appName}' on relays: ${
+        chosenRelays.join(", ")
+      }`,
+    ),
   );
   return initiateNostrConnect(appName, chosenRelays);
 }
@@ -452,7 +503,9 @@ async function newBunker(): Promise<NostrConnectSigner | undefined> {
   });
 
   try {
-    signer = choice === "qr" ? await connectToBunkerWithQR() : await connectToBunkerWithURI();
+    signer = choice === "qr"
+      ? await connectToBunkerWithQR()
+      : await connectToBunkerWithURI();
 
     if (!signer) {
       throw new Error("Failed to establish signer connection");
@@ -463,7 +516,9 @@ async function newBunker(): Promise<NostrConnectSigner | undefined> {
     log.error(`Failed to connect to bunker: ${error}`);
     console.error(
       colors.red(
-        `Failed to connect to bunker: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to connect to bunker: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       ),
     );
     Deno.exit(1);
@@ -526,7 +581,9 @@ async function selectKeySource(
   if (keyChoice === "generate") {
     const keyPair = generateKeyPair();
     privateKey = keyPair.privateKey;
-    console.log(colors.green(`Generated new private key: ${keyPair.privateKey}`));
+    console.log(
+      colors.green(`Generated new private key: ${keyPair.privateKey}`),
+    );
     console.log(
       colors.yellow(
         "IMPORTANT: Save this key securely. It will not be stored and cannot be recovered!",
@@ -570,7 +627,9 @@ async function selectKeySource(
 
     config.bunkerPubkey = selectedPubkey;
     console.log(
-      colors.green(`Using existing bunker with pubkey: ${selectedPubkey.slice(0, 8)}...`),
+      colors.green(
+        `Using existing bunker with pubkey: ${selectedPubkey.slice(0, 8)}...`,
+      ),
     );
     configChanged = originalBunkerPubkey !== selectedPubkey;
   }
@@ -625,10 +684,14 @@ export function buildNappConfigFromAnswers(answers: {
     name: { value: answers.name },
     icon: {
       hash: answers.iconHash,
-      mime: answers.iconMime && answers.iconMime.trim() ? answers.iconMime : "image/png",
+      mime: answers.iconMime && answers.iconMime.trim()
+        ? answers.iconMime
+        : "image/png",
     },
     categories: answers.categories,
-    countries: (answers.countries && answers.countries.length) ? answers.countries : ["*"],
+    countries: (answers.countries && answers.countries.length)
+      ? answers.countries
+      : ["*"],
   };
 
   if (answers.summary && answers.summary.trim()) {
@@ -681,7 +744,9 @@ async function interactiveSetup(): Promise<ProjectContext> {
   if (keyChoice === "generate") {
     const keyPair = generateKeyPair();
     privateKey = keyPair.privateKey;
-    console.log(colors.green(`Generated new private key: ${keyPair.privateKey}`));
+    console.log(
+      colors.green(`Generated new private key: ${keyPair.privateKey}`),
+    );
     console.log(
       colors.yellow(
         "IMPORTANT: Save this key securely. It will not be stored and cannot be recovered!",
@@ -709,27 +774,37 @@ async function interactiveSetup(): Promise<ProjectContext> {
         const defaultRelays = ["wss://relay.nsec.app"];
 
         const relayInput = await Input.prompt({
-          message: `Enter relays (comma-separated), or press Enter for default (${
-            defaultRelays.join(", ")
-          }):`,
+          message:
+            `Enter relays (comma-separated), or press Enter for default (${
+              defaultRelays.join(", ")
+            }):`,
           default: defaultRelays.join(", "),
         });
 
         let chosenRelays: string[];
-        if (relayInput.trim() === "" || relayInput.trim() === defaultRelays.join(", ")) {
+        if (
+          relayInput.trim() === "" ||
+          relayInput.trim() === defaultRelays.join(", ")
+        ) {
           chosenRelays = defaultRelays;
         } else {
-          chosenRelays = relayInput.split(",").map((r) => r.trim()).filter((r) => r.length > 0);
+          chosenRelays = relayInput.split(",").map((r) => r.trim()).filter((
+            r,
+          ) => r.length > 0);
         }
 
         if (chosenRelays.length === 0) {
-          console.log(colors.yellow("No relays provided. Using default relays."));
+          console.log(
+            colors.yellow("No relays provided. Using default relays."),
+          );
           chosenRelays = defaultRelays;
         }
 
         console.log(
           colors.cyan(
-            `Initiating Nostr Connect as '${appName}' on relays: ${chosenRelays.join(", ")}`,
+            `Initiating Nostr Connect as '${appName}' on relays: ${
+              chosenRelays.join(", ")
+            }`,
           ),
         );
         signer = await initiateNostrConnect(appName, chosenRelays);
@@ -754,13 +829,19 @@ async function interactiveSetup(): Promise<ProjectContext> {
       const nbunkString = getNbunkString(signer);
       await secretsManager.storeNbunk(bunkerPubkey, nbunkString);
 
-      console.log(colors.green(`Successfully connected to bunker ${bunkerPubkey.slice(0, 8)}...
-Generated and stored nbunksec string.`));
+      console.log(
+        colors.green(
+          `Successfully connected to bunker ${bunkerPubkey.slice(0, 8)}...
+Generated and stored nbunksec string.`,
+        ),
+      );
     } catch (error) {
       log.error(`Failed to connect to bunker: ${error}`);
       console.error(
         colors.red(
-          `Failed to connect to bunker: ${error instanceof Error ? error.message : String(error)}`,
+          `Failed to connect to bunker: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
         ),
       );
       Deno.exit(1);
@@ -791,7 +872,9 @@ Generated and stored nbunksec string.`));
 
     bunkerPubkey = selectedPubkey;
     console.log(
-      colors.green(`Using existing bunker with pubkey: ${selectedPubkey.slice(0, 8)}...`),
+      colors.green(
+        `Using existing bunker with pubkey: ${selectedPubkey.slice(0, 8)}...`,
+      ),
     );
   }
 
@@ -800,14 +883,18 @@ Generated and stored nbunksec string.`));
     message: "What type of site are you creating?",
     options: [
       { name: "Root site - e.g., npub1xxxx.nsite.lol", value: "root" },
-      { name: "Named site - e.g., {base36pubkey}blog.nsite.lol", value: "named" },
+      {
+        name: "Named site - e.g., {base36pubkey}blog.nsite.lol",
+        value: "named",
+      },
     ],
   });
 
   let siteId: string | null | undefined;
   if (siteType === "named") {
     const identifier = await Input.prompt({
-      message: "Enter site identifier (lowercase, max 13 chars, e.g., blog, my-site):",
+      message:
+        "Enter site identifier (lowercase, max 13 chars, e.g., blog, my-site):",
       validate: (input: string) => {
         const trimmed = input.trim();
         if (!trimmed) {
@@ -816,7 +903,9 @@ Generated and stored nbunksec string.`));
         const result = validateDTag(trimmed);
         if (!result.valid) {
           const suggestion = suggestIdentifier(trimmed);
-          return `${result.error}${suggestion !== trimmed ? `. Try "${suggestion}"` : ""}`;
+          return `${result.error}${
+            suggestion !== trimmed ? `. Try "${suggestion}"` : ""
+          }`;
         }
         return true;
       },
@@ -838,8 +927,13 @@ Generated and stored nbunksec string.`));
   console.log(colors.cyan("\nEnter nostr relay URLs (leave empty when done):"));
   const relays = await promptForUrls("Enter relay URL:", popularRelays);
 
-  console.log(colors.cyan("\nEnter blossom server URLs (leave empty when done):"));
-  const servers = await promptForUrls("Enter blossom server URL:", popularBlossomServers);
+  console.log(
+    colors.cyan("\nEnter blossom server URLs (leave empty when done):"),
+  );
+  const servers = await promptForUrls(
+    "Enter blossom server URL:",
+    popularBlossomServers,
+  );
 
   const config: ProjectConfig = {
     "$schema": CONFIG_SCHEMA_URL,
@@ -896,14 +990,17 @@ Generated and stored nbunksec string.`));
       .filter((c) => c.length > 0);
 
     const summary = await Input.prompt({ message: "Summary (optional):" });
-    const description = await Input.prompt({ message: "Description (optional):" });
+    const description = await Input.prompt({
+      message: "Description (optional):",
+    });
 
     const napp = buildNappConfigFromAnswers({
       name,
       iconHash,
       iconMime,
       categories: [label],
-      countries: (countries.length === 0 || (countries.length === 1 && countries[0] === "*"))
+      countries: (countries.length === 0 ||
+          (countries.length === 1 && countries[0] === "*"))
         ? ["*"]
         : countries,
       summary,
@@ -932,7 +1029,10 @@ Generated and stored nbunksec string.`));
 /**
  * Prompt for URLs with suggestions
  */
-async function promptForUrls(message: string, suggestions: string[]): Promise<string[]> {
+async function promptForUrls(
+  message: string,
+  suggestions: string[],
+): Promise<string[]> {
   const urls: string[] = [];
 
   while (true) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -686,36 +686,36 @@ export function buildNappConfigFromAnswers(answers: {
   tags?: string[];
   indexerRelays?: string[];
 }): NappConfig {
-  const name: LangText = { value: answers.name };
+  const name: LangText = { value: answers.name.trim() };
   if (answers.nameLang && answers.nameLang.trim()) {
-    name.lang = answers.nameLang;
+    name.lang = answers.nameLang.trim();
   }
 
   const napp: NappConfig = {
     name,
     icon: {
-      hash: answers.iconHash,
-      mime: answers.iconMime && answers.iconMime.trim() ? answers.iconMime : "image/png",
+      hash: answers.iconHash.trim(),
+      mime: answers.iconMime && answers.iconMime.trim() ? answers.iconMime.trim() : "image/png",
     },
     categories: answers.categories,
     countries: (answers.countries && answers.countries.length) ? answers.countries : ["*"],
   };
 
   if (answers.summary && answers.summary.trim()) {
-    napp.summary = { value: answers.summary };
+    napp.summary = { value: answers.summary.trim() };
     if (answers.summaryLang && answers.summaryLang.trim()) {
-      napp.summary.lang = answers.summaryLang;
+      napp.summary.lang = answers.summaryLang.trim();
     }
   }
   if (answers.description && answers.description.trim()) {
-    napp.description = { value: answers.description };
+    napp.description = { value: answers.description.trim() };
     if (answers.descriptionLang && answers.descriptionLang.trim()) {
-      napp.description.lang = answers.descriptionLang;
+      napp.description.lang = answers.descriptionLang.trim();
     }
   }
 
   if (answers.self && answers.self.trim()) {
-    napp.self = answers.self;
+    napp.self = answers.self.trim();
   }
   if (answers.keyart) {
     napp.keyart = answers.keyart;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,16 +3,21 @@ import { Input, Secret, Select } from "@cliffy/prompt";
 import { ensureDirSync } from "@std/fs/ensure-dir";
 import { dirname, isAbsolute, join, resolve } from "@std/path";
 import { NostrConnectSigner } from "applesauce-signers";
-import {
-  formatValidationErrors,
-  validateConfigWithFeedback,
-} from "./config-validator.ts";
+import { formatValidationErrors, validateConfigWithFeedback } from "./config-validator.ts";
 import { createLogger } from "./logger.ts";
 import { suggestIdentifier, validateDTag } from "./nip5a.ts";
 import { getNbunkString, initiateNostrConnect } from "./nip46.ts";
-import type { NappConfig } from "./napp/types.ts";
-import { NAPP_CATEGORIES } from "./napp/categories.ts";
+import type { LangText, NappAsset, NappConfig } from "./napp/types.ts";
+import { MAX_NAPP_CATEGORIES, NAPP_CATEGORIES } from "./napp/categories.ts";
 import { validateNappConfig } from "./napp/detect.ts";
+import {
+  classifyAssetInput,
+  deriveAssetMime,
+  isRootSite,
+  rootSiteMigrationNotice,
+  uploadNappAsset,
+} from "./napp/assets.ts";
+import { createSigner } from "./auth/signer-factory.ts";
 import { generateKeyPair } from "./nostr.ts";
 import { SecretsManager } from "./secrets/mod.ts";
 
@@ -113,9 +118,7 @@ export const defaultConfig: ProjectConfig = {
 function resolveConfigPath(customPath?: string): string {
   if (customPath) {
     // If custom path is provided, resolve it relative to CWD
-    return isAbsolute(customPath)
-      ? customPath
-      : resolve(Deno.cwd(), customPath);
+    return isAbsolute(customPath) ? customPath : resolve(Deno.cwd(), customPath);
   }
   // Default: .nsite/config.json in CWD
   return join(Deno.cwd(), configDir, projectFile);
@@ -182,9 +185,7 @@ export function writeProjectFile(
 
   // If a configPath is provided but resolves to the real project .nsite dir, block in tests
   if (isTestEnv && configPath) {
-    const resolved = isAbsolute(configPath)
-      ? configPath
-      : resolve(cwd, configPath);
+    const resolved = isAbsolute(configPath) ? configPath : resolve(cwd, configPath);
     // Block if the resolved path is inside the actual nsyte project directory
     if (
       !resolved.includes("nsyte-test-") && !resolved.startsWith("/tmp/") &&
@@ -458,9 +459,7 @@ async function connectToBunkerWithQR(): Promise<NostrConnectSigner> {
   ) {
     chosenRelays = defaultRelays;
   } else {
-    chosenRelays = relayInput.split(",").map((r) => r.trim()).filter((r) =>
-      r.length > 0
-    );
+    chosenRelays = relayInput.split(",").map((r) => r.trim()).filter((r) => r.length > 0);
   }
 
   if (chosenRelays.length === 0) {
@@ -470,9 +469,7 @@ async function connectToBunkerWithQR(): Promise<NostrConnectSigner> {
 
   console.log(
     colors.cyan(
-      `Initiating Nostr Connect as '${appName}' on relays: ${
-        chosenRelays.join(", ")
-      }`,
+      `Initiating Nostr Connect as '${appName}' on relays: ${chosenRelays.join(", ")}`,
     ),
   );
   return initiateNostrConnect(appName, chosenRelays);
@@ -503,9 +500,7 @@ async function newBunker(): Promise<NostrConnectSigner | undefined> {
   });
 
   try {
-    signer = choice === "qr"
-      ? await connectToBunkerWithQR()
-      : await connectToBunkerWithURI();
+    signer = choice === "qr" ? await connectToBunkerWithQR() : await connectToBunkerWithURI();
 
     if (!signer) {
       throw new Error("Failed to establish signer connection");
@@ -516,9 +511,7 @@ async function newBunker(): Promise<NostrConnectSigner | undefined> {
     log.error(`Failed to connect to bunker: ${error}`);
     console.error(
       colors.red(
-        `Failed to connect to bunker: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Failed to connect to bunker: ${error instanceof Error ? error.message : String(error)}`,
       ),
     );
     Deno.exit(1);
@@ -666,42 +659,263 @@ export function categoryLabel(category: string, subcategory: string): string {
  * {@link validateNappConfig} on the result before writing, warning (wizard) or
  * refusing to write (`napp init`) on errors.
  *
- * - `name` -> `{ value }`
+ * - `name` -> `{ value, lang? }` (lang only when provided)
  * - `icon.mime` defaults to `"image/png"` when omitted/blank
  * - `countries` defaults to `["*"]` when omitted/empty
- * - `summary`/`description` are included ONLY when non-empty (never `{ value: "" }`)
+ * - `summary`/`description` are included ONLY when non-empty (never `{ value: "" }`),
+ *   each carrying `lang` only when provided
+ * - `self`/`keyart`/`screenshots`/`tags`/`indexerRelays` are included ONLY when present
+ *   and non-empty
+ *
+ * All Phase-25 fields are OPTIONAL so every pre-existing call site keeps working unchanged.
  */
 export function buildNappConfigFromAnswers(answers: {
   name: string;
+  nameLang?: string;
   iconHash: string;
   iconMime?: string;
   categories: string[];
   countries?: string[];
   summary?: string;
+  summaryLang?: string;
   description?: string;
+  descriptionLang?: string;
+  self?: string;
+  keyart?: NappAsset;
+  screenshots?: NappAsset[];
+  tags?: string[];
+  indexerRelays?: string[];
 }): NappConfig {
+  const name: LangText = { value: answers.name };
+  if (answers.nameLang && answers.nameLang.trim()) {
+    name.lang = answers.nameLang;
+  }
+
   const napp: NappConfig = {
-    name: { value: answers.name },
+    name,
     icon: {
       hash: answers.iconHash,
-      mime: answers.iconMime && answers.iconMime.trim()
-        ? answers.iconMime
-        : "image/png",
+      mime: answers.iconMime && answers.iconMime.trim() ? answers.iconMime : "image/png",
     },
     categories: answers.categories,
-    countries: (answers.countries && answers.countries.length)
-      ? answers.countries
-      : ["*"],
+    countries: (answers.countries && answers.countries.length) ? answers.countries : ["*"],
   };
 
   if (answers.summary && answers.summary.trim()) {
     napp.summary = { value: answers.summary };
+    if (answers.summaryLang && answers.summaryLang.trim()) {
+      napp.summary.lang = answers.summaryLang;
+    }
   }
   if (answers.description && answers.description.trim()) {
     napp.description = { value: answers.description };
+    if (answers.descriptionLang && answers.descriptionLang.trim()) {
+      napp.description.lang = answers.descriptionLang;
+    }
+  }
+
+  if (answers.self && answers.self.trim()) {
+    napp.self = answers.self;
+  }
+  if (answers.keyart) {
+    napp.keyart = answers.keyart;
+  }
+  if (answers.screenshots && answers.screenshots.length > 0) {
+    napp.screenshots = answers.screenshots;
+  }
+  if (answers.tags && answers.tags.length > 0) {
+    napp.tags = answers.tags;
+  }
+  if (answers.indexerRelays && answers.indexerRelays.length > 0) {
+    napp.indexerRelays = answers.indexerRelays;
   }
 
   return napp;
+}
+
+/**
+ * Flag/wizard-provided values fed into {@link collectNappListing}. Asset fields carry the
+ * RAW input string (a sha256 hash, a URL, or a local path); the injected `resolveAsset`
+ * turns each into a {@link NappAsset}. Already-parsed listing fields (categories as labels,
+ * countries as an array) are passed through verbatim.
+ */
+export interface NappListingPrefill {
+  name?: string;
+  nameLang?: string;
+  icon?: string;
+  iconMime?: string;
+  categories?: string[];
+  countries?: string[];
+  summary?: string;
+  summaryLang?: string;
+  description?: string;
+  descriptionLang?: string;
+  self?: string;
+  keyart?: string;
+  screenshots?: string[];
+  tags?: string[];
+  indexerRelays?: string[];
+}
+
+/** A resolver turning a raw asset input (hash/URL/path) into a {@link NappAsset}. */
+export type NappAssetResolver = (value: string) => Promise<NappAsset>;
+
+/**
+ * The SHARED napp-listing collector used by BOTH `nsyte napp init` (prefill = parsed flags,
+ * resolveAsset uploads) and the `nsyte init` wizard napp branch (prefill = {}, interactive,
+ * resolveAsset = hash/URL-or-upload). For each field: use prefill when present; else, when
+ * `interactive`, prompt; else leave unset. Asset strings are turned into {@link NappAsset}
+ * via the injected `resolveAsset`. Returns the assembled config via
+ * {@link buildNappConfigFromAnswers} (PURE assembly; validation is the caller's job).
+ *
+ * Dependency-light by design: `resolveAsset` is injected so this module never imports
+ * upload.ts.
+ */
+export async function collectNappListing(opts: {
+  prefill: NappListingPrefill;
+  interactive: boolean;
+  resolveAsset: NappAssetResolver;
+}): Promise<NappConfig> {
+  const { prefill, interactive, resolveAsset } = opts;
+
+  // --- name ---
+  let name = prefill.name;
+  if (name === undefined && interactive) {
+    name = await Input.prompt({
+      message: "App name:",
+      validate: (v: string) => v.trim().length > 0 || "Name is required",
+    });
+  }
+
+  // --- icon (raw input) ---
+  let iconInput = prefill.icon;
+  let iconMime = prefill.iconMime;
+  if (iconInput === undefined && interactive) {
+    iconInput = await Input.prompt({
+      message: "Icon (sha256 hash, URL, or local file path):",
+      validate: (v: string) => v.trim().length > 0 || "Icon is required",
+    });
+    iconMime = await Input.prompt({
+      message: "Icon MIME type (used for hash/URL inputs):",
+      default: "image/png",
+    });
+  }
+
+  // --- categories (labels) ---
+  let categories = prefill.categories;
+  if ((categories === undefined || categories.length === 0) && interactive) {
+    categories = [];
+    while (categories.length < MAX_NAPP_CATEGORIES) {
+      const category = await Select.prompt<string>({
+        message: categories.length === 0
+          ? "Category"
+          : `Category (${categories.length}/${MAX_NAPP_CATEGORIES}, choose "done" to finish)`,
+        options: [
+          ...Object.keys(NAPP_CATEGORIES).map((c) => ({ name: c, value: c })),
+          ...(categories.length > 0 ? [{ name: "done", value: "__done__" }] : []),
+        ],
+      });
+      if (category === "__done__") break;
+      const subcategory = await Select.prompt<string>({
+        message: "Subcategory",
+        options: NAPP_CATEGORIES[category].map((s) => ({ name: s, value: s })),
+      });
+      categories.push(categoryLabel(category, subcategory));
+    }
+  }
+
+  // --- countries ---
+  let countries = prefill.countries;
+  if ((countries === undefined || countries.length === 0) && interactive) {
+    const countriesInput = await Input.prompt({
+      message: "Countries (comma-separated ISO codes, or * for worldwide):",
+      default: "*",
+    });
+    const parts = countriesInput.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+    countries = (parts.length === 0 || (parts.length === 1 && parts[0] === "*")) ? ["*"] : parts;
+  }
+
+  // --- summary / description ---
+  let summary = prefill.summary;
+  let description = prefill.description;
+  if (summary === undefined && interactive) {
+    summary = await Input.prompt({ message: "Summary (optional):" });
+  }
+  if (description === undefined && interactive) {
+    description = await Input.prompt({ message: "Description (optional):" });
+  }
+
+  // --- self ---
+  let self = prefill.self;
+  if (self === undefined && interactive) {
+    const v = await Input.prompt({
+      message: "Author pubkey (64-hex, optional):",
+    });
+    self = v.trim() || undefined;
+  }
+
+  // --- keyart / screenshots (raw inputs) ---
+  let keyartInput = prefill.keyart;
+  let screenshotInputs = prefill.screenshots;
+  if (keyartInput === undefined && interactive) {
+    const v = await Input.prompt({
+      message: "Key art (sha256 hash, URL, or local path; optional):",
+    });
+    keyartInput = v.trim() || undefined;
+  }
+  if (screenshotInputs === undefined && interactive) {
+    const collected: string[] = [];
+    while (true) {
+      const v = await Input.prompt({
+        message: "Screenshot (hash/URL/path; blank to finish):",
+      });
+      if (!v || !v.trim()) break;
+      collected.push(v.trim());
+    }
+    screenshotInputs = collected;
+  }
+
+  // --- tags / indexerRelays ---
+  let tags = prefill.tags;
+  if (tags === undefined && interactive) {
+    const v = await Input.prompt({
+      message: "Tags (comma-separated, optional):",
+    });
+    tags = v.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
+  }
+  const indexerRelays = prefill.indexerRelays;
+
+  // --- resolve assets via the injected resolver ---
+  let icon: NappAsset | undefined;
+  if (iconInput && iconInput.trim()) {
+    icon = await resolveAsset(iconInput.trim());
+  }
+  let keyart: NappAsset | undefined;
+  if (keyartInput && keyartInput.trim()) {
+    keyart = await resolveAsset(keyartInput.trim());
+  }
+  const screenshots: NappAsset[] = [];
+  for (const s of screenshotInputs ?? []) {
+    if (s && s.trim()) screenshots.push(await resolveAsset(s.trim()));
+  }
+
+  return buildNappConfigFromAnswers({
+    name: name ?? "",
+    nameLang: prefill.nameLang,
+    iconHash: icon?.hash ?? "",
+    iconMime: icon?.mime ?? iconMime,
+    categories: categories ?? [],
+    countries,
+    summary,
+    summaryLang: prefill.summaryLang,
+    description,
+    descriptionLang: prefill.descriptionLang,
+    self,
+    keyart,
+    screenshots: screenshots.length > 0 ? screenshots : undefined,
+    tags: tags && tags.length > 0 ? tags : undefined,
+    indexerRelays: indexerRelays && indexerRelays.length > 0 ? indexerRelays : undefined,
+  });
 }
 
 /**
@@ -774,10 +988,9 @@ async function interactiveSetup(): Promise<ProjectContext> {
         const defaultRelays = ["wss://relay.nsec.app"];
 
         const relayInput = await Input.prompt({
-          message:
-            `Enter relays (comma-separated), or press Enter for default (${
-              defaultRelays.join(", ")
-            }):`,
+          message: `Enter relays (comma-separated), or press Enter for default (${
+            defaultRelays.join(", ")
+          }):`,
           default: defaultRelays.join(", "),
         });
 
@@ -802,9 +1015,7 @@ async function interactiveSetup(): Promise<ProjectContext> {
 
         console.log(
           colors.cyan(
-            `Initiating Nostr Connect as '${appName}' on relays: ${
-              chosenRelays.join(", ")
-            }`,
+            `Initiating Nostr Connect as '${appName}' on relays: ${chosenRelays.join(", ")}`,
           ),
         );
         signer = await initiateNostrConnect(appName, chosenRelays);
@@ -839,9 +1050,7 @@ Generated and stored nbunksec string.`,
       log.error(`Failed to connect to bunker: ${error}`);
       console.error(
         colors.red(
-          `Failed to connect to bunker: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `Failed to connect to bunker: ${error instanceof Error ? error.message : String(error)}`,
         ),
       );
       Deno.exit(1);
@@ -893,8 +1102,7 @@ Generated and stored nbunksec string.`,
   let siteId: string | null | undefined;
   if (siteType === "named") {
     const identifier = await Input.prompt({
-      message:
-        "Enter site identifier (lowercase, max 13 chars, e.g., blog, my-site):",
+      message: "Enter site identifier (lowercase, max 13 chars, e.g., blog, my-site):",
       validate: (input: string) => {
         const trimmed = input.trim();
         if (!trimmed) {
@@ -903,9 +1111,7 @@ Generated and stored nbunksec string.`,
         const result = validateDTag(trimmed);
         if (!result.valid) {
           const suggestion = suggestIdentifier(trimmed);
-          return `${result.error}${
-            suggestion !== trimmed ? `. Try "${suggestion}"` : ""
-          }`;
+          return `${result.error}${suggestion !== trimmed ? `. Try "${suggestion}"` : ""}`;
         }
         return true;
       },
@@ -957,70 +1163,103 @@ Generated and stored nbunksec string.`,
   });
 
   if (projectType === "napp") {
-    const name = await Input.prompt({
-      message: "App name:",
-      validate: (v: string) => v.trim().length > 0 || "Name is required",
-    });
-    const iconHash = await Input.prompt({
-      message: "Icon (sha256 hash or URL):",
-      validate: (v: string) => v.trim().length > 0 || "Icon is required",
-    });
-    const iconMime = await Input.prompt({
-      message: "Icon MIME type:",
-      default: "image/png",
-    });
-
-    const category = await Select.prompt<string>({
-      message: "Category",
-      options: Object.keys(NAPP_CATEGORIES).map((c) => ({ name: c, value: c })),
-    });
-    const subcategory = await Select.prompt<string>({
-      message: "Subcategory",
-      options: NAPP_CATEGORIES[category].map((s) => ({ name: s, value: s })),
-    });
-    const label = categoryLabel(category, subcategory);
-
-    const countriesInput = await Input.prompt({
-      message: "Countries (comma-separated ISO codes, or * for worldwide):",
-      default: "*",
-    });
-    const countries = countriesInput
-      .split(",")
-      .map((c) => c.trim())
-      .filter((c) => c.length > 0);
-
-    const summary = await Input.prompt({ message: "Summary (optional):" });
-    const description = await Input.prompt({
-      message: "Description (optional):",
-    });
-
-    const napp = buildNappConfigFromAnswers({
-      name,
-      iconHash,
-      iconMime,
-      categories: [label],
-      countries: (countries.length === 0 ||
-          (countries.length === 1 && countries[0] === "*"))
-        ? ["*"]
-        : countries,
-      summary,
-      description,
-    });
-
-    // Validate before writing. On errors, WARN but still attach the scaffold so the
-    // author can fix `.nsite/config.json` by hand rather than losing their answers.
-    const nappErrors = validateNappConfig(napp);
-    if (nappErrors.length > 0) {
-      for (const e of nappErrors) {
-        console.log(colors.yellow(`  ${e.path}: ${e.message}`));
+    // Plan-check #4: the napp branch MUST degrade gracefully. An asset/upload failure
+    // WARNS and still lets `nsyte init` finish (consistent with warn-but-write); it must
+    // NOT throw out of interactiveSetup and abort the whole `nsyte init`.
+    try {
+      // Root-site guidance: a napp needs a NAMED site to be discoverable. We WARN and
+      // (interactive) offer to set an id, but NEVER auto-migrate (no consent => no id).
+      if (isRootSite(config)) {
+        console.log(colors.yellow(rootSiteMigrationNotice()));
+        const setIdNow = await Select.prompt<string>({
+          message: "Set a site identifier now? (required for `nsyte napp id`)",
+          options: [
+            { name: "No — leave as a root site for now", value: "no" },
+            { name: "Yes — set a named site identifier", value: "yes" },
+          ],
+          default: "no",
+        });
+        if (setIdNow === "yes") {
+          const identifier = await Input.prompt({
+            message: "Enter site identifier (lowercase, max 13 chars):",
+            validate: (input: string) => {
+              const trimmed = input.trim();
+              if (!trimmed) return "Site identifier is required";
+              const result = validateDTag(trimmed);
+              if (!result.valid) {
+                const suggestion = suggestIdentifier(trimmed);
+                return `${result.error}${suggestion !== trimmed ? `. Try "${suggestion}"` : ""}`;
+              }
+              return true;
+            },
+          });
+          config.id = identifier.trim();
+        } else {
+          console.log(
+            colors.yellow(
+              "Leaving this as a root site — `nsyte napp id` will not work until you set an id.",
+            ),
+          );
+        }
       }
+
+      // Wizard asset resolver: hash/URL pass through ({hash, mime}); a local path is
+      // uploaded via uploadNappAsset when blossom servers + a signer are available, else
+      // a clear error tells the author to configure servers or paste a hash/URL.
+      const resolveAsset: NappAssetResolver = async (value: string) => {
+        if (classifyAssetInput(value) !== "path") {
+          return { hash: value, mime: deriveAssetMime(value) };
+        }
+        if (!config.servers || config.servers.length === 0) {
+          throw new Error(
+            `Cannot upload "${value}": configure blossom servers (or paste a sha256 hash / URL) for assets.`,
+          );
+        }
+        const signerResult = await createSigner({
+          sec: privateKey,
+          bunkerPubkey,
+        });
+        if ("error" in signerResult) {
+          throw new Error(
+            `Cannot upload "${value}": ${signerResult.error} (or paste a sha256 hash / URL).`,
+          );
+        }
+        return await uploadNappAsset(value, {
+          servers: config.servers,
+          relays: config.relays,
+          signer: signerResult.signer,
+        });
+      };
+
+      const napp = await collectNappListing({
+        prefill: {},
+        interactive: true,
+        resolveAsset,
+      });
+
+      // Validate before writing. On errors, WARN but still attach the scaffold so the
+      // author can fix `.nsite/config.json` by hand rather than losing their answers.
+      const nappErrors = validateNappConfig(napp);
+      if (nappErrors.length > 0) {
+        for (const e of nappErrors) {
+          console.log(colors.yellow(`  ${e.path}: ${e.message}`));
+        }
+        console.log(
+          colors.yellow(
+            "The napp section may need manual fixes in .nsite/config.json before deploying.",
+          ),
+        );
+      }
+      config.napp = napp;
+    } catch (e) {
+      // Graceful degradation: warn and still finish `nsyte init`.
+      const msg = e instanceof Error ? e.message : String(e);
       console.log(
         colors.yellow(
-          "The napp section may need manual fixes in .nsite/config.json before deploying.",
+          `Skipped napp section (you can add it later with \`nsyte napp init\`): ${msg}`,
         ),
       );
     }
-    config.napp = napp;
   }
 
   return { config, privateKey };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,6 +8,8 @@ import { createLogger } from "./logger.ts";
 import { suggestIdentifier, validateDTag } from "./nip5a.ts";
 import { getNbunkString, initiateNostrConnect } from "./nip46.ts";
 import type { NappConfig } from "./napp/types.ts";
+import { NAPP_CATEGORIES } from "./napp/categories.ts";
+import { validateNappConfig } from "./napp/detect.ts";
 import { generateKeyPair } from "./nostr.ts";
 import { SecretsManager } from "./secrets/mod.ts";
 
@@ -585,6 +587,61 @@ async function selectKeySource(
 }
 
 /**
+ * Build a `napp.<category>:<subcategory>` label from a category + subcategory.
+ *
+ * PURE string join — no validation here (the caller validates the assembled label or
+ * the whole config via validateCategoryLabel/validateNappConfig). Subcategories are
+ * stored verbatim, including spaces (e.g. `categoryLabel("utilities", "text editor")`
+ * yields `napp.utilities:text editor`).
+ */
+export function categoryLabel(category: string, subcategory: string): string {
+  return `napp.${category}:${subcategory}`;
+}
+
+/**
+ * The SINGLE pure assembly helper that shapes wizard/`napp init` answers into a
+ * {@link NappConfig}. Reused verbatim by the `nsyte init` project-type wizard AND by
+ * `nsyte napp init`.
+ *
+ * This is a PURE shaper: it does NOT validate or throw. Callers run
+ * {@link validateNappConfig} on the result before writing, warning (wizard) or
+ * refusing to write (`napp init`) on errors.
+ *
+ * - `name` -> `{ value }`
+ * - `icon.mime` defaults to `"image/png"` when omitted/blank
+ * - `countries` defaults to `["*"]` when omitted/empty
+ * - `summary`/`description` are included ONLY when non-empty (never `{ value: "" }`)
+ */
+export function buildNappConfigFromAnswers(answers: {
+  name: string;
+  iconHash: string;
+  iconMime?: string;
+  categories: string[];
+  countries?: string[];
+  summary?: string;
+  description?: string;
+}): NappConfig {
+  const napp: NappConfig = {
+    name: { value: answers.name },
+    icon: {
+      hash: answers.iconHash,
+      mime: answers.iconMime && answers.iconMime.trim() ? answers.iconMime : "image/png",
+    },
+    categories: answers.categories,
+    countries: (answers.countries && answers.countries.length) ? answers.countries : ["*"],
+  };
+
+  if (answers.summary && answers.summary.trim()) {
+    napp.summary = { value: answers.summary };
+  }
+  if (answers.description && answers.description.trim()) {
+    napp.description = { value: answers.description };
+  }
+
+  return napp;
+}
+
+/**
  * Interactive project setup
  */
 async function interactiveSetup(): Promise<ProjectContext> {
@@ -793,6 +850,81 @@ Generated and stored nbunksec string.`));
     title: siteTitle || undefined,
     description: siteDescription || undefined,
   };
+
+  // Project-type step (additive, nsite-default). The nsite branch returns the EXACT
+  // pre-phase config above (zero regression); the napp branch only ADDS `config.napp`.
+  const projectType = await Select.prompt<string>({
+    message: "Project type",
+    options: [
+      { name: "nsite (static site)", value: "nsite" },
+      { name: "napp (discoverable app)", value: "napp" },
+    ],
+    default: "nsite",
+  });
+
+  if (projectType === "napp") {
+    const name = await Input.prompt({
+      message: "App name:",
+      validate: (v: string) => v.trim().length > 0 || "Name is required",
+    });
+    const iconHash = await Input.prompt({
+      message: "Icon (sha256 hash or URL):",
+      validate: (v: string) => v.trim().length > 0 || "Icon is required",
+    });
+    const iconMime = await Input.prompt({
+      message: "Icon MIME type:",
+      default: "image/png",
+    });
+
+    const category = await Select.prompt<string>({
+      message: "Category",
+      options: Object.keys(NAPP_CATEGORIES).map((c) => ({ name: c, value: c })),
+    });
+    const subcategory = await Select.prompt<string>({
+      message: "Subcategory",
+      options: NAPP_CATEGORIES[category].map((s) => ({ name: s, value: s })),
+    });
+    const label = categoryLabel(category, subcategory);
+
+    const countriesInput = await Input.prompt({
+      message: "Countries (comma-separated ISO codes, or * for worldwide):",
+      default: "*",
+    });
+    const countries = countriesInput
+      .split(",")
+      .map((c) => c.trim())
+      .filter((c) => c.length > 0);
+
+    const summary = await Input.prompt({ message: "Summary (optional):" });
+    const description = await Input.prompt({ message: "Description (optional):" });
+
+    const napp = buildNappConfigFromAnswers({
+      name,
+      iconHash,
+      iconMime,
+      categories: [label],
+      countries: (countries.length === 0 || (countries.length === 1 && countries[0] === "*"))
+        ? ["*"]
+        : countries,
+      summary,
+      description,
+    });
+
+    // Validate before writing. On errors, WARN but still attach the scaffold so the
+    // author can fix `.nsite/config.json` by hand rather than losing their answers.
+    const nappErrors = validateNappConfig(napp);
+    if (nappErrors.length > 0) {
+      for (const e of nappErrors) {
+        console.log(colors.yellow(`  ${e.path}: ${e.message}`));
+      }
+      console.log(
+        colors.yellow(
+          "The napp section may need manual fixes in .nsite/config.json before deploying.",
+        ),
+      );
+    }
+    config.napp = napp;
+  }
 
   return { config, privateKey };
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -7,6 +7,7 @@ import { formatValidationErrors, validateConfigWithFeedback } from "./config-val
 import { createLogger } from "./logger.ts";
 import { suggestIdentifier, validateDTag } from "./nip5a.ts";
 import { getNbunkString, initiateNostrConnect } from "./nip46.ts";
+import type { NappConfig } from "./napp/types.ts";
 import { generateKeyPair } from "./nostr.ts";
 import { SecretsManager } from "./secrets/mod.ts";
 
@@ -59,6 +60,7 @@ export type ProjectConfig = {
       linux?: string;
     };
   };
+  napp?: NappConfig; // NIP-5B napp listing section (optional). Present => this project is a napp. See src/lib/napp/.
 };
 
 export interface ProjectContext {

--- a/src/lib/dry-run/collector.ts
+++ b/src/lib/dry-run/collector.ts
@@ -40,9 +40,11 @@ export function collectDeployEvents(
 
   // 1. Site manifest (always published)
   const siteId = config.id || undefined;
-  const manifestRelays = options.relays?.split(",").map((r) => r.trim()).filter((r) => r) ||
+  const manifestRelays =
+    options.relays?.split(",").map((r) => r.trim()).filter((r) => r) ||
     config.relays || [];
-  const manifestServers = options.servers?.split(",").map((s) => s.trim()).filter((s) => s) ||
+  const manifestServers =
+    options.servers?.split(",").map((s) => s.trim()).filter((s) => s) ||
     config.servers || [];
 
   const manifestFiles = buildManifestFileMappings(
@@ -68,9 +70,13 @@ export function collectDeployEvents(
   });
 
   // 2. App handler (kind 31990) — if enabled
-  const shouldPublishAppHandler = options.publishAppHandler || config.publishAppHandler;
+  const shouldPublishAppHandler = options.publishAppHandler ||
+    config.publishAppHandler;
   if (shouldPublishAppHandler) {
-    const handlerTemplate = buildAppHandlerTemplate(config, options.handlerKinds);
+    const handlerTemplate = buildAppHandlerTemplate(
+      config,
+      options.handlerKinds,
+    );
     if (handlerTemplate) {
       events.push({
         label: "App Handler (kind 31990)",
@@ -93,7 +99,8 @@ export function collectDeployEvents(
   }
 
   // 4. Relay list (kind 10002) — if enabled
-  const shouldPublishRelayList = options.publishRelayList || config.publishRelayList;
+  const shouldPublishRelayList = options.publishRelayList ||
+    config.publishRelayList;
   if (shouldPublishRelayList) {
     const relays = manifestRelays;
     if (relays.length > 0) {
@@ -107,7 +114,8 @@ export function collectDeployEvents(
   }
 
   // 5. Server list (kind 10063) — if enabled
-  const shouldPublishServerList = options.publishServerList || config.publishServerList;
+  const shouldPublishServerList = options.publishServerList ||
+    config.publishServerList;
   if (shouldPublishServerList) {
     const servers = manifestServers;
     if (servers.length > 0) {
@@ -128,7 +136,11 @@ export function collectDeployEvents(
   if (isNapp(config)) {
     const listingDTag = deriveListingDTag({ id: config.id });
     // Pass "" for pubkey — dry-run never signs and `self` is never auto-defaulted.
-    const listingTemplate = createAppListingTemplate("", config.napp, listingDTag);
+    const listingTemplate = createAppListingTemplate(
+      "",
+      config.napp,
+      listingDTag,
+    );
     events.push({
       label: `App Listing (kind ${NSITE_APP_LISTING_KIND})`,
       kind: NSITE_APP_LISTING_KIND,
@@ -172,7 +184,9 @@ function buildAppHandlerTemplate(
 ): EventTemplate | null {
   let kinds: number[] = [];
   if (handlerKindsStr) {
-    kinds = handlerKindsStr.split(",").map((k) => parseInt(k.trim())).filter((k) => !isNaN(k));
+    kinds = handlerKindsStr.split(",").map((k) => parseInt(k.trim())).filter((
+      k,
+    ) => !isNaN(k));
   } else if (config.appHandler?.kinds) {
     kinds = config.appHandler.kinds;
   }
@@ -224,10 +238,15 @@ function buildAppHandlerTemplate(
 
   // NIP-01 style metadata content
   let content = "";
-  if (config.appHandler?.name || config.appHandler?.description || config.appHandler?.icon) {
+  if (
+    config.appHandler?.name || config.appHandler?.description ||
+    config.appHandler?.icon
+  ) {
     const profile: Record<string, string> = {};
     if (config.appHandler.name) profile.name = config.appHandler.name;
-    if (config.appHandler.description) profile.about = config.appHandler.description;
+    if (config.appHandler.description) {
+      profile.about = config.appHandler.description;
+    }
     if (config.appHandler.icon) profile.picture = config.appHandler.icon;
     content = JSON.stringify(profile);
   }

--- a/src/lib/dry-run/collector.ts
+++ b/src/lib/dry-run/collector.ts
@@ -8,6 +8,12 @@ import {
   NSITE_NAME_SITE_KIND,
   NSITE_ROOT_SITE_KIND,
 } from "../manifest.ts";
+import { isNapp } from "../napp/detect.ts";
+import {
+  createAppListingTemplate,
+  deriveListingDTag,
+  NSITE_APP_LISTING_KIND,
+} from "../napp/listing.ts";
 import type { DryRunEvent } from "./types.ts";
 
 /** Options that affect which events would be published */
@@ -112,6 +118,23 @@ export function collectDeployEvents(
         filename: "server-list-10063.json",
       });
     }
+  }
+
+  // 6. App Listing (kind 37348) — ONLY for napps. Appended LAST so the non-napp
+  //    template set is byte-for-byte unchanged (NAPP-LST-03 / NAPP-LST-05). The d tag
+  //    is derived from config.id (NOT a manifest event — dry-run has the config in
+  //    hand) so it matches `const siteId = config.id || undefined;` used for the
+  //    manifest template above: named -> config.id, root -> "".
+  if (isNapp(config)) {
+    const listingDTag = deriveListingDTag({ id: config.id });
+    // Pass "" for pubkey — dry-run never signs and `self` is never auto-defaulted.
+    const listingTemplate = createAppListingTemplate("", config.napp, listingDTag);
+    events.push({
+      label: `App Listing (kind ${NSITE_APP_LISTING_KIND})`,
+      kind: NSITE_APP_LISTING_KIND,
+      template: listingTemplate,
+      filename: `app-listing-${NSITE_APP_LISTING_KIND}.json`,
+    });
   }
 
   return events;

--- a/src/lib/napp/assets.ts
+++ b/src/lib/napp/assets.ts
@@ -1,0 +1,189 @@
+/**
+ * napp asset-input classification + local-file upload helper.
+ *
+ * Pure helpers (`classifyAssetInput`/`deriveAssetMime`/`parseCategoriesInput`/
+ * `parseCountriesInput`/`isRootSite`/`rootSiteMigrationNotice`) plus the upload boundary
+ * (`resolveNappAsset`/`uploadNappAsset`). The boundary keeps the existing paste-a-hash/URL
+ * path working while making local-path uploads unit-testable via an injected upload fn.
+ */
+import { contentType } from "@std/media-types";
+import { basename, dirname, extname } from "@std/path";
+import { calculateFileHash } from "../files.ts";
+import { processUploads, type UploadResponse } from "../upload.ts";
+import type { FileEntry } from "../nostr.ts";
+import type { ISigner } from "applesauce-signers";
+import type { NappAsset } from "./types.ts";
+
+const HEX64 = /^[0-9a-fA-F]{64}$/;
+
+/** Classify a raw asset-input string into hash / url / path (anything else). PURE. */
+export function classifyAssetInput(value: string): "hash" | "url" | "path" {
+  if (HEX64.test(value)) return "hash";
+  if (/^https?:\/\//i.test(value)) return "url";
+  return "path";
+}
+
+/**
+ * Map a recognizable image extension to its MIME via `@std/media-types`, falling back to
+ * `"image/png"`. GUARD: `contentType` returns NON-image types for many extensions
+ * (e.g. `.xyz`→`chemical/x-xyz`), so the result is used ONLY when it starts with
+ * `"image/"`. PURE.
+ */
+export function deriveAssetMime(value: string): string {
+  const ext = extname(value);
+  if (ext) {
+    const mime = contentType(ext);
+    if (mime && mime.startsWith("image/")) {
+      // Strip any parameters (e.g. "; charset=...") that may be appended.
+      return mime.split(";")[0].trim();
+    }
+  }
+  return "image/png";
+}
+
+/**
+ * Normalize raw category inputs into `napp.<cat>:<sub>` labels: prepend `napp.` only when
+ * missing, trim, drop blanks, preserve order. Validation / the ≤3 cap is left to
+ * `validateNappConfig`/`validateCategories`. PURE.
+ */
+export function parseCategoriesInput(values: string[]): string[] {
+  const out: string[] = [];
+  for (const raw of values) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    out.push(trimmed.startsWith("napp.") ? trimmed : `napp.${trimmed}`);
+  }
+  return out;
+}
+
+/**
+ * Split a comma-separated countries string: trim, drop blanks; return `["*"]` when the
+ * result is empty or exactly `["*"]`. Mirrors the existing wizard logic. PURE.
+ */
+export function parseCountriesInput(csv: string): string[] {
+  const parts = csv.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+  if (parts.length === 0 || (parts.length === 1 && parts[0] === "*")) {
+    return ["*"];
+  }
+  return parts;
+}
+
+/** True iff `config.id` is missing/empty (a root site, kind 15128). PURE. */
+export function isRootSite(config: { id?: string | null }): boolean {
+  return config.id === undefined || config.id === null || config.id === "";
+}
+
+/** Multi-line warning shown before converting a ROOT site into a named napp. PURE. */
+export function rootSiteMigrationNotice(): string {
+  return [
+    "This is a ROOT site (no id). napps require a NAMED site to be discoverable.",
+    "Setting an id republishes your manifest from kind 15128 (root) to kind 35128 (named).",
+    "The old root manifest is then ORPHANED — it is not deleted, just no longer your live site.",
+    "Your gateway URLs change (e.g. npub1….nsite.lol → {id}.npub1….nsite.lol).",
+    "nsyte never auto-migrates: an id is set ONLY when you pass --id or explicitly confirm.",
+  ].join("\n");
+}
+
+/** Context the upload helper needs (servers/relays/signer). */
+export interface UploadAssetContext {
+  servers: string[];
+  relays: string[];
+  signer: ISigner;
+}
+
+/** Injectable upload boundary signature (default = real processUploads). */
+export type ProcessFn = (
+  files: FileEntry[],
+  baseDir: string,
+  servers: string[],
+  signer: ISigner,
+  relays: string[],
+) => Promise<UploadResponse[]>;
+
+/**
+ * Resolve a raw asset input into a {@link NappAsset}. For hash/url it returns
+ * `{ hash: value, mime: deriveAssetMime(value) }` WITHOUT calling `upload`; for a local
+ * path it returns `await upload(value)`.
+ */
+export async function resolveNappAsset(
+  value: string,
+  upload: (localPath: string) => Promise<{ hash: string; mime: string }>,
+): Promise<NappAsset> {
+  const kind = classifyAssetInput(value);
+  if (kind === "path") {
+    const result = await upload(value);
+    return { hash: result.hash, mime: result.mime };
+  }
+  return { hash: value, mime: deriveAssetMime(value) };
+}
+
+/**
+ * Read a local file, compute its sha256 + mime, upload it to blossom, and return
+ * `{ hash, mime }` ONLY when the upload succeeded. Throws a clear, distinct error when
+ * servers/relays are empty, the file is missing/empty, or the upload did not succeed.
+ *
+ * `processFn` is injectable (default = the real {@link processUploads}) so tests can
+ * verify FileEntry construction + success/failure handling without real blossom/relays.
+ */
+export async function uploadNappAsset(
+  localPath: string,
+  ctx: UploadAssetContext,
+  processFn: ProcessFn = processUploads,
+): Promise<{ hash: string; mime: string }> {
+  if (!ctx.servers || ctx.servers.length === 0) {
+    throw new Error(
+      `Cannot upload "${localPath}": no blossom servers configured. ` +
+        "Add servers to .nsite/config.json, or paste a sha256 hash / URL instead.",
+    );
+  }
+  // Pre-empt processUploads' generic "No relays" error with our own clear message.
+  if (!ctx.relays || ctx.relays.length === 0) {
+    throw new Error(
+      `Cannot upload "${localPath}": no relays configured. ` +
+        "Add relays to .nsite/config.json, or paste a sha256 hash / URL instead.",
+    );
+  }
+
+  let raw: Uint8Array;
+  try {
+    raw = await Deno.readFile(localPath);
+  } catch {
+    throw new Error(`Cannot upload "${localPath}": file not found or unreadable.`);
+  }
+  if (raw.length === 0) {
+    throw new Error(`Cannot upload "${localPath}": file is empty.`);
+  }
+  // FileEntry.data is ByteArray (Uint8Array<ArrayBuffer>); Deno.readFile may return a
+  // SharedArrayBuffer-backed view — copy into a plain ArrayBuffer to satisfy the type.
+  const data = new Uint8Array(raw);
+
+  const sha256 = await calculateFileHash(localPath);
+  const mime = deriveAssetMime(localPath);
+  const baseDir = dirname(localPath);
+  const entry: FileEntry = {
+    path: basename(localPath),
+    sha256,
+    data,
+    size: data.length,
+    contentType: mime,
+  };
+
+  const results = await processFn(
+    [entry],
+    baseDir,
+    ctx.servers,
+    ctx.signer,
+    ctx.relays,
+  );
+
+  const result = results.find((r) => r.file.sha256 === sha256) ?? results[0];
+  if (!result || result.success !== true) {
+    throw new Error(
+      `Upload of "${localPath}" failed${
+        result?.error ? `: ${result.error}` : " on all configured servers."
+      }`,
+    );
+  }
+
+  return { hash: sha256, mime };
+}

--- a/src/lib/napp/categories.ts
+++ b/src/lib/napp/categories.ts
@@ -1,0 +1,125 @@
+/**
+ * The fixed NIP-5B category/subcategory table and label validators.
+ *
+ * Per the NIP-5B spec (PR #2282 / 5B.md): a category label has the shape
+ * `napp.<category>:<subcategory>`. Clients SHOULD ignore unknown category/subcategory
+ * values, but OUR publisher rejects them at config-validation time so that authors fix
+ * typos before publishing a malformed App Listing event. This is a deliberate
+ * publisher-side strictness choice, not a deviation from the spec's client guidance.
+ *
+ * Subcategories are stored verbatim, including multi-word values such as
+ * "text editor", "image editor", "audio editor", and "video editor".
+ */
+
+/** Maximum number of category labels allowed on a napp listing. */
+export const MAX_NAPP_CATEGORIES = 3;
+
+/** The fixed NIP-5B category -> subcategory table. */
+export const NAPP_CATEGORIES: Record<string, readonly string[]> = {
+  other: ["other"],
+  games: [
+    "other",
+    "action",
+    "rpg",
+    "strategy",
+    "shooter",
+    "fighting",
+    "simulation",
+    "puzzle",
+    "board",
+    "gambling",
+    "racing",
+    "sports",
+    "ar",
+    "vr",
+  ],
+  money: [
+    "other",
+    "crypto",
+    "loans",
+    "investments",
+    "wallet",
+    "gambling",
+    "raffle",
+    "crowdfunding",
+    "donation",
+    "jobs",
+  ],
+  shopping: ["other", "marketplace", "store", "auction"],
+  social: ["other", "network", "messenger", "blog", "dating"],
+  audiovisual: ["other", "podcast", "music", "video", "news"],
+  utilities: [
+    "other",
+    "weather",
+    "office",
+    "finances",
+    "learning",
+    "text editor",
+    "image editor",
+    "audio editor",
+    "video editor",
+    "ar",
+    "vr",
+    "ai",
+  ],
+};
+
+const LABEL_SHAPE = /^napp\.[^:]+:[^:]+$/;
+
+/**
+ * Validate a single `napp.<category>:<subcategory>` label against the fixed table.
+ * Returns `null` when valid, otherwise a clear error message that names the offending
+ * category or subcategory.
+ */
+export function validateCategoryLabel(label: string): string | null {
+  if (!label.startsWith("napp.")) {
+    return `Category label "${label}" must start with "napp." (format: napp.<category>:<subcategory>)`;
+  }
+  if (!LABEL_SHAPE.test(label)) {
+    return `Category label "${label}" must match napp.<category>:<subcategory>`;
+  }
+
+  const body = label.slice("napp.".length);
+  const sepIndex = body.indexOf(":");
+  const category = body.slice(0, sepIndex);
+  const subcategory = body.slice(sepIndex + 1);
+
+  const subcategories = NAPP_CATEGORIES[category];
+  if (!subcategories) {
+    return `Unknown napp category "${category}" in label "${label}"`;
+  }
+  if (!subcategories.includes(subcategory)) {
+    return `Unknown napp subcategory "${subcategory}" for category "${category}" in label "${label}"`;
+  }
+
+  return null;
+}
+
+/**
+ * Validate an array of category labels.
+ * Returns an array of error strings (empty when all valid):
+ *  - empty array -> "at least one category is required"
+ *  - more than MAX_NAPP_CATEGORIES -> a limit error mentioning the limit and the count
+ *  - then accumulates per-label errors from validateCategoryLabel.
+ */
+export function validateCategories(labels: string[]): string[] {
+  const errors: string[] = [];
+
+  if (labels.length === 0) {
+    errors.push("at least one category is required");
+    return errors;
+  }
+
+  if (labels.length > MAX_NAPP_CATEGORIES) {
+    errors.push(
+      `too many categories: ${labels.length} provided, at most ${MAX_NAPP_CATEGORIES} allowed`,
+    );
+  }
+
+  for (const label of labels) {
+    const err = validateCategoryLabel(label);
+    if (err) errors.push(err);
+  }
+
+  return errors;
+}

--- a/src/lib/napp/detect.ts
+++ b/src/lib/napp/detect.ts
@@ -53,10 +53,16 @@ function validateAsset(
     return;
   }
   if (!isNonEmptyString(value.hash)) {
-    errors.push({ path: `${path}/hash`, message: "must be a non-empty string" });
+    errors.push({
+      path: `${path}/hash`,
+      message: "must be a non-empty string",
+    });
   }
   if (!isNonEmptyString(value.mime)) {
-    errors.push({ path: `${path}/mime`, message: "must be a non-empty string" });
+    errors.push({
+      path: `${path}/mime`,
+      message: "must be a non-empty string",
+    });
   }
   if (
     value.country !== undefined &&
@@ -101,8 +107,14 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
   // categories (required string[])
   if (napp.categories === undefined) {
     errors.push({ path: "/napp/categories", message: "is required" });
-  } else if (!Array.isArray(napp.categories) || !napp.categories.every((c) => typeof c === "string")) {
-    errors.push({ path: "/napp/categories", message: "must be an array of strings" });
+  } else if (
+    !Array.isArray(napp.categories) ||
+    !napp.categories.every((c) => typeof c === "string")
+  ) {
+    errors.push({
+      path: "/napp/categories",
+      message: "must be an array of strings",
+    });
   } else {
     for (const msg of validateCategories(napp.categories)) {
       errors.push({ path: "/napp/categories", message: msg });
@@ -113,18 +125,25 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
   if (napp.countries === undefined) {
     errors.push({ path: "/napp/countries", message: "is required" });
   } else if (
-    !Array.isArray(napp.countries) || !napp.countries.every((c) => typeof c === "string")
+    !Array.isArray(napp.countries) ||
+    !napp.countries.every((c) => typeof c === "string")
   ) {
-    errors.push({ path: "/napp/countries", message: "must be an array of strings" });
+    errors.push({
+      path: "/napp/countries",
+      message: "must be an array of strings",
+    });
   } else {
     const countries = napp.countries as string[];
     const hasWildcard = countries.includes("*");
     if (countries.length === 0) {
       errors.push({
         path: "/napp/countries",
-        message: 'must be ["*"] (worldwide) or at least one ISO 3166-1 alpha-2 code',
+        message:
+          'must be ["*"] (worldwide) or at least one ISO 3166-1 alpha-2 code',
       });
-    } else if (hasWildcard && !(countries.length === 1 && countries[0] === "*")) {
+    } else if (
+      hasWildcard && !(countries.length === 1 && countries[0] === "*")
+    ) {
       errors.push({
         path: "/napp/countries",
         message: 'cannot mix "*" (worldwide) with specific country codes',
@@ -132,7 +151,8 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
     } else if (!hasWildcard && !countries.every((c) => ALPHA2.test(c))) {
       errors.push({
         path: "/napp/countries",
-        message: "each entry must be a 2-letter ISO 3166-1 alpha-2 code (or use [\"*\"])",
+        message:
+          'each entry must be a 2-letter ISO 3166-1 alpha-2 code (or use ["*"])',
       });
     }
   }
@@ -140,7 +160,10 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
   // self (optional 64-hex)
   if (napp.self !== undefined) {
     if (!(typeof napp.self === "string" && HEX64.test(napp.self))) {
-      errors.push({ path: "/napp/self", message: "must be a 64-character hex pubkey" });
+      errors.push({
+        path: "/napp/self",
+        message: "must be a 64-character hex pubkey",
+      });
     }
   }
 
@@ -170,8 +193,14 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
 
   // tags (optional string[])
   if (napp.tags !== undefined) {
-    if (!Array.isArray(napp.tags) || !napp.tags.every((t) => typeof t === "string")) {
-      errors.push({ path: "/napp/tags", message: "must be an array of strings" });
+    if (
+      !Array.isArray(napp.tags) ||
+      !napp.tags.every((t) => typeof t === "string")
+    ) {
+      errors.push({
+        path: "/napp/tags",
+        message: "must be an array of strings",
+      });
     }
   }
 

--- a/src/lib/napp/detect.ts
+++ b/src/lib/napp/detect.ts
@@ -1,0 +1,188 @@
+/**
+ * napp detection + structural validation.
+ *
+ * NOTE on the error type: config-validator.ts will import `validateNappConfig` from
+ * this module (Task 3 wiring). Importing `ValidationError` back from config-validator.ts
+ * would create a module cycle, so we define a local structurally-identical alias here.
+ * It matches `{ path: string; message: string }` exactly, so the errors returned by
+ * `validateNappConfig` slot straight into the validator's `errors` array.
+ */
+import type { NappConfig } from "./types.ts";
+import { validateCategories } from "./categories.ts";
+
+/** Identical shape to config-validator.ts ValidationError (kept local to avoid a cycle). */
+export interface ValidationError {
+  path: string;
+  message: string;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+/** Validate a `{ value: string; lang?: string }` shape at the given path. */
+function validateLangText(
+  value: unknown,
+  path: string,
+  errors: ValidationError[],
+): void {
+  if (!isObject(value)) {
+    errors.push({ path, message: "must be an object with a string 'value'" });
+    return;
+  }
+  if (!isNonEmptyString(value.value)) {
+    errors.push({ path, message: "'value' must be a non-empty string" });
+  }
+  if (value.lang !== undefined && typeof value.lang !== "string") {
+    errors.push({ path, message: "'lang' must be a string when present" });
+  }
+}
+
+/** Validate a NappAsset (`{ hash, mime, country? }`) shape at the given path. */
+function validateAsset(
+  value: unknown,
+  path: string,
+  errors: ValidationError[],
+): void {
+  if (!isObject(value)) {
+    errors.push({ path, message: "must be an object with 'hash' and 'mime'" });
+    return;
+  }
+  if (!isNonEmptyString(value.hash)) {
+    errors.push({ path: `${path}/hash`, message: "must be a non-empty string" });
+  }
+  if (!isNonEmptyString(value.mime)) {
+    errors.push({ path: `${path}/mime`, message: "must be a non-empty string" });
+  }
+  if (
+    value.country !== undefined &&
+    !(typeof value.country === "string" && /^[A-Za-z]{2}$/.test(value.country))
+  ) {
+    errors.push({
+      path: `${path}/country`,
+      message: "must be a 2-letter ISO 3166-1 alpha-2 code when present",
+    });
+  }
+}
+
+const HEX64 = /^[0-9a-fA-F]{64}$/;
+const ALPHA2 = /^[A-Za-z]{2}$/;
+
+/**
+ * Structurally validate a napp section. Returns an array of errors (empty = valid).
+ * This is intentionally stricter than the JSON schema: it enforces the deep NIP-5B
+ * category table and the countries `*`-vs-codes rule that the schema pattern can't.
+ */
+export function validateNappConfig(napp: unknown): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  if (!isObject(napp)) {
+    return [{ path: "/napp", message: "must be an object" }];
+  }
+
+  // name (required LangText)
+  if (napp.name === undefined) {
+    errors.push({ path: "/napp/name", message: "is required" });
+  } else {
+    validateLangText(napp.name, "/napp/name", errors);
+  }
+
+  // icon (required asset)
+  if (napp.icon === undefined) {
+    errors.push({ path: "/napp/icon", message: "is required" });
+  } else {
+    validateAsset(napp.icon, "/napp/icon", errors);
+  }
+
+  // categories (required string[])
+  if (napp.categories === undefined) {
+    errors.push({ path: "/napp/categories", message: "is required" });
+  } else if (!Array.isArray(napp.categories) || !napp.categories.every((c) => typeof c === "string")) {
+    errors.push({ path: "/napp/categories", message: "must be an array of strings" });
+  } else {
+    for (const msg of validateCategories(napp.categories)) {
+      errors.push({ path: "/napp/categories", message: msg });
+    }
+  }
+
+  // countries (required string[]: exactly ["*"] OR non-empty alpha-2 list)
+  if (napp.countries === undefined) {
+    errors.push({ path: "/napp/countries", message: "is required" });
+  } else if (
+    !Array.isArray(napp.countries) || !napp.countries.every((c) => typeof c === "string")
+  ) {
+    errors.push({ path: "/napp/countries", message: "must be an array of strings" });
+  } else {
+    const countries = napp.countries as string[];
+    const hasWildcard = countries.includes("*");
+    if (countries.length === 0) {
+      errors.push({
+        path: "/napp/countries",
+        message: 'must be ["*"] (worldwide) or at least one ISO 3166-1 alpha-2 code',
+      });
+    } else if (hasWildcard && !(countries.length === 1 && countries[0] === "*")) {
+      errors.push({
+        path: "/napp/countries",
+        message: 'cannot mix "*" (worldwide) with specific country codes',
+      });
+    } else if (!hasWildcard && !countries.every((c) => ALPHA2.test(c))) {
+      errors.push({
+        path: "/napp/countries",
+        message: "each entry must be a 2-letter ISO 3166-1 alpha-2 code (or use [\"*\"])",
+      });
+    }
+  }
+
+  // self (optional 64-hex)
+  if (napp.self !== undefined) {
+    if (!(typeof napp.self === "string" && HEX64.test(napp.self))) {
+      errors.push({ path: "/napp/self", message: "must be a 64-character hex pubkey" });
+    }
+  }
+
+  // summary / description (optional LangText)
+  if (napp.summary !== undefined) {
+    validateLangText(napp.summary, "/napp/summary", errors);
+  }
+  if (napp.description !== undefined) {
+    validateLangText(napp.description, "/napp/description", errors);
+  }
+
+  // keyart (optional asset)
+  if (napp.keyart !== undefined) {
+    validateAsset(napp.keyart, "/napp/keyart", errors);
+  }
+
+  // screenshots (optional asset[])
+  if (napp.screenshots !== undefined) {
+    if (!Array.isArray(napp.screenshots)) {
+      errors.push({ path: "/napp/screenshots", message: "must be an array" });
+    } else {
+      napp.screenshots.forEach((shot, i) => {
+        validateAsset(shot, `/napp/screenshots/${i}`, errors);
+      });
+    }
+  }
+
+  // tags (optional string[])
+  if (napp.tags !== undefined) {
+    if (!Array.isArray(napp.tags) || !napp.tags.every((t) => typeof t === "string")) {
+      errors.push({ path: "/napp/tags", message: "must be an array of strings" });
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Returns true iff `config` is an object with a `napp` property AND that napp section is
+ * structurally valid. This guarantees `isNapp` is true ONLY for valid napp listings.
+ */
+export function isNapp(config: unknown): config is { napp: NappConfig } {
+  if (!isObject(config) || config.napp === undefined) return false;
+  return validateNappConfig(config.napp).length === 0;
+}

--- a/src/lib/napp/detect.ts
+++ b/src/lib/napp/detect.ts
@@ -77,6 +77,7 @@ function validateAsset(
 
 const HEX64 = /^[0-9a-fA-F]{64}$/;
 const ALPHA2 = /^[A-Za-z]{2}$/;
+const RELAY_URL = /^wss?:\/\//;
 
 /**
  * Structurally validate a napp section. Returns an array of errors (empty = valid).
@@ -138,8 +139,7 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
     if (countries.length === 0) {
       errors.push({
         path: "/napp/countries",
-        message:
-          'must be ["*"] (worldwide) or at least one ISO 3166-1 alpha-2 code',
+        message: 'must be ["*"] (worldwide) or at least one ISO 3166-1 alpha-2 code',
       });
     } else if (
       hasWildcard && !(countries.length === 1 && countries[0] === "*")
@@ -151,8 +151,7 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
     } else if (!hasWildcard && !countries.every((c) => ALPHA2.test(c))) {
       errors.push({
         path: "/napp/countries",
-        message:
-          'each entry must be a 2-letter ISO 3166-1 alpha-2 code (or use ["*"])',
+        message: 'each entry must be a 2-letter ISO 3166-1 alpha-2 code (or use ["*"])',
       });
     }
   }
@@ -200,6 +199,19 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
       errors.push({
         path: "/napp/tags",
         message: "must be an array of strings",
+      });
+    }
+  }
+
+  // indexerRelays (optional ws/wss relay URL strings)
+  if (napp.indexerRelays !== undefined) {
+    if (
+      !Array.isArray(napp.indexerRelays) ||
+      !napp.indexerRelays.every((relay) => typeof relay === "string" && RELAY_URL.test(relay))
+    ) {
+      errors.push({
+        path: "/napp/indexerRelays",
+        message: "must be an array of ws:// or wss:// relay URLs",
       });
     }
   }

--- a/src/lib/napp/identifier.ts
+++ b/src/lib/napp/identifier.ts
@@ -16,19 +16,13 @@
  * so it CANNOT be encoded — the `napp id` command rejects it (see src/commands/napp.ts).
  * Relay hints are optional; decode MUST tolerate zero relays.
  */
-import {
-  bytesToHex,
-  bytesToUtf8,
-  hexToBytes,
-  utf8ToBytes,
-} from "@noble/hashes/utils";
+import { bytesToHex, bytesToUtf8, hexToBytes, utf8ToBytes } from "@noble/hashes/utils";
 
 // ---------------------------------------------------------------------------
 // base62 — verbatim port
 // ---------------------------------------------------------------------------
 
-export const BASE62_ALPHABET =
-  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+export const BASE62_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 const BASE = 62n;
 const LEADER = "0";
@@ -190,6 +184,11 @@ export function appDecode(
 
   const base62 = entity.slice(prefix.length);
   const tlv = tlvToObj(base62ToBytes(base62));
+
+  // TLV types 0 (dTag) and 2 (pubkey) are REQUIRED. Guard before indexing so a malformed
+  // identifier yields a clear validation error rather than a raw TypeError on `tlv[t][0]`.
+  if (!tlv[0]?.[0]) throw new Error("invalid app identifier: missing d tag (TLV type 0)");
+  if (!tlv[2]?.[0]) throw new Error("invalid app identifier: missing pubkey (TLV type 2)");
 
   const dTag = bytesToUtf8(tlv[0][0]);
   const pkBytes = tlv[2][0];

--- a/src/lib/napp/identifier.ts
+++ b/src/lib/napp/identifier.ts
@@ -1,0 +1,226 @@
+/**
+ * NIP-5B base-62 `+`-prefixed TLV app identifier (encode + decode).
+ *
+ * FAITHFUL PORT of the 44Billion/nappup reference (the spec's cited implementation).
+ * Byte-for-byte INTEROP is the requirement here, NOT algorithmic elegance — do NOT
+ * "improve" or normalize the algorithm. Any deviation breaks interop with every other
+ * NIP-5B client. The shape of the port is fixed:
+ *   - base62 alphabet order is `0-9a-zA-Z`
+ *   - the byte array is treated as ONE big-endian bigint (whole-array, not per-byte)
+ *   - each leading 0x00 byte becomes one leading '0' (LEADER) char, and vice versa
+ *   - TLV type order is REVERSED before serialization (T2 pubkey, T1 relays, T0 dTag)
+ *   - channel '+' => kind 35128 (main), '++' => 35129 (next), '+++' => 35130 (draft)
+ *
+ * nsyte scoping decision: nsyte publishes NAMED sites (kind 35128, channel main,
+ * prefix "+"). A ROOT site (kind 15128) has NO `d` tag and is NOT in `kindByChannel`,
+ * so it CANNOT be encoded — the `napp id` command rejects it (see src/commands/napp.ts).
+ * Relay hints are optional; decode MUST tolerate zero relays.
+ */
+import { bytesToHex, bytesToUtf8, hexToBytes, utf8ToBytes } from "@noble/hashes/utils";
+
+// ---------------------------------------------------------------------------
+// base62 — verbatim port
+// ---------------------------------------------------------------------------
+
+export const BASE62_ALPHABET =
+  "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+const BASE = 62n;
+const LEADER = "0";
+
+/**
+ * Encode a byte array as a base62 string. The whole array is interpreted as one
+ * big-endian bigint; leading 0x00 bytes are preserved as leading LEADER chars.
+ */
+export function bytesToBase62(bytes: Uint8Array): string {
+  let num = 0n;
+  for (const b of bytes) {
+    num = (num << 8n) + BigInt(b);
+  }
+
+  let out = "";
+  while (num > 0n) {
+    out = BASE62_ALPHABET[Number(num % BASE)] + out;
+    num = num / BASE;
+  }
+
+  // Preserve each leading zero byte as one leader char.
+  for (let i = 0; i < bytes.length && bytes[i] === 0; i++) {
+    out = LEADER + out;
+  }
+
+  return out;
+}
+
+/**
+ * Decode a base62 string back to the original byte array. Leading LEADER chars are
+ * restored as leading 0x00 bytes.
+ */
+export function base62ToBytes(str: string): Uint8Array {
+  let leadingZeros = 0;
+  while (leadingZeros < str.length && str[leadingZeros] === LEADER) {
+    leadingZeros++;
+  }
+
+  let num = 0n;
+  for (const ch of str.slice(leadingZeros)) {
+    const idx = BASE62_ALPHABET.indexOf(ch);
+    if (idx < 0) throw new Error("invalid base62 char");
+    num = num * BASE + BigInt(idx);
+  }
+
+  const tail: number[] = [];
+  while (num > 0n) {
+    tail.unshift(Number(num & 0xffn));
+    num >>= 8n;
+  }
+
+  const out = new Uint8Array(leadingZeros + tail.length);
+  out.set(tail, leadingZeros);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// TLV — verbatim port (CRITICAL: type order is REVERSED before serialization)
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize TLV values. Input is indexed: [0]=dTag values, [1]=relay values,
+ * [2]=pubkey values. The [index, vals] pairs are REVERSED so the serialized byte
+ * order becomes type 2 (pubkey), type 1 (relays), type 0 (dTag).
+ */
+function toTlv(values: Uint8Array[][]): Uint8Array {
+  const pairs: Array<[number, Uint8Array[]]> = values.map((vals, index) => [index, vals]);
+  pairs.reverse();
+
+  const chunks: Uint8Array[] = [];
+  for (const [type, vals] of pairs) {
+    for (const value of vals) {
+      if (value.length === 0) continue;
+      if (value.length > 255) throw new Error("TLV value too long");
+      chunks.push(Uint8Array.of(type, value.length, ...value));
+    }
+  }
+
+  const total = chunks.reduce((n, c) => n + c.length, 0);
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+/** Walk a serialized TLV buffer back into a `{ type: values[] }` map. */
+function tlvToObj(bytes: Uint8Array): Record<number, Uint8Array[]> {
+  const obj: Record<number, Uint8Array[]> = {};
+  let i = 0;
+  while (i + 1 < bytes.length) {
+    const t = bytes[i];
+    const l = bytes[i + 1];
+    const v = bytes.slice(i + 2, i + 2 + l);
+    i += 2 + l;
+    (obj[t] ??= []).push(v);
+  }
+  return obj;
+}
+
+// ---------------------------------------------------------------------------
+// Channels
+// ---------------------------------------------------------------------------
+
+const kindByChannel = { main: 35128, next: 35129, draft: 35130 };
+const prefixByChannel: Record<string, string> = { main: "+", next: "++", draft: "+++" };
+const channelByPrefix: Record<string, string> = { "+": "main", "++": "next", "+++": "draft" };
+
+// ---------------------------------------------------------------------------
+// Low-level encode / decode
+// ---------------------------------------------------------------------------
+
+export function appEncode(
+  ref: { dTag: string; pubkey: string; kind: number; relays?: string[]; channel?: string },
+): string {
+  const channel = ref.channel ||
+    (Object.entries(kindByChannel).find(([, k]) => k === ref.kind)?.[0]);
+  if (!channel) throw new Error("Wrong channel");
+  if (ref.dTag.length > 260) throw new Error("dTag too long");
+
+  const tlv = toTlv([
+    [utf8ToBytes(ref.dTag)],
+    (ref.relays ?? []).map(utf8ToBytes),
+    [hexToBytes(ref.pubkey)],
+  ]);
+
+  return prefixByChannel[channel] + bytesToBase62(tlv);
+}
+
+export function appDecode(
+  entity: string,
+): { dTag: string; pubkey: string; relays: string[]; kind: number } {
+  let prefixLen = 0;
+  while (prefixLen < entity.length && entity[prefixLen] === "+") {
+    prefixLen++;
+  }
+  const prefix = entity.slice(0, prefixLen);
+  const channel = channelByPrefix[prefix];
+  if (!channel) throw new Error("Wrong channel");
+
+  const base62 = entity.slice(prefix.length);
+  const tlv = tlvToObj(base62ToBytes(base62));
+
+  const dTag = bytesToUtf8(tlv[0][0]);
+  const pkBytes = tlv[2][0];
+  if (pkBytes.length !== 32) throw new Error("invalid pubkey length");
+  const pubkey = bytesToHex(pkBytes);
+  const relays = (tlv[1] ?? []).map(bytesToUtf8);
+  const kind = kindByChannel[channel as keyof typeof kindByChannel];
+
+  if (dTag.length > 260) throw new Error("dTag too long");
+
+  return { dTag, pubkey, relays, kind };
+}
+
+// ---------------------------------------------------------------------------
+// High-level wrappers (nsyte-facing API — default channel main / kind 35128)
+// ---------------------------------------------------------------------------
+
+export function nappIdentifier(
+  ref: { dTag: string; pubkey: string; relays?: string[] },
+): string {
+  return appEncode({
+    dTag: ref.dTag,
+    pubkey: ref.pubkey,
+    kind: kindByChannel.main,
+    relays: ref.relays ?? [],
+  });
+}
+
+export function decodeNappIdentifier(entity: string) {
+  return appDecode(entity);
+}
+
+// ---------------------------------------------------------------------------
+// Indexer relays (NAPP-ID-03)
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_NAPP_INDEXER_RELAYS = ["wss://relay.44billion.net"];
+
+/**
+ * Resolve the indexer relays an App Listing is published to. Returns the configured
+ * `napp.indexerRelays` array when it is a non-empty array, otherwise the default.
+ * Tolerates a non-object / non-napp config (returns the default).
+ */
+export function resolveIndexerRelays(
+  config: { napp?: { indexerRelays?: string[] } } | unknown,
+): string[] {
+  if (typeof config !== "object" || config === null) {
+    return DEFAULT_NAPP_INDEXER_RELAYS;
+  }
+  const napp = (config as { napp?: { indexerRelays?: string[] } }).napp;
+  const indexerRelays = napp?.indexerRelays;
+  if (Array.isArray(indexerRelays) && indexerRelays.length > 0) {
+    return indexerRelays;
+  }
+  return DEFAULT_NAPP_INDEXER_RELAYS;
+}

--- a/src/lib/napp/identifier.ts
+++ b/src/lib/napp/identifier.ts
@@ -16,7 +16,12 @@
  * so it CANNOT be encoded — the `napp id` command rejects it (see src/commands/napp.ts).
  * Relay hints are optional; decode MUST tolerate zero relays.
  */
-import { bytesToHex, bytesToUtf8, hexToBytes, utf8ToBytes } from "@noble/hashes/utils";
+import {
+  bytesToHex,
+  bytesToUtf8,
+  hexToBytes,
+  utf8ToBytes,
+} from "@noble/hashes/utils";
 
 // ---------------------------------------------------------------------------
 // base62 — verbatim port
@@ -90,7 +95,10 @@ export function base62ToBytes(str: string): Uint8Array {
  * order becomes type 2 (pubkey), type 1 (relays), type 0 (dTag).
  */
 function toTlv(values: Uint8Array[][]): Uint8Array {
-  const pairs: Array<[number, Uint8Array[]]> = values.map((vals, index) => [index, vals]);
+  const pairs: Array<[number, Uint8Array[]]> = values.map((
+    vals,
+    index,
+  ) => [index, vals]);
   pairs.reverse();
 
   const chunks: Uint8Array[] = [];
@@ -131,15 +139,29 @@ function tlvToObj(bytes: Uint8Array): Record<number, Uint8Array[]> {
 // ---------------------------------------------------------------------------
 
 const kindByChannel = { main: 35128, next: 35129, draft: 35130 };
-const prefixByChannel: Record<string, string> = { main: "+", next: "++", draft: "+++" };
-const channelByPrefix: Record<string, string> = { "+": "main", "++": "next", "+++": "draft" };
+const prefixByChannel: Record<string, string> = {
+  main: "+",
+  next: "++",
+  draft: "+++",
+};
+const channelByPrefix: Record<string, string> = {
+  "+": "main",
+  "++": "next",
+  "+++": "draft",
+};
 
 // ---------------------------------------------------------------------------
 // Low-level encode / decode
 // ---------------------------------------------------------------------------
 
 export function appEncode(
-  ref: { dTag: string; pubkey: string; kind: number; relays?: string[]; channel?: string },
+  ref: {
+    dTag: string;
+    pubkey: string;
+    kind: number;
+    relays?: string[];
+    channel?: string;
+  },
 ): string {
   const channel = ref.channel ||
     (Object.entries(kindByChannel).find(([, k]) => k === ref.kind)?.[0]);

--- a/src/lib/napp/listing.ts
+++ b/src/lib/napp/listing.ts
@@ -23,7 +23,12 @@ export const NSITE_APP_LISTING_KIND = 37348;
 export const NSITE_RELEASE_NOTE_KIND = 39108;
 
 /** Build an asset-style tag, dropping the trailing `country` element when undefined. */
-function assetTag(name: string, hash: string, mime: string, country?: string): string[] {
+function assetTag(
+  name: string,
+  hash: string,
+  mime: string,
+  country?: string,
+): string[] {
   return country ? [name, hash, mime, country] : [name, hash, mime];
 }
 
@@ -46,7 +51,9 @@ function langTag(name: string, value: string, lang?: string): string[] {
  *    which yields the d for named sites and "" for root sites.
  *  - a config-shaped object pre-publish (has `id`): returns `source.id ?? ""`.
  */
-export function deriveListingDTag(source: { id?: string | null } | NostrEvent): string {
+export function deriveListingDTag(
+  source: { id?: string | null } | NostrEvent,
+): string {
   // Signed manifest event branch: has a numeric kind and a tags array.
   if (
     typeof (source as NostrEvent).kind === "number" &&
@@ -96,7 +103,9 @@ export function createAppListingTemplate(
   tags.push(langTag("name", napp.name.value, napp.name.lang));
 
   // 3. icon (country optional).
-  tags.push(assetTag("icon", napp.icon.hash, napp.icon.mime, napp.icon.country));
+  tags.push(
+    assetTag("icon", napp.icon.hash, napp.icon.mime, napp.icon.country),
+  );
 
   // 4. one c tag per country ("*" worldwide -> a single ["c","*"]).
   for (const code of napp.countries) {
@@ -115,12 +124,21 @@ export function createAppListingTemplate(
 
   // 7. description.
   if (napp.description) {
-    tags.push(langTag("description", napp.description.value, napp.description.lang));
+    tags.push(
+      langTag("description", napp.description.value, napp.description.lang),
+    );
   }
 
   // 8. keyart.
   if (napp.keyart) {
-    tags.push(assetTag("keyart", napp.keyart.hash, napp.keyart.mime, napp.keyart.country));
+    tags.push(
+      assetTag(
+        "keyart",
+        napp.keyart.hash,
+        napp.keyart.mime,
+        napp.keyart.country,
+      ),
+    );
   }
 
   // 9. one screenshot per entry, in order.

--- a/src/lib/napp/listing.ts
+++ b/src/lib/napp/listing.ts
@@ -1,0 +1,165 @@
+/**
+ * NIP-5B napp App Listing event (kind 37348).
+ *
+ * This module is the single home for the napp event kinds and the pure builder that
+ * maps a validated `NappConfig` plus the website manifest's `d` tag into a fully-tagged
+ * kind-37348 App Listing event. It mirrors the structure of `createSiteManifestTemplate`
+ * / `createSiteManifestEvent` in `../manifest.ts` and `../nostr.ts`: a pure template
+ * builder plus a thin signing wrapper.
+ */
+import type { EventTemplate, NostrEvent } from "applesauce-core/helpers";
+import type { ISigner } from "applesauce-signers";
+import type { NappConfig } from "./types.ts";
+import { getManifestIdentifier, NSITE_NAME_SITE_KIND } from "../manifest.ts";
+
+/** NIP-5B App Listing — addressable / parameterized-replaceable event. */
+export const NSITE_APP_LISTING_KIND = 37348;
+
+/**
+ * NIP-5B Release Note kind. Reserved here (the single home for napp kinds) so the
+ * NIP-46 signing permissions can authorize it now. Phase 23 builds the actual 39108
+ * event; this phase does NOT construct any release-note event.
+ */
+export const NSITE_RELEASE_NOTE_KIND = 39108;
+
+/** Build an asset-style tag, dropping the trailing `country` element when undefined. */
+function assetTag(name: string, hash: string, mime: string, country?: string): string[] {
+  return country ? [name, hash, mime, country] : [name, hash, mime];
+}
+
+/** Build a localizable-text tag, dropping the trailing `lang` element when undefined. */
+function langTag(name: string, value: string, lang?: string): string[] {
+  return lang ? [name, value, lang] : [name, value];
+}
+
+/**
+ * Derive the shared `d` tag for the App Listing — the SINGLE SOURCE OF TRUTH so the
+ * listing's `d` tag never drifts from the website manifest's `d` tag (T-21-01).
+ *
+ * CRITICAL d-tag rule: the website manifest only carries a `d` tag for NAMED sites
+ * (kind 35128, where d = config.id). ROOT sites (kind 15128) are plain replaceable
+ * events with NO `d` tag, so a root-site napp shares an EMPTY-STRING `d` tag — a valid
+ * addressable-event `d`, matching NIP-5A root addressing.
+ *
+ * Two input shapes are accepted:
+ *  - a signed manifest event (has `kind` + `tags`): returns `getManifestIdentifier(...) ?? ""`,
+ *    which yields the d for named sites and "" for root sites.
+ *  - a config-shaped object pre-publish (has `id`): returns `source.id ?? ""`.
+ */
+export function deriveListingDTag(source: { id?: string | null } | NostrEvent): string {
+  // Signed manifest event branch: has a numeric kind and a tags array.
+  if (
+    typeof (source as NostrEvent).kind === "number" &&
+    Array.isArray((source as NostrEvent).tags)
+  ) {
+    const event = source as NostrEvent;
+    // Named sites (35128) carry the d tag; root sites (15128) have none.
+    // getManifestIdentifier(root) ?? "" already returns "", so the kind guard is
+    // only for clarity.
+    if (event.kind === NSITE_NAME_SITE_KIND) {
+      return getManifestIdentifier(event) ?? "";
+    }
+    return getManifestIdentifier(event) ?? "";
+  }
+
+  // Config-shaped object branch (pre-publish): the deploy/dry-run path has config in hand.
+  return (source as { id?: string | null }).id ?? "";
+}
+
+/**
+ * PURE App Listing template builder (mirror of `createSiteManifestTemplate`).
+ *
+ * Tags are emitted in a deterministic order (matters for tests/snapshots):
+ *   1. d (always; "" allowed for root)  2. name  3. icon  4. one c per country
+ *   5. self (only if configured)  6. summary  7. description  8. keyart
+ *   9. one screenshot per entry  10. one l per category  11. one t per free tag
+ *   12. client.
+ *
+ * The `pubkey` parameter is accepted for signature symmetry with `createAppListingEvent`
+ * / `createSiteManifestEvent`. It is intentionally NOT used to default `self`: `self` is
+ * emitted ONLY when explicitly configured — never auto-defaulted to the author pubkey
+ * (T-21-02). `manifestDTag` MUST equal the website manifest's `d` tag; callers derive it
+ * via `deriveListingDTag(...)`.
+ */
+export function createAppListingTemplate(
+  _pubkey: string,
+  napp: NappConfig,
+  manifestDTag: string,
+  createdAt?: number,
+): EventTemplate {
+  const tags: string[][] = [];
+
+  // 1. d — ALWAYS emitted (empty string allowed for root-site napps).
+  tags.push(["d", manifestDTag]);
+
+  // 2. name (lang optional).
+  tags.push(langTag("name", napp.name.value, napp.name.lang));
+
+  // 3. icon (country optional).
+  tags.push(assetTag("icon", napp.icon.hash, napp.icon.mime, napp.icon.country));
+
+  // 4. one c tag per country ("*" worldwide -> a single ["c","*"]).
+  for (const code of napp.countries) {
+    tags.push(["c", code]);
+  }
+
+  // 5. self — ONLY when explicitly configured (never default to the author pubkey).
+  if (napp.self) {
+    tags.push(["self", napp.self]);
+  }
+
+  // 6. summary.
+  if (napp.summary) {
+    tags.push(langTag("summary", napp.summary.value, napp.summary.lang));
+  }
+
+  // 7. description.
+  if (napp.description) {
+    tags.push(langTag("description", napp.description.value, napp.description.lang));
+  }
+
+  // 8. keyart.
+  if (napp.keyart) {
+    tags.push(assetTag("keyart", napp.keyart.hash, napp.keyart.mime, napp.keyart.country));
+  }
+
+  // 9. one screenshot per entry, in order.
+  for (const shot of napp.screenshots ?? []) {
+    tags.push(assetTag("screenshot", shot.hash, shot.mime, shot.country));
+  }
+
+  // 10. one l tag per category label.
+  for (const label of napp.categories) {
+    tags.push(["l", label]);
+  }
+
+  // 11. one t tag per free-form tag.
+  for (const tag of napp.tags ?? []) {
+    tags.push(["t", tag]);
+  }
+
+  // 12. client (mirror the manifest/handler builders).
+  tags.push(["client", "nsyte"]);
+
+  return {
+    kind: NSITE_APP_LISTING_KIND,
+    created_at: createdAt ?? Math.floor(Date.now() / 1000),
+    tags,
+    content: "",
+  };
+}
+
+/**
+ * Thin signing wrapper — mirrors `createSiteManifestEvent`.
+ */
+export async function createAppListingEvent(
+  signer: ISigner,
+  pubkey: string,
+  napp: NappConfig,
+  manifestDTag: string,
+  createdAt?: number,
+): Promise<NostrEvent> {
+  return await signer.signEvent(
+    createAppListingTemplate(pubkey, napp, manifestDTag, createdAt),
+  );
+}

--- a/src/lib/napp/release.ts
+++ b/src/lib/napp/release.ts
@@ -1,0 +1,110 @@
+/**
+ * NIP-5B napp Release Note event (kind 39108).
+ *
+ * This module builds the NIP-5B Release Note — a changelog for ONE app version, where the
+ * "app version" is pinned to the website manifest's EVENT id. It mirrors the structure of
+ * `createAppListingTemplate` / `createAppListingEvent` in `./listing.ts`: a pure template
+ * builder plus a thin signing wrapper.
+ *
+ * SPEC DISCREPANCY (recorded here and in `.planning/milestones/v1.6-REQUIREMENTS.md`):
+ * the NIP-5B event-DEFINITION example uses kind **39108**, but the spec's REQ example reads
+ * `"kinds":[31908]`. We use **39108** — the event definition is authoritative — and treat
+ * the 31908 in the REQ example as a transposition typo. Both literals (39108, 31908) are
+ * named here so the discrepancy stays discoverable in code.
+ */
+import type { EventTemplate, NostrEvent } from "applesauce-core/helpers";
+import type { ISigner } from "applesauce-signers";
+import { NSITE_RELEASE_NOTE_KIND } from "./listing.ts";
+
+// Re-export the SINGLE 39108 definition (listing.ts is the home for napp kinds) so
+// consumers can import the kind from either module without redefining the literal (DRY).
+export { NSITE_RELEASE_NOTE_KIND } from "./listing.ts";
+
+/** Seconds in one week — the `w` tag bucket width. */
+export const SECONDS_IN_WEEK = 604800;
+
+/** Floor a unix timestamp into its week bucket (the `w` tag value). */
+export function weekBucket(ts: number): number {
+  return Math.floor(ts / SECONDS_IN_WEEK);
+}
+
+/**
+ * Structured changelog entries for a release note. Each category maps to a tag name
+ * (`fix`/`add`/`try`/`cut`/`sub`); every string in an array becomes one tag.
+ *
+ * `sub` is the generic "substitute/changed" entry — used when the author does not
+ * distinguish fix/add/try/cut.
+ */
+export interface ReleaseChanges {
+  fix?: string[];
+  add?: string[];
+  try?: string[];
+  cut?: string[];
+  sub?: string[];
+}
+
+/** Fixed category iteration order so emitted tags are deterministic (matters for tests). */
+const CHANGE_CATEGORIES = ["fix", "add", "try", "cut", "sub"] as const;
+
+/**
+ * PURE Release Note template builder.
+ *
+ * Tags are emitted in a deterministic order:
+ *   1. d  — the website manifest's EVENT id (this release note's addressable d value,
+ *           distinct per app version).
+ *   2. D  — the website manifest's `d` tag (`config.id ?? ""`, same value the listing uses).
+ *   3. ts — the manifest's created_at, as a STRING.
+ *   4. w  — floor(created_at / 604800), as a STRING (week bucket).
+ *   5. change entries — iterated in fixed category order, one `[category, text]` per entry,
+ *      preserving array order; undefined/empty categories are skipped.
+ *
+ * d vs D are INTENTIONALLY different: d = manifest EVENT id, D = manifest `d` tag. See the
+ * d-tag note in `.planning/milestones/v1.6-REQUIREMENTS.md`.
+ */
+export function createReleaseNoteTemplate(params: {
+  manifestId: string;
+  manifestDTag: string;
+  manifestCreatedAt: number;
+  changes: ReleaseChanges;
+  createdAt?: number;
+}): EventTemplate {
+  const { manifestId, manifestDTag, manifestCreatedAt, changes } = params;
+
+  const tags: string[][] = [];
+
+  // d = manifest EVENT id; D = manifest `d` tag — intentionally different (REQUIREMENTS.md).
+  tags.push(["d", manifestId]);
+  tags.push(["D", manifestDTag]);
+  tags.push(["ts", String(manifestCreatedAt)]);
+  tags.push(["w", String(weekBucket(manifestCreatedAt))]);
+
+  // Change entries: one tag per text, fixed category order, preserving array order.
+  for (const category of CHANGE_CATEGORIES) {
+    const entries = changes[category];
+    if (!entries) continue;
+    for (const text of entries) {
+      tags.push([category, text]);
+    }
+  }
+
+  return {
+    kind: NSITE_RELEASE_NOTE_KIND,
+    created_at: params.createdAt ?? Math.floor(Date.now() / 1000),
+    tags,
+    content: "",
+  };
+}
+
+/** Thin signing wrapper — mirrors `createAppListingEvent`. */
+export async function createReleaseNoteEvent(
+  signer: ISigner,
+  params: {
+    manifestId: string;
+    manifestDTag: string;
+    manifestCreatedAt: number;
+    changes: ReleaseChanges;
+    createdAt?: number;
+  },
+): Promise<NostrEvent> {
+  return await signer.signEvent(createReleaseNoteTemplate(params));
+}

--- a/src/lib/napp/types.ts
+++ b/src/lib/napp/types.ts
@@ -1,0 +1,66 @@
+/**
+ * NIP-5B napp ("nostr app") config types.
+ *
+ * Design decision: the "value + optional language" pattern (used for human-readable
+ * fields like name/summary/description) is modeled as a `{ value: string; lang?: string }`
+ * object (`LangText`) rather than a tuple. This round-trips cleanly to nostr tags — a
+ * `["name", value, lang?]` tag simply drops the third element when `lang` is undefined —
+ * and is self-describing when serialized to JSON in `.nsite/config.json`.
+ *
+ * camelCase is used throughout to match the existing nsyte config style.
+ */
+
+/** A localizable text value. `lang` is an ISO 639-1 language code (e.g. "en", "de"). */
+export interface LangText {
+  value: string;
+  lang?: string;
+}
+
+/**
+ * An image/media asset reference used for `icon`, `keyart`, and `screenshots` entries.
+ * - `hash`: a sha256/blossom hash OR a URL pointing at the asset.
+ * - `mime`: the asset's MIME type (e.g. "image/png").
+ * - `country`: optional ISO 3166-1 alpha-2 code, for region-specific assets.
+ */
+export interface NappAsset {
+  hash: string;
+  mime: string;
+  country?: string;
+}
+
+/**
+ * The optional NIP-5B napp listing section of a project config.
+ *
+ * Present (and structurally valid) => the project is a napp; see `isNapp()` in `./detect.ts`.
+ *
+ * NOTE: `indexerRelays` is intentionally deferred to Phase 22 to keep this foundation
+ * phase minimal — do NOT add it here.
+ */
+export interface NappConfig {
+  /** Display name of the app. */
+  name: LangText;
+  /** App icon asset. */
+  icon: NappAsset;
+  /**
+   * `napp.<category>:<subcategory>` labels. Min 1, max 3.
+   * Validated against the fixed NIP-5B table in `./categories.ts`.
+   */
+  categories: string[];
+  /**
+   * Availability: either `["*"]` (worldwide) or a list of ISO 3166-1 alpha-2
+   * codes. Maps to `c` tags on the published event later.
+   */
+  countries: string[];
+  /** Optional author/self hex pubkey (64 hex chars). */
+  self?: string;
+  /** Optional short summary. */
+  summary?: LangText;
+  /** Optional long description. */
+  description?: LangText;
+  /** Optional key art / hero image asset. */
+  keyart?: NappAsset;
+  /** Optional screenshot assets. */
+  screenshots?: NappAsset[];
+  /** Optional free-form `t` tags. */
+  tags?: string[];
+}

--- a/src/lib/napp/types.ts
+++ b/src/lib/napp/types.ts
@@ -33,8 +33,9 @@ export interface NappAsset {
  *
  * Present (and structurally valid) => the project is a napp; see `isNapp()` in `./detect.ts`.
  *
- * NOTE: `indexerRelays` is intentionally deferred to Phase 22 to keep this foundation
- * phase minimal — do NOT add it here.
+ * NOTE: `indexerRelays` (Phase 22) is part of the App Listing publish targeting — the
+ * kind-37348 listing is published to the deduped union of NIP-65 write relays and these
+ * indexer relays (defaults to DEFAULT_NAPP_INDEXER_RELAYS when unset; see ./identifier.ts).
  */
 export interface NappConfig {
   /** Display name of the app. */
@@ -63,4 +64,9 @@ export interface NappConfig {
   screenshots?: NappAsset[];
   /** Optional free-form `t` tags. */
   tags?: string[];
+  /**
+   * Optional NIP-5B indexer relays the listing is also published to. Defaults to
+   * DEFAULT_NAPP_INDEXER_RELAYS when unset (see ../napp/identifier.ts).
+   */
+  indexerRelays?: string[];
 }

--- a/src/lib/nip46.ts
+++ b/src/lib/nip46.ts
@@ -9,8 +9,15 @@ import { BLOSSOM_SERVER_LIST_KIND } from "applesauce-common/helpers";
 import { kinds } from "applesauce-core/helpers";
 import { NostrConnectSigner, PrivateKeySigner } from "applesauce-signers";
 import { createLogger } from "./logger.ts";
-import { NSITE_NAME_SITE_KIND, NSITE_ROOT_SITE_KIND, NSITE_SNAPSHOT_KIND } from "./manifest.ts";
-import { NSITE_APP_LISTING_KIND, NSITE_RELEASE_NOTE_KIND } from "./napp/listing.ts";
+import {
+  NSITE_NAME_SITE_KIND,
+  NSITE_ROOT_SITE_KIND,
+  NSITE_SNAPSHOT_KIND,
+} from "./manifest.ts";
+import {
+  NSITE_APP_LISTING_KIND,
+  NSITE_RELEASE_NOTE_KIND,
+} from "./napp/listing.ts";
 import { SecretsManager } from "./secrets/mod.ts";
 
 const log = createLogger("nip46");
@@ -384,9 +391,13 @@ export async function importFromNbunk(
     const clientKey = hexToBytes(info.local_key);
 
     log.debug(
-      `Creating NostrConnectSigner with remote: ${info.pubkey}, relays: ${info.relays.join(", ")}`,
+      `Creating NostrConnectSigner with remote: ${info.pubkey}, relays: ${
+        info.relays.join(", ")
+      }`,
     );
-    log.debug(`Pool subscription method: ${NostrConnectSigner.subscriptionMethod}`);
+    log.debug(
+      `Pool subscription method: ${NostrConnectSigner.subscriptionMethod}`,
+    );
     log.debug(`Pool publish method: ${NostrConnectSigner.publishMethod}`);
 
     const signer = new NostrConnectSigner({
@@ -401,7 +412,10 @@ export async function importFromNbunk(
       // Add timeout to prevent hanging
       const connectPromise = signer.connect();
       const timeoutPromise = new Promise((_, reject) => {
-        setTimeout(() => reject(new Error("Bunker connection timeout after 30s")), 30000);
+        setTimeout(
+          () => reject(new Error("Bunker connection timeout after 30s")),
+          30000,
+        );
       });
 
       log.debug("Waiting for connection or timeout...");
@@ -419,7 +433,9 @@ export async function importFromNbunk(
     } catch (error: unknown) {
       await signer.close();
 
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = error instanceof Error
+        ? error.message
+        : String(error);
       log.error(
         `Failed to establish session with bunker from nbunksec: ${errorMessage}`,
       );
@@ -532,7 +548,9 @@ export async function initiateNostrConnect(
   const timeoutPromise = new Promise<never>((_, reject) => {
     timeoutHandle = setTimeout(() => {
       log.error(
-        `Connection explicitly timed out after ${connectTimeoutMs / 1000} seconds`,
+        `Connection explicitly timed out after ${
+          connectTimeoutMs / 1000
+        } seconds`,
       );
       reject(
         new Error(

--- a/src/lib/nip46.ts
+++ b/src/lib/nip46.ts
@@ -10,6 +10,7 @@ import { kinds } from "applesauce-core/helpers";
 import { NostrConnectSigner, PrivateKeySigner } from "applesauce-signers";
 import { createLogger } from "./logger.ts";
 import { NSITE_NAME_SITE_KIND, NSITE_ROOT_SITE_KIND, NSITE_SNAPSHOT_KIND } from "./manifest.ts";
+import { NSITE_APP_LISTING_KIND, NSITE_RELEASE_NOTE_KIND } from "./napp/listing.ts";
 import { SecretsManager } from "./secrets/mod.ts";
 
 const log = createLogger("nip46");
@@ -23,6 +24,8 @@ export const PERMISSIONS = NostrConnectSigner.buildSigningPermissions([
   NSITE_ROOT_SITE_KIND, // NIP-XX root site manifest
   NSITE_NAME_SITE_KIND, // NIP-XX named site manifest
   NSITE_SNAPSHOT_KIND, // NIP-5A manifest snapshot
+  NSITE_APP_LISTING_KIND, // NIP-5B napp app listing (37348)
+  NSITE_RELEASE_NOTE_KIND, // NIP-5B napp release note (39108) — reserved for Phase 23, authorized now
   kinds.EventDeletion, // NIP-09 event deletion
 ]);
 

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -397,6 +397,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "indexerRelays": {
+          "type": "array",
+          "description": "Optional NIP-5B indexer relays the App Listing is also published to. Defaults to wss://relay.44billion.net when unset.",
+          "items": { "type": "string", "pattern": "^wss?://" }
         }
       },
       "required": ["name", "icon", "categories", "countries"],

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -239,6 +239,168 @@
       },
       "required": ["kinds"],
       "additionalProperties": false
+    },
+    "napp": {
+      "type": "object",
+      "description": "NIP-5B napp (nostr app) listing section. Present => this project is a napp.",
+      "properties": {
+        "name": {
+          "type": "object",
+          "description": "Display name of the app (localizable)",
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "The text value",
+              "minLength": 1
+            },
+            "lang": {
+              "type": "string",
+              "description": "ISO 639-1 language code (e.g. 'en')"
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        },
+        "summary": {
+          "type": "object",
+          "description": "Short summary of the app (localizable)",
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "The text value",
+              "minLength": 1
+            },
+            "lang": {
+              "type": "string",
+              "description": "ISO 639-1 language code (e.g. 'en')"
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        },
+        "description": {
+          "type": "object",
+          "description": "Long description of the app (localizable)",
+          "properties": {
+            "value": {
+              "type": "string",
+              "description": "The text value",
+              "minLength": 1
+            },
+            "lang": {
+              "type": "string",
+              "description": "ISO 639-1 language code (e.g. 'en')"
+            }
+          },
+          "required": ["value"],
+          "additionalProperties": false
+        },
+        "icon": {
+          "type": "object",
+          "description": "App icon asset",
+          "properties": {
+            "hash": {
+              "type": "string",
+              "description": "sha256/blossom hash or URL of the asset",
+              "minLength": 1
+            },
+            "mime": {
+              "type": "string",
+              "description": "MIME type of the asset (e.g. 'image/png')",
+              "minLength": 1
+            },
+            "country": {
+              "type": "string",
+              "description": "Optional ISO 3166-1 alpha-2 code for a region-specific asset",
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          "required": ["hash", "mime"],
+          "additionalProperties": false
+        },
+        "keyart": {
+          "type": "object",
+          "description": "Key art / hero image asset",
+          "properties": {
+            "hash": {
+              "type": "string",
+              "description": "sha256/blossom hash or URL of the asset",
+              "minLength": 1
+            },
+            "mime": {
+              "type": "string",
+              "description": "MIME type of the asset (e.g. 'image/png')",
+              "minLength": 1
+            },
+            "country": {
+              "type": "string",
+              "description": "Optional ISO 3166-1 alpha-2 code for a region-specific asset",
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          "required": ["hash", "mime"],
+          "additionalProperties": false
+        },
+        "screenshots": {
+          "type": "array",
+          "description": "Screenshot assets",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hash": {
+                "type": "string",
+                "description": "sha256/blossom hash or URL of the asset",
+                "minLength": 1
+              },
+              "mime": {
+                "type": "string",
+                "description": "MIME type of the asset (e.g. 'image/png')",
+                "minLength": 1
+              },
+              "country": {
+                "type": "string",
+                "description": "Optional ISO 3166-1 alpha-2 code for a region-specific asset",
+                "pattern": "^[A-Za-z]{2}$"
+              }
+            },
+            "required": ["hash", "mime"],
+            "additionalProperties": false
+          }
+        },
+        "categories": {
+          "type": "array",
+          "description": "napp.<category>:<subcategory> labels (NIP-5B). Deep table validation is enforced structurally; the schema enforces label shape and count only.",
+          "items": {
+            "type": "string",
+            "pattern": "^napp\\.[^:]+:[^:]+$"
+          },
+          "minItems": 1,
+          "maxItems": 3
+        },
+        "countries": {
+          "type": "array",
+          "description": "Availability: ['*'] for worldwide, or a list of ISO 3166-1 alpha-2 codes",
+          "items": {
+            "type": "string",
+            "pattern": "^(\\*|[A-Za-z]{2})$"
+          },
+          "minItems": 1
+        },
+        "self": {
+          "type": "string",
+          "description": "Optional author/self hex pubkey (64 hex chars)",
+          "pattern": "^[0-9a-fA-F]{64}$"
+        },
+        "tags": {
+          "type": "array",
+          "description": "Optional free-form 't' tags",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["name", "icon", "categories", "countries"],
+      "additionalProperties": false
     }
   },
   "required": ["relays", "servers"],
@@ -279,6 +441,16 @@
         "picture": "https://example.com/avatar.jpg",
         "nip05": "alice@example.com",
         "lud16": "alice@getalby.com"
+      }
+    },
+    {
+      "relays": ["wss://relay.damus.io"],
+      "servers": ["https://cdn.hzrd149.com"],
+      "napp": {
+        "name": { "value": "My Game" },
+        "icon": { "hash": "abc123", "mime": "image/png" },
+        "categories": ["napp.games:rpg"],
+        "countries": ["*"]
       }
     }
   ]

--- a/src/schemas/config.schema.json
+++ b/src/schemas/config.schema.json
@@ -205,7 +205,13 @@
                         "description": "Supported entity types for this pattern",
                         "items": {
                           "type": "string",
-                          "enum": ["nevent", "naddr", "nprofile", "note", "npub"]
+                          "enum": [
+                            "nevent",
+                            "naddr",
+                            "nprofile",
+                            "note",
+                            "npub"
+                          ]
                         }
                       }
                     },

--- a/tests/unit/config/napp_wizard_test.ts
+++ b/tests/unit/config/napp_wizard_test.ts
@@ -59,7 +59,7 @@ describe("buildNappConfigFromAnswers (pure assembly helper)", () => {
     assertEquals(blank.icon.mime, "image/png");
   });
 
-  it("defaults countries to [\"*\"] when omitted or empty", () => {
+  it('defaults countries to ["*"] when omitted or empty', () => {
     const omitted = buildNappConfigFromAnswers({
       name: "App",
       iconHash: "h",
@@ -76,7 +76,7 @@ describe("buildNappConfigFromAnswers (pure assembly helper)", () => {
     assertEquals(empty.countries, ["*"]);
   });
 
-  it("includes summary/description only when non-empty, never { value: \"\" }", () => {
+  it('includes summary/description only when non-empty, never { value: "" }', () => {
     const withOptionals = buildNappConfigFromAnswers({
       name: "App",
       iconHash: "h",
@@ -97,7 +97,10 @@ describe("buildNappConfigFromAnswers (pure assembly helper)", () => {
       description: "   ",
     });
     assert(!("summary" in withoutOptionals), "summary key should be absent");
-    assert(!("description" in withoutOptionals), "description key should be absent");
+    assert(
+      !("description" in withoutOptionals),
+      "description key should be absent",
+    );
   });
 
   it("is a pure shaper: invalid answers produce a config that fails validation (no throw)", () => {
@@ -107,7 +110,10 @@ describe("buildNappConfigFromAnswers (pure assembly helper)", () => {
       categories: ["napp.bogus:nope"],
       countries: ["*"],
     });
-    assert(validateNappConfig(result).length > 0, "invalid answers should surface errors");
+    assert(
+      validateNappConfig(result).length > 0,
+      "invalid answers should surface errors",
+    );
   });
 });
 

--- a/tests/unit/config/napp_wizard_test.ts
+++ b/tests/unit/config/napp_wizard_test.ts
@@ -1,0 +1,130 @@
+import "../../test-setup-global.ts";
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import {
+  buildNappConfigFromAnswers,
+  categoryLabel,
+  type ProjectConfig,
+} from "../../../src/lib/config.ts";
+import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
+import { validateCategoryLabel } from "../../../src/lib/napp/categories.ts";
+
+describe("categoryLabel (pure helper)", () => {
+  it("joins category and subcategory into a napp.<cat>:<sub> label", () => {
+    assertEquals(categoryLabel("games", "rpg"), "napp.games:rpg");
+    assertEquals(validateCategoryLabel(categoryLabel("games", "rpg")), null);
+  });
+
+  it("stores multi-word subcategories verbatim (spaces preserved) and validates", () => {
+    const label = categoryLabel("utilities", "text editor");
+    assertEquals(label, "napp.utilities:text editor");
+    assertEquals(validateCategoryLabel(label), null);
+  });
+});
+
+describe("buildNappConfigFromAnswers (pure assembly helper)", () => {
+  it("assembles a structurally-valid NappConfig for valid answers", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "My App",
+      iconHash: "abc123",
+      iconMime: "image/png",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(result, {
+      name: { value: "My App" },
+      icon: { hash: "abc123", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(validateNappConfig(result), []);
+  });
+
+  it("defaults icon.mime to image/png when omitted or blank", () => {
+    const omitted = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(omitted.icon.mime, "image/png");
+
+    const blank = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      iconMime: "   ",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(blank.icon.mime, "image/png");
+  });
+
+  it("defaults countries to [\"*\"] when omitted or empty", () => {
+    const omitted = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+    });
+    assertEquals(omitted.countries, ["*"]);
+
+    const empty = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+      countries: [],
+    });
+    assertEquals(empty.countries, ["*"]);
+  });
+
+  it("includes summary/description only when non-empty, never { value: \"\" }", () => {
+    const withOptionals = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+      summary: "Quick app",
+      description: "Longer text",
+    });
+    assertEquals(withOptionals.summary, { value: "Quick app" });
+    assertEquals(withOptionals.description, { value: "Longer text" });
+
+    const withoutOptionals = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+      summary: "",
+      description: "   ",
+    });
+    assert(!("summary" in withoutOptionals), "summary key should be absent");
+    assert(!("description" in withoutOptionals), "description key should be absent");
+  });
+
+  it("is a pure shaper: invalid answers produce a config that fails validation (no throw)", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "",
+      iconHash: "h",
+      categories: ["napp.bogus:nope"],
+      countries: ["*"],
+    });
+    assert(validateNappConfig(result).length > 0, "invalid answers should surface errors");
+  });
+});
+
+describe("nsite path unchanged (additive-branch reasoning anchor)", () => {
+  it("a plain nsite ProjectConfig (no napp section) is not a napp", () => {
+    const nsiteConfig: ProjectConfig = {
+      relays: ["wss://r"],
+      servers: ["https://s"],
+      id: "my-site",
+    };
+    assertFalse(isNapp(nsiteConfig));
+  });
+
+  it("buildNappConfigFromAnswers + categoryLabel are the only napp-shaping exports", () => {
+    // Both helpers exist and are callable; this anchors the design that the napp
+    // branch is purely additive and reuses a single assembly helper.
+    assertEquals(typeof buildNappConfigFromAnswers, "function");
+    assertEquals(typeof categoryLabel, "function");
+  });
+});

--- a/tests/unit/config/napp_wizard_test.ts
+++ b/tests/unit/config/napp_wizard_test.ts
@@ -4,6 +4,8 @@ import { describe, it } from "@std/testing/bdd";
 import {
   buildNappConfigFromAnswers,
   categoryLabel,
+  collectNappListing,
+  type NappAssetResolver,
   type ProjectConfig,
 } from "../../../src/lib/config.ts";
 import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
@@ -114,6 +116,149 @@ describe("buildNappConfigFromAnswers (pure assembly helper)", () => {
       validateNappConfig(result).length > 0,
       "invalid answers should surface errors",
     );
+  });
+});
+
+describe("buildNappConfigFromAnswers full NIP-5B field coverage", () => {
+  const SELF = "a".repeat(64);
+
+  it("assembles every optional field and passes validateNappConfig with 0 errors", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "My App",
+      nameLang: "en",
+      iconHash: "h",
+      iconMime: "image/png",
+      categories: ["napp.games:rpg", "napp.social:network"],
+      countries: ["US", "de"],
+      summary: "Short",
+      summaryLang: "en",
+      description: "Long text",
+      descriptionLang: "de",
+      self: SELF,
+      keyart: { hash: "k", mime: "image/png" },
+      screenshots: [
+        { hash: "s1", mime: "image/png" },
+        { hash: "s2", mime: "image/webp" },
+      ],
+      tags: ["nostr", "social"],
+      indexerRelays: ["wss://indexer"],
+    });
+
+    assertEquals(validateNappConfig(result), []);
+    assertEquals(result.name, { value: "My App", lang: "en" });
+    assertEquals(result.summary, { value: "Short", lang: "en" });
+    assertEquals(result.description, { value: "Long text", lang: "de" });
+    assertEquals(result.self, SELF);
+    assertEquals(result.keyart, { hash: "k", mime: "image/png" });
+    assertEquals(result.screenshots, [
+      { hash: "s1", mime: "image/png" },
+      { hash: "s2", mime: "image/webp" },
+    ]);
+    assertEquals(result.tags, ["nostr", "social"]);
+    assertEquals(result.indexerRelays, ["wss://indexer"]);
+    assertEquals(result.categories, ["napp.games:rpg", "napp.social:network"]);
+    assertEquals(result.countries, ["US", "de"]);
+  });
+
+  it("minimal answers still produce the SAME object as before (regression anchor)", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "My App",
+      iconHash: "abc123",
+      iconMime: "image/png",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(result, {
+      name: { value: "My App" },
+      icon: { hash: "abc123", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+  });
+
+  it("omits lang keys when not provided", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+      summary: "Short",
+      description: "Long",
+    });
+    assert(!("lang" in result.name), "name.lang absent");
+    assertEquals(result.summary, { value: "Short" });
+    assertEquals(result.description, { value: "Long" });
+    assert(!("lang" in (result.summary as object)), "summary.lang absent");
+  });
+
+  it("omits empty optional collections and blank summary/description", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+      summary: "",
+      description: "   ",
+      self: "",
+      screenshots: [],
+      tags: [],
+      indexerRelays: [],
+    });
+    assert(!("summary" in result), "summary absent");
+    assert(!("description" in result), "description absent");
+    assert(!("self" in result), "self absent");
+    assert(!("keyart" in result), "keyart absent");
+    assert(!("screenshots" in result), "screenshots absent");
+    assert(!("tags" in result), "tags absent");
+    assert(!("indexerRelays" in result), "indexerRelays absent");
+  });
+});
+
+describe("collectNappListing minimal-prefill regression (no upload, non-interactive)", () => {
+  it("preserves the pre-phase minimal single-field shape", async () => {
+    // A no-upload resolver: hash inputs round-trip via the boundary semantics.
+    const noUpload: NappAssetResolver = (value: string) =>
+      Promise.resolve({ hash: value, mime: "image/png" });
+
+    const napp = await collectNappListing({
+      prefill: {
+        name: "My App",
+        icon: "abc123",
+        iconMime: "image/png",
+        categories: ["napp.games:rpg"],
+        countries: ["*"],
+      },
+      interactive: false,
+      resolveAsset: noUpload,
+    });
+
+    assertEquals(napp, {
+      name: { value: "My App" },
+      icon: { hash: "abc123", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(validateNappConfig(napp), []);
+  });
+
+  it("never calls the resolver when no asset inputs are present", async () => {
+    let called = false;
+    const failResolver: NappAssetResolver = (_v: string) => {
+      called = true;
+      return Promise.reject(new Error("should not resolve"));
+    };
+    const napp = await collectNappListing({
+      prefill: {
+        name: "App",
+        categories: ["napp.games:rpg"],
+        countries: ["*"],
+      },
+      interactive: false,
+      resolveAsset: failResolver,
+    });
+    assertEquals(called, false);
+    // icon stays empty (invalid) — validation is the caller's job, not the collector's.
+    assertEquals(napp.icon.hash, "");
   });
 });
 

--- a/tests/unit/dry-run/collector_napp_test.ts
+++ b/tests/unit/dry-run/collector_napp_test.ts
@@ -1,0 +1,81 @@
+// Import test setup FIRST to block all system access
+import "../../test-setup-global.ts";
+
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { collectDeployEvents } from "../../../src/lib/dry-run/collector.ts";
+import type { ProjectConfig } from "../../../src/lib/config.ts";
+import type { FilePathMapping } from "../../../src/lib/manifest.ts";
+import type { NappConfig } from "../../../src/lib/napp/types.ts";
+
+const testFiles: FilePathMapping[] = [
+  { path: "/index.html", sha256: "abc123" },
+  { path: "/style.css", sha256: "def456" },
+];
+
+const baseConfig: ProjectConfig = {
+  servers: ["https://blossom.example.com"],
+  relays: ["wss://relay.example.com"],
+};
+
+const napp: NappConfig = {
+  name: { value: "My App" },
+  icon: { hash: "iconhash", mime: "image/png" },
+  categories: ["napp.games:rpg"],
+  countries: ["*"],
+  summary: { value: "a summary" },
+  tags: ["foo"],
+};
+
+describe("collectDeployEvents — napp listing (kind 37348)", () => {
+  it("plain config produces NO kind-37348 event (zero regression)", () => {
+    const events = collectDeployEvents(baseConfig, testFiles);
+    assertEquals(events.filter((e) => e.kind === 37348).length, 0);
+  });
+
+  it("napp config produces exactly one kind-37348 event with right label/filename", () => {
+    const config = { ...baseConfig, napp };
+    const events = collectDeployEvents(config, testFiles);
+    const listing = events.filter((e) => e.kind === 37348);
+    assertEquals(listing.length, 1);
+    assertEquals(listing[0].label, "App Listing (kind 37348)");
+    assertEquals(listing[0].filename, "app-listing-37348.json");
+  });
+
+  it("listing appended LAST after the manifest (order unchanged for non-napp prefix)", () => {
+    const config = { ...baseConfig, napp };
+    const events = collectDeployEvents(config, testFiles);
+    assertEquals(events[0].kind, 15128); // manifest still first (root)
+    assertEquals(events[events.length - 1].kind, 37348); // listing last
+  });
+
+  it("root napp: listing d tag is '' and manifest has no d tag", () => {
+    const config = { ...baseConfig, napp }; // no id -> root
+    const events = collectDeployEvents(config, testFiles);
+    const manifest = events.find((e) => e.kind === 15128)!;
+    const listing = events.find((e) => e.kind === 37348)!;
+    assertEquals(manifest.template.tags.find((t) => t[0] === "d"), undefined);
+    assertEquals(listing.template.tags[0], ["d", ""]);
+  });
+
+  it("named napp: listing d tag equals manifest d tag (config.id)", () => {
+    const config = { ...baseConfig, id: "my-site", napp };
+    const events = collectDeployEvents(config, testFiles);
+    const manifest = events.find((e) => e.kind === 35128)!;
+    const listing = events.find((e) => e.kind === 37348)!;
+    const manifestD = manifest.template.tags.find((t) => t[0] === "d")?.[1];
+    const listingD = listing.template.tags.find((t) => t[0] === "d")?.[1];
+    assertEquals(manifestD, "my-site");
+    assertEquals(listingD, "my-site");
+    assertEquals(listingD, manifestD);
+  });
+
+  it("listing template carries name + c + l tags (sanity)", () => {
+    const config = { ...baseConfig, napp };
+    const events = collectDeployEvents(config, testFiles);
+    const listing = events.find((e) => e.kind === 37348)!;
+    assertEquals(listing.template.tags.find((t) => t[0] === "name"), ["name", "My App"]);
+    assertEquals(listing.template.tags.filter((t) => t[0] === "c"), [["c", "*"]]);
+    assertEquals(listing.template.tags.filter((t) => t[0] === "l"), [["l", "napp.games:rpg"]]);
+  });
+});

--- a/tests/unit/dry-run/collector_napp_test.ts
+++ b/tests/unit/dry-run/collector_napp_test.ts
@@ -74,8 +74,17 @@ describe("collectDeployEvents — napp listing (kind 37348)", () => {
     const config = { ...baseConfig, napp };
     const events = collectDeployEvents(config, testFiles);
     const listing = events.find((e) => e.kind === 37348)!;
-    assertEquals(listing.template.tags.find((t) => t[0] === "name"), ["name", "My App"]);
-    assertEquals(listing.template.tags.filter((t) => t[0] === "c"), [["c", "*"]]);
-    assertEquals(listing.template.tags.filter((t) => t[0] === "l"), [["l", "napp.games:rpg"]]);
+    assertEquals(listing.template.tags.find((t) => t[0] === "name"), [
+      "name",
+      "My App",
+    ]);
+    assertEquals(listing.template.tags.filter((t) => t[0] === "c"), [[
+      "c",
+      "*",
+    ]]);
+    assertEquals(listing.template.tags.filter((t) => t[0] === "l"), [[
+      "l",
+      "napp.games:rpg",
+    ]]);
   });
 });

--- a/tests/unit/napp/categories_test.ts
+++ b/tests/unit/napp/categories_test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import {
+  MAX_NAPP_CATEGORIES,
+  NAPP_CATEGORIES,
+  validateCategories,
+  validateCategoryLabel,
+} from "../../../src/lib/napp/categories.ts";
+
+Deno.test("validateCategoryLabel - valid label returns null", () => {
+  assertEquals(validateCategoryLabel("napp.games:rpg"), null);
+  assertEquals(validateCategoryLabel("napp.money:wallet"), null);
+  assertEquals(validateCategoryLabel("napp.other:other"), null);
+  // Multi-word subcategories must be accepted verbatim.
+  assertEquals(validateCategoryLabel("napp.utilities:text editor"), null);
+  assertEquals(validateCategoryLabel("napp.utilities:image editor"), null);
+  assertEquals(validateCategoryLabel("napp.utilities:audio editor"), null);
+  assertEquals(validateCategoryLabel("napp.utilities:video editor"), null);
+});
+
+Deno.test("validateCategoryLabel - unknown category returns error naming it", () => {
+  const err = validateCategoryLabel("napp.bogus:rpg");
+  assertEquals(typeof err, "string");
+  assertEquals(err!.includes("bogus"), true);
+});
+
+Deno.test("validateCategoryLabel - unknown subcategory returns error naming it", () => {
+  const err = validateCategoryLabel("napp.games:notreal");
+  assertEquals(typeof err, "string");
+  assertEquals(err!.includes("notreal"), true);
+});
+
+Deno.test("validateCategoryLabel - missing napp. prefix returns error", () => {
+  const err = validateCategoryLabel("games:rpg");
+  assertEquals(typeof err, "string");
+});
+
+Deno.test("validateCategoryLabel - malformed (no subcategory) returns error", () => {
+  assertEquals(typeof validateCategoryLabel("napp.games"), "string");
+  assertEquals(typeof validateCategoryLabel("napp.games:rpg:extra"), "string");
+});
+
+Deno.test("validateCategories - all valid returns []", () => {
+  assertEquals(
+    validateCategories(["napp.games:rpg", "napp.money:wallet"]),
+    [],
+  );
+});
+
+Deno.test("validateCategories - more than 3 labels returns limit error", () => {
+  const errs = validateCategories([
+    "napp.games:rpg",
+    "napp.money:wallet",
+    "napp.social:blog",
+    "napp.shopping:store",
+  ]);
+  assertEquals(errs.length >= 1, true);
+  const joined = errs.join(" ");
+  assertEquals(joined.includes(String(MAX_NAPP_CATEGORIES)), true);
+});
+
+Deno.test("validateCategories - empty array returns required error", () => {
+  const errs = validateCategories([]);
+  assertEquals(errs.length >= 1, true);
+});
+
+Deno.test("validateCategories - accumulates per-label errors", () => {
+  const errs = validateCategories(["napp.bogus:rpg", "napp.games:notreal"]);
+  assertEquals(errs.length, 2);
+});
+
+Deno.test("NAPP_CATEGORIES - table has exact NIP-5B entries", () => {
+  assertEquals(Object.keys(NAPP_CATEGORIES).sort(), [
+    "audiovisual",
+    "games",
+    "money",
+    "other",
+    "shopping",
+    "social",
+    "utilities",
+  ]);
+  assertEquals(NAPP_CATEGORIES["other"], ["other"]);
+  assertEquals(NAPP_CATEGORIES["utilities"].includes("text editor"), true);
+  assertEquals(NAPP_CATEGORIES["games"].length, 14);
+});

--- a/tests/unit/napp/categories_test.ts
+++ b/tests/unit/napp/categories_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import {
   MAX_NAPP_CATEGORIES,
   NAPP_CATEGORIES,

--- a/tests/unit/napp/deploy_listing_test.ts
+++ b/tests/unit/napp/deploy_listing_test.ts
@@ -47,7 +47,11 @@ describe("buildDeployListing", () => {
     const config = { ...baseConfig, napp };
     const t = buildDeployListing(config, "pub", "")!;
     assertEquals(t.tags.find((x) => x[0] === "name"), ["name", "My App"]);
-    assertEquals(t.tags.find((x) => x[0] === "icon"), ["icon", "iconhash", "image/png"]);
+    assertEquals(t.tags.find((x) => x[0] === "icon"), [
+      "icon",
+      "iconhash",
+      "image/png",
+    ]);
     assertEquals(t.tags.filter((x) => x[0] === "c"), [["c", "*"]]);
     assertEquals(t.tags.filter((x) => x[0] === "l"), [["l", "napp.games:rpg"]]);
   });

--- a/tests/unit/napp/deploy_listing_test.ts
+++ b/tests/unit/napp/deploy_listing_test.ts
@@ -1,0 +1,54 @@
+// Import test setup FIRST to block all system access
+import "../../test-setup-global.ts";
+
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { buildDeployListing } from "../../../src/commands/deploy.ts";
+import type { ProjectConfig } from "../../../src/lib/config.ts";
+import type { NappConfig } from "../../../src/lib/napp/types.ts";
+
+const napp: NappConfig = {
+  name: { value: "My App" },
+  icon: { hash: "iconhash", mime: "image/png" },
+  categories: ["napp.games:rpg"],
+  countries: ["*"],
+};
+
+const baseConfig: ProjectConfig = {
+  servers: ["https://blossom.example.com"],
+  relays: ["wss://relay.example.com"],
+};
+
+describe("buildDeployListing", () => {
+  it("returns null for a non-napp config (zero-regression proof)", () => {
+    assertEquals(buildDeployListing(baseConfig, "pub", ""), null);
+  });
+
+  it('named napp -> template kind 37348 with ["d","my-site"]', () => {
+    const config = { ...baseConfig, napp };
+    const t = buildDeployListing(config, "pub", "my-site");
+    assertEquals(t?.kind, 37348);
+    assertEquals(t?.tags[0], ["d", "my-site"]);
+  });
+
+  it('root napp -> ["d",""]', () => {
+    const config = { ...baseConfig, napp };
+    const t = buildDeployListing(config, "pub", "");
+    assertEquals(t?.tags[0], ["d", ""]);
+  });
+
+  it("honors the createdAt override", () => {
+    const config = { ...baseConfig, napp };
+    const t = buildDeployListing(config, "pub", "", 1234567890);
+    assertEquals(t?.created_at, 1234567890);
+  });
+
+  it("required tags present (name/icon/c/l)", () => {
+    const config = { ...baseConfig, napp };
+    const t = buildDeployListing(config, "pub", "")!;
+    assertEquals(t.tags.find((x) => x[0] === "name"), ["name", "My App"]);
+    assertEquals(t.tags.find((x) => x[0] === "icon"), ["icon", "iconhash", "image/png"]);
+    assertEquals(t.tags.filter((x) => x[0] === "c"), [["c", "*"]]);
+    assertEquals(t.tags.filter((x) => x[0] === "l"), [["l", "napp.games:rpg"]]);
+  });
+});

--- a/tests/unit/napp/detect_test.ts
+++ b/tests/unit/napp/detect_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
 import type { NappConfig } from "../../../src/lib/napp/types.ts";
 

--- a/tests/unit/napp/detect_test.ts
+++ b/tests/unit/napp/detect_test.ts
@@ -160,3 +160,19 @@ Deno.test("validateNappConfig - tags must be string[]", () => {
   });
   assertEquals(errs.some((e) => e.path === "/napp/tags"), true);
 });
+
+Deno.test("validateNappConfig - indexerRelays must be ws/wss relay URLs", () => {
+  const errs = validateNappConfig({
+    ...validNapp(),
+    indexerRelays: ["nope", "https://relay.example.com"],
+  });
+  assertEquals(errs.some((e) => e.path === "/napp/indexerRelays"), true);
+  assertEquals(
+    isNapp({
+      relays: [],
+      servers: [],
+      napp: { ...validNapp(), indexerRelays: ["nope"] },
+    }),
+    false,
+  );
+});

--- a/tests/unit/napp/detect_test.ts
+++ b/tests/unit/napp/detect_test.ts
@@ -13,7 +13,10 @@ function validNapp(): NappConfig {
 
 Deno.test("isNapp - plain nsite config (no napp) is false", () => {
   assertEquals(
-    isNapp({ relays: ["wss://relay.damus.io"], servers: ["https://cdn.hzrd149.com"] }),
+    isNapp({
+      relays: ["wss://relay.damus.io"],
+      servers: ["https://cdn.hzrd149.com"],
+    }),
     false,
   );
 });
@@ -93,7 +96,10 @@ Deno.test("validateNappConfig - countries ['*'] is valid", () => {
 });
 
 Deno.test("validateNappConfig - countries with codes is valid", () => {
-  assertEquals(validateNappConfig({ ...validNapp(), countries: ["US", "de"] }), []);
+  assertEquals(
+    validateNappConfig({ ...validNapp(), countries: ["US", "de"] }),
+    [],
+  );
 });
 
 Deno.test("validateNappConfig - mixing '*' and a code -> /napp/countries error", () => {
@@ -133,7 +139,10 @@ Deno.test("validateNappConfig - bad screenshots entry -> indexed path", () => {
     ...validNapp(),
     screenshots: [{ hash: "ok", mime: "image/png" }, { hash: "", mime: "" }],
   });
-  assertEquals(errs.some((e) => e.path.startsWith("/napp/screenshots/1")), true);
+  assertEquals(
+    errs.some((e) => e.path.startsWith("/napp/screenshots/1")),
+    true,
+  );
 });
 
 Deno.test("validateNappConfig - keyart same shape as icon", () => {
@@ -145,6 +154,9 @@ Deno.test("validateNappConfig - keyart same shape as icon", () => {
 });
 
 Deno.test("validateNappConfig - tags must be string[]", () => {
-  const errs = validateNappConfig({ ...validNapp(), tags: [1, 2] as unknown as string[] });
+  const errs = validateNappConfig({
+    ...validNapp(),
+    tags: [1, 2] as unknown as string[],
+  });
   assertEquals(errs.some((e) => e.path === "/napp/tags"), true);
 });

--- a/tests/unit/napp/detect_test.ts
+++ b/tests/unit/napp/detect_test.ts
@@ -1,0 +1,150 @@
+import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
+import type { NappConfig } from "../../../src/lib/napp/types.ts";
+
+function validNapp(): NappConfig {
+  return {
+    name: { value: "My App" },
+    icon: { hash: "abc123", mime: "image/png" },
+    categories: ["napp.games:rpg"],
+    countries: ["*"],
+  };
+}
+
+Deno.test("isNapp - plain nsite config (no napp) is false", () => {
+  assertEquals(
+    isNapp({ relays: ["wss://relay.damus.io"], servers: ["https://cdn.hzrd149.com"] }),
+    false,
+  );
+});
+
+Deno.test("isNapp - fully valid napp section is true", () => {
+  assertEquals(isNapp({ relays: [], servers: [], napp: validNapp() }), true);
+});
+
+Deno.test("isNapp - napp present but missing name is false", () => {
+  const napp = validNapp() as Record<string, unknown>;
+  delete napp.name;
+  assertEquals(isNapp({ relays: [], servers: [], napp }), false);
+});
+
+Deno.test("validateNappConfig - valid napp returns []", () => {
+  assertEquals(validateNappConfig(validNapp()), []);
+});
+
+Deno.test("validateNappConfig - non-object returns /napp error", () => {
+  const errs = validateNappConfig(null);
+  assertEquals(errs.length, 1);
+  assertEquals(errs[0].path, "/napp");
+});
+
+Deno.test("validateNappConfig - missing icon -> /napp/icon error", () => {
+  const napp = validNapp() as Record<string, unknown>;
+  delete napp.icon;
+  const errs = validateNappConfig(napp);
+  assertEquals(errs.some((e) => e.path === "/napp/icon"), true);
+});
+
+Deno.test("validateNappConfig - icon missing hash/mime -> specific paths", () => {
+  const errs = validateNappConfig({
+    ...validNapp(),
+    icon: { hash: "", mime: "" },
+  });
+  assertEquals(errs.some((e) => e.path === "/napp/icon/hash"), true);
+  assertEquals(errs.some((e) => e.path === "/napp/icon/mime"), true);
+});
+
+Deno.test("validateNappConfig - missing name -> /napp/name error", () => {
+  const napp = validNapp() as Record<string, unknown>;
+  delete napp.name;
+  const errs = validateNappConfig(napp);
+  assertEquals(errs.some((e) => e.path === "/napp/name"), true);
+});
+
+Deno.test("validateNappConfig - 4 categories -> limit error", () => {
+  const errs = validateNappConfig({
+    ...validNapp(),
+    categories: [
+      "napp.games:rpg",
+      "napp.money:wallet",
+      "napp.social:blog",
+      "napp.shopping:store",
+    ],
+  });
+  assertEquals(errs.some((e) => e.path === "/napp/categories"), true);
+  assertEquals(errs.some((e) => /at most|too many/.test(e.message)), true);
+});
+
+Deno.test("validateNappConfig - bad category label -> /napp/categories error", () => {
+  const errs = validateNappConfig({
+    ...validNapp(),
+    categories: ["napp.bogus:rpg"],
+  });
+  assertEquals(errs.some((e) => e.path === "/napp/categories"), true);
+});
+
+Deno.test("validateNappConfig - empty countries -> /napp/countries error", () => {
+  const errs = validateNappConfig({ ...validNapp(), countries: [] });
+  assertEquals(errs.some((e) => e.path === "/napp/countries"), true);
+});
+
+Deno.test("validateNappConfig - countries ['*'] is valid", () => {
+  assertEquals(validateNappConfig({ ...validNapp(), countries: ["*"] }), []);
+});
+
+Deno.test("validateNappConfig - countries with codes is valid", () => {
+  assertEquals(validateNappConfig({ ...validNapp(), countries: ["US", "de"] }), []);
+});
+
+Deno.test("validateNappConfig - mixing '*' and a code -> /napp/countries error", () => {
+  // Plan-checker note: the schema pattern alone permits ["*","US"]; the structural
+  // check must reject mixing the worldwide wildcard with explicit codes.
+  const errs = validateNappConfig({ ...validNapp(), countries: ["*", "US"] });
+  assertEquals(errs.some((e) => e.path === "/napp/countries"), true);
+});
+
+Deno.test("validateNappConfig - bad country code -> /napp/countries error", () => {
+  const errs = validateNappConfig({ ...validNapp(), countries: ["USA"] });
+  assertEquals(errs.some((e) => e.path === "/napp/countries"), true);
+});
+
+Deno.test("validateNappConfig - self not 64-hex -> /napp/self error", () => {
+  const errs = validateNappConfig({ ...validNapp(), self: "deadbeef" });
+  assertEquals(errs.some((e) => e.path === "/napp/self"), true);
+});
+
+Deno.test("validateNappConfig - valid self (64-hex) passes", () => {
+  assertEquals(
+    validateNappConfig({
+      ...validNapp(),
+      self: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    }),
+    [],
+  );
+});
+
+Deno.test("validateNappConfig - bad summary -> /napp/summary error", () => {
+  const errs = validateNappConfig({ ...validNapp(), summary: { value: 123 } });
+  assertEquals(errs.some((e) => e.path === "/napp/summary"), true);
+});
+
+Deno.test("validateNappConfig - bad screenshots entry -> indexed path", () => {
+  const errs = validateNappConfig({
+    ...validNapp(),
+    screenshots: [{ hash: "ok", mime: "image/png" }, { hash: "", mime: "" }],
+  });
+  assertEquals(errs.some((e) => e.path.startsWith("/napp/screenshots/1")), true);
+});
+
+Deno.test("validateNappConfig - keyart same shape as icon", () => {
+  const errs = validateNappConfig({
+    ...validNapp(),
+    keyart: { hash: "", mime: "" },
+  });
+  assertEquals(errs.some((e) => e.path.startsWith("/napp/keyart")), true);
+});
+
+Deno.test("validateNappConfig - tags must be string[]", () => {
+  const errs = validateNappConfig({ ...validNapp(), tags: [1, 2] as unknown as string[] });
+  assertEquals(errs.some((e) => e.path === "/napp/tags"), true);
+});

--- a/tests/unit/napp/identifier_test.ts
+++ b/tests/unit/napp/identifier_test.ts
@@ -133,11 +133,11 @@ describe("appEncode / appDecode channels", () => {
     assertEquals(decoded.kind, 35128);
   });
 
-  it("rejects a pubkey TLV value that is not 32 bytes", () => {
-    // Encode a deliberately short pubkey and ensure decode rejects it.
-    assertThrows(
-      () => appEncode({ dTag: "x", pubkey: "abcd", kind: 35128, relays: [] }),
-    );
+  it("rejects a pubkey TLV value that is not 32 bytes on decode", () => {
+    // Encode a deliberately short (2-byte) pubkey; decode must reject the
+    // non-32-byte pubkey TLV value.
+    const entity = appEncode({ dTag: "x", pubkey: "abcd", kind: 35128, relays: [] });
+    assertThrows(() => appDecode(entity), Error, "invalid pubkey length");
   });
 });
 

--- a/tests/unit/napp/identifier_test.ts
+++ b/tests/unit/napp/identifier_test.ts
@@ -23,15 +23,12 @@ import {
  */
 
 // Vector 1: the spec's published entity (strongest assertion).
-const SPEC_ENTITY =
-  "+cA99KnC0UCyqHT5oI8fIkoza0jfB1lrvaWKmuh6h2EhTz2nw4R2a5qVNM";
+const SPEC_ENTITY = "+cA99KnC0UCyqHT5oI8fIkoza0jfB1lrvaWKmuh6h2EhTz2nw4R2a5qVNM";
 const SPEC_DTAG = "0ufiaf2";
-const SPEC_PUBKEY =
-  "5a8bc85694d8fbb4f30208649c1c52509636d1e6fdb1f0f4c84a3f10f9383ec9";
+const SPEC_PUBKEY = "5a8bc85694d8fbb4f30208649c1c52509636d1e6fdb1f0f4c84a3f10f9383ec9";
 
 // Vector 2: golden, no relays.
-const GOLDEN_NO_RELAYS =
-  "+ehjV4kucmWYSCIqa4YfqS08hdZu1kNgHTJT7epcHHWIOJPJvkdc5poyZ2ffrn";
+const GOLDEN_NO_RELAYS = "+ehjV4kucmWYSCIqa4YfqS08hdZu1kNgHTJT7epcHHWIOJPJvkdc5poyZ2ffrn";
 // Vector 3: golden, 1 relay.
 const GOLDEN_ONE_RELAY =
   "+2CQzXAhYFUBwLJDSw4KYzy3JgqAB2351RPc4q2OXt167Cm6gvMCvNlpUELbuDAu5Qqfi8HGwVvL4XRw37s6EXbsfKRu7D37";
@@ -108,6 +105,13 @@ describe("appEncode / appDecode channels", () => {
       Error,
       "Wrong channel",
     );
+  });
+
+  it("throws a clear validation error (not a TypeError) for a malformed identifier missing TLV type 0/2", () => {
+    // A valid prefix with an empty TLV body decodes to {} — type 0 (dTag) is absent.
+    // Without the guard this threw `Cannot read properties of undefined (reading '0')`.
+    const err = assertThrows(() => appDecode("+"), Error, "invalid app identifier");
+    assertEquals(err instanceof TypeError, false);
   });
 
   it("round-trips with zero relays", () => {

--- a/tests/unit/napp/identifier_test.ts
+++ b/tests/unit/napp/identifier_test.ts
@@ -4,11 +4,11 @@ import { describe, it } from "@std/testing/bdd";
 import {
   appDecode,
   appEncode,
-  base62ToBytes,
   BASE62_ALPHABET,
+  base62ToBytes,
   bytesToBase62,
-  DEFAULT_NAPP_INDEXER_RELAYS,
   decodeNappIdentifier,
+  DEFAULT_NAPP_INDEXER_RELAYS,
   nappIdentifier,
   resolveIndexerRelays,
 } from "../../../src/lib/napp/identifier.ts";
@@ -136,7 +136,12 @@ describe("appEncode / appDecode channels", () => {
   it("rejects a pubkey TLV value that is not 32 bytes on decode", () => {
     // Encode a deliberately short (2-byte) pubkey; decode must reject the
     // non-32-byte pubkey TLV value.
-    const entity = appEncode({ dTag: "x", pubkey: "abcd", kind: 35128, relays: [] });
+    const entity = appEncode({
+      dTag: "x",
+      pubkey: "abcd",
+      kind: 35128,
+      relays: [],
+    });
     assertThrows(() => appDecode(entity), Error, "invalid pubkey length");
   });
 });
@@ -229,7 +234,10 @@ describe("indexer relays", () => {
   });
 
   it("returns the default when napp present but indexerRelays unset", () => {
-    assertEquals(resolveIndexerRelays({ napp: {} }), DEFAULT_NAPP_INDEXER_RELAYS);
+    assertEquals(
+      resolveIndexerRelays({ napp: {} }),
+      DEFAULT_NAPP_INDEXER_RELAYS,
+    );
   });
 
   it("returns the default for a plain config without a napp section", () => {

--- a/tests/unit/napp/identifier_test.ts
+++ b/tests/unit/napp/identifier_test.ts
@@ -1,0 +1,246 @@
+import "../../test-setup-global.ts";
+import { assertEquals, assertMatch, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import {
+  appDecode,
+  appEncode,
+  base62ToBytes,
+  BASE62_ALPHABET,
+  bytesToBase62,
+  DEFAULT_NAPP_INDEXER_RELAYS,
+  decodeNappIdentifier,
+  nappIdentifier,
+  resolveIndexerRelays,
+} from "../../../src/lib/napp/identifier.ts";
+
+/**
+ * EXTERNALLY-VERIFIED interop vectors.
+ *
+ * These were produced by running the genuine upstream 44Billion/nappup algorithm,
+ * which round-trips the spec's own published vector. They are hard-coded here as the
+ * primary interop assertions — if the port drifts from the reference, one of these
+ * fails. Do NOT change the vectors; fix the port.
+ */
+
+// Vector 1: the spec's published entity (strongest assertion).
+const SPEC_ENTITY =
+  "+cA99KnC0UCyqHT5oI8fIkoza0jfB1lrvaWKmuh6h2EhTz2nw4R2a5qVNM";
+const SPEC_DTAG = "0ufiaf2";
+const SPEC_PUBKEY =
+  "5a8bc85694d8fbb4f30208649c1c52509636d1e6fdb1f0f4c84a3f10f9383ec9";
+
+// Vector 2: golden, no relays.
+const GOLDEN_NO_RELAYS =
+  "+ehjV4kucmWYSCIqa4YfqS08hdZu1kNgHTJT7epcHHWIOJPJvkdc5poyZ2ffrn";
+// Vector 3: golden, 1 relay.
+const GOLDEN_ONE_RELAY =
+  "+2CQzXAhYFUBwLJDSw4KYzy3JgqAB2351RPc4q2OXt167Cm6gvMCvNlpUELbuDAu5Qqfi8HGwVvL4XRw37s6EXbsfKRu7D37";
+const GOLDEN_DTAG = "my-website";
+const GOLDEN_PUBKEY = "1".repeat(64);
+
+describe("base62 codec", () => {
+  it("encodes a single zero byte to a single leader", () => {
+    assertEquals(bytesToBase62(new Uint8Array([0])), "0");
+  });
+
+  it("preserves both leading-zero leader chars for [0,0,1]", () => {
+    const s = bytesToBase62(new Uint8Array([0, 0, 1]));
+    // two leading zeros -> two leader chars, then the digit(s) for 1.
+    assertEquals(s.startsWith("00"), true);
+    assertEquals(s, "001");
+    assertEquals(Array.from(base62ToBytes(s)), [0, 0, 1]);
+  });
+
+  it("round-trips arbitrary byte arrays including leading zeros", () => {
+    const samples: number[][] = [
+      [],
+      [0],
+      [0, 0, 0],
+      [255],
+      [0, 0, 255, 1, 7],
+      [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    ];
+    for (const arr of samples) {
+      const b = new Uint8Array(arr);
+      assertEquals(Array.from(base62ToBytes(bytesToBase62(b))), arr);
+    }
+    // random arrays
+    for (let i = 0; i < 50; i++) {
+      const len = Math.floor(Math.random() * 40);
+      const b = new Uint8Array(len);
+      crypto.getRandomValues(b);
+      assertEquals(Array.from(base62ToBytes(bytesToBase62(b))), Array.from(b));
+    }
+  });
+
+  it("uses the 0-9a-zA-Z alphabet", () => {
+    assertEquals(
+      BASE62_ALPHABET,
+      "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    );
+  });
+
+  it("rejects an invalid base62 char", () => {
+    assertThrows(() => base62ToBytes("!!!"));
+  });
+});
+
+describe("appEncode / appDecode channels", () => {
+  const pubkey = GOLDEN_PUBKEY;
+
+  it("encodes channel main with a single + prefix and base62 body", () => {
+    const entity = appEncode({ dTag: "x", pubkey, kind: 35128, relays: [] });
+    assertMatch(entity, /^\+[0-9A-Za-z]+$/);
+    assertEquals(entity.startsWith("++"), false);
+  });
+
+  it("maps kinds to prefixes ++ and +++", () => {
+    const next = appEncode({ dTag: "x", pubkey, kind: 35129, relays: [] });
+    const draft = appEncode({ dTag: "x", pubkey, kind: 35130, relays: [] });
+    assertEquals(next.startsWith("++"), true);
+    assertEquals(next.startsWith("+++"), false);
+    assertEquals(draft.startsWith("+++"), true);
+  });
+
+  it("throws Wrong channel for an unknown kind with no explicit channel", () => {
+    assertThrows(
+      () => appEncode({ dTag: "x", pubkey, kind: 99999, relays: [] }),
+      Error,
+      "Wrong channel",
+    );
+  });
+
+  it("round-trips with zero relays", () => {
+    const ref = { dTag: "hello", pubkey, kind: 35128, relays: [] };
+    const decoded = appDecode(appEncode(ref));
+    assertEquals(decoded.dTag, "hello");
+    assertEquals(decoded.pubkey, pubkey);
+    assertEquals(decoded.relays, []);
+    assertEquals(decoded.kind, 35128);
+  });
+
+  it("round-trips with multiple relays", () => {
+    const ref = {
+      dTag: "hello",
+      pubkey,
+      kind: 35128,
+      relays: ["wss://a", "wss://b"],
+    };
+    const decoded = appDecode(appEncode(ref));
+    assertEquals(decoded.dTag, "hello");
+    assertEquals(decoded.pubkey, pubkey);
+    assertEquals(decoded.relays, ["wss://a", "wss://b"]);
+    assertEquals(decoded.kind, 35128);
+  });
+
+  it("rejects a pubkey TLV value that is not 32 bytes", () => {
+    // Encode a deliberately short pubkey and ensure decode rejects it.
+    assertThrows(
+      () => appEncode({ dTag: "x", pubkey: "abcd", kind: 35128, relays: [] }),
+    );
+  });
+});
+
+describe("interop vectors (externally verified)", () => {
+  it("VECTOR 1: decodes the spec entity to the expected fields", () => {
+    const decoded = decodeNappIdentifier(SPEC_ENTITY);
+    assertEquals(decoded.dTag, SPEC_DTAG);
+    assertEquals(decoded.pubkey, SPEC_PUBKEY);
+    assertEquals(decoded.kind, 35128);
+    assertEquals(decoded.relays, []);
+  });
+
+  it("VECTOR 1: re-encodes the spec fields to the identical string", () => {
+    const entity = nappIdentifier({
+      dTag: SPEC_DTAG,
+      pubkey: SPEC_PUBKEY,
+      relays: [],
+    });
+    assertEquals(entity, SPEC_ENTITY);
+  });
+
+  it("VECTOR 2: golden no-relays vector reproduces byte-for-byte", () => {
+    const entity = nappIdentifier({
+      dTag: GOLDEN_DTAG,
+      pubkey: GOLDEN_PUBKEY,
+      relays: [],
+    });
+    assertEquals(entity, GOLDEN_NO_RELAYS);
+    assertMatch(entity, /^\+[0-9A-Za-z]{48,}$/);
+  });
+
+  it("VECTOR 3: golden one-relay vector reproduces byte-for-byte", () => {
+    const entity = nappIdentifier({
+      dTag: GOLDEN_DTAG,
+      pubkey: GOLDEN_PUBKEY,
+      relays: ["wss://relay.example.com"],
+    });
+    assertEquals(entity, GOLDEN_ONE_RELAY);
+    assertMatch(entity, /^\+[0-9A-Za-z]{48,}$/);
+  });
+
+  it("all vectors round-trip encode->decode->encode", () => {
+    for (const entity of [SPEC_ENTITY, GOLDEN_NO_RELAYS, GOLDEN_ONE_RELAY]) {
+      const decoded = decodeNappIdentifier(entity);
+      const reencoded = nappIdentifier({
+        dTag: decoded.dTag,
+        pubkey: decoded.pubkey,
+        relays: decoded.relays,
+      });
+      assertEquals(reencoded, entity);
+    }
+  });
+});
+
+describe("nappIdentifier wrappers", () => {
+  it("produces a + identifier matching the shape regex", () => {
+    const entity = nappIdentifier({
+      dTag: "my-website",
+      pubkey: GOLDEN_PUBKEY,
+      relays: [],
+    });
+    assertMatch(entity, /^\+[0-9A-Za-z]{48,}$/);
+  });
+
+  it("round-trips dTag/pubkey/relays/kind through decode", () => {
+    const entity = nappIdentifier({
+      dTag: "x",
+      pubkey: GOLDEN_PUBKEY,
+      relays: ["wss://a", "wss://b"],
+    });
+    const decoded = decodeNappIdentifier(entity);
+    assertEquals(decoded.dTag, "x");
+    assertEquals(decoded.pubkey, GOLDEN_PUBKEY);
+    assertEquals(decoded.relays, ["wss://a", "wss://b"]);
+    assertEquals(decoded.kind, 35128);
+  });
+});
+
+describe("indexer relays", () => {
+  it("DEFAULT_NAPP_INDEXER_RELAYS is the 44billion relay", () => {
+    assertEquals(DEFAULT_NAPP_INDEXER_RELAYS, ["wss://relay.44billion.net"]);
+  });
+
+  it("returns the configured override array when set", () => {
+    assertEquals(
+      resolveIndexerRelays({ napp: { indexerRelays: ["wss://x"] } }),
+      ["wss://x"],
+    );
+  });
+
+  it("returns the default when napp present but indexerRelays unset", () => {
+    assertEquals(resolveIndexerRelays({ napp: {} }), DEFAULT_NAPP_INDEXER_RELAYS);
+  });
+
+  it("returns the default for a plain config without a napp section", () => {
+    assertEquals(
+      resolveIndexerRelays({ relays: [], servers: [] }),
+      DEFAULT_NAPP_INDEXER_RELAYS,
+    );
+  });
+
+  it("returns the default for non-object config", () => {
+    assertEquals(resolveIndexerRelays(null), DEFAULT_NAPP_INDEXER_RELAYS);
+    assertEquals(resolveIndexerRelays(undefined), DEFAULT_NAPP_INDEXER_RELAYS);
+  });
+});

--- a/tests/unit/napp/indexer_relays_test.ts
+++ b/tests/unit/napp/indexer_relays_test.ts
@@ -66,14 +66,22 @@ describe("deploy listing publish targeting (dedupe union)", () => {
     //   Array.from(new Set([...resolvedRelays, ...indexerRelays]))
     const resolvedRelays = ["wss://a", "wss://b"];
     const indexerRelays = ["wss://b", "wss://relay.44billion.net"];
-    const publishRelays = Array.from(new Set([...resolvedRelays, ...indexerRelays]));
-    assertEquals(publishRelays, ["wss://a", "wss://b", "wss://relay.44billion.net"]);
+    const publishRelays = Array.from(
+      new Set([...resolvedRelays, ...indexerRelays]),
+    );
+    assertEquals(publishRelays, [
+      "wss://a",
+      "wss://b",
+      "wss://relay.44billion.net",
+    ]);
   });
 
   it("keeps every resolved relay even when no indexer overlap", () => {
     const resolvedRelays = ["wss://a", "wss://b", "wss://c"];
     const indexerRelays = DEFAULT_NAPP_INDEXER_RELAYS;
-    const publishRelays = Array.from(new Set([...resolvedRelays, ...indexerRelays]));
+    const publishRelays = Array.from(
+      new Set([...resolvedRelays, ...indexerRelays]),
+    );
     assertEquals(publishRelays, [
       "wss://a",
       "wss://b",

--- a/tests/unit/napp/indexer_relays_test.ts
+++ b/tests/unit/napp/indexer_relays_test.ts
@@ -1,0 +1,84 @@
+import "../../test-setup-global.ts";
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import {
+  DEFAULT_NAPP_INDEXER_RELAYS,
+  resolveIndexerRelays,
+} from "../../../src/lib/napp/identifier.ts";
+import { validateConfig } from "../../../src/lib/config-validator.ts";
+
+function nappConfig(napp: Record<string, unknown> = {}) {
+  return {
+    relays: ["wss://relay.damus.io"],
+    servers: ["https://cdn.hzrd149.com"],
+    napp: {
+      name: { value: "My App" },
+      icon: { hash: "abc123", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+      ...napp,
+    },
+  };
+}
+
+describe("resolveIndexerRelays (config targeting)", () => {
+  it("applies the default when napp present but indexerRelays unset", () => {
+    assertEquals(
+      resolveIndexerRelays({ napp: { name: { value: "x" } } }),
+      DEFAULT_NAPP_INDEXER_RELAYS,
+    );
+  });
+
+  it("respects a configured indexerRelays override", () => {
+    assertEquals(
+      resolveIndexerRelays({ napp: { indexerRelays: ["wss://custom"] } }),
+      ["wss://custom"],
+    );
+  });
+
+  it("returns the default for a plain config with no napp section", () => {
+    assertEquals(
+      resolveIndexerRelays({ relays: [], servers: [] }),
+      DEFAULT_NAPP_INDEXER_RELAYS,
+    );
+  });
+});
+
+describe("schema (indexerRelays is optional + additive)", () => {
+  it("accepts a napp with indexerRelays", () => {
+    const result = validateConfig(
+      nappConfig({ indexerRelays: ["wss://x", "ws://y"] }),
+    );
+    assertEquals(result.valid, true);
+    assertEquals(result.errors.length, 0);
+  });
+
+  it("still accepts a napp without indexerRelays (optional)", () => {
+    const result = validateConfig(nappConfig());
+    assertEquals(result.valid, true);
+    assertEquals(result.errors.length, 0);
+  });
+});
+
+describe("deploy listing publish targeting (dedupe union)", () => {
+  it("publishes to the deduped union of resolved + indexer relays", () => {
+    // This mirrors the exact set logic used in maybePublishAppListing:
+    //   Array.from(new Set([...resolvedRelays, ...indexerRelays]))
+    const resolvedRelays = ["wss://a", "wss://b"];
+    const indexerRelays = ["wss://b", "wss://relay.44billion.net"];
+    const publishRelays = Array.from(new Set([...resolvedRelays, ...indexerRelays]));
+    assertEquals(publishRelays, ["wss://a", "wss://b", "wss://relay.44billion.net"]);
+  });
+
+  it("keeps every resolved relay even when no indexer overlap", () => {
+    const resolvedRelays = ["wss://a", "wss://b", "wss://c"];
+    const indexerRelays = DEFAULT_NAPP_INDEXER_RELAYS;
+    const publishRelays = Array.from(new Set([...resolvedRelays, ...indexerRelays]));
+    assertEquals(publishRelays, [
+      "wss://a",
+      "wss://b",
+      "wss://c",
+      "wss://relay.44billion.net",
+    ]);
+  });
+});

--- a/tests/unit/napp/listing_test.ts
+++ b/tests/unit/napp/listing_test.ts
@@ -171,12 +171,13 @@ describe("createAppListingTemplate — createdAt override", () => {
 describe("createAppListingEvent", () => {
   it("returns a signed event with id/pubkey/sig", async () => {
     const stub = {
-      signEvent: async (template: unknown) => ({
-        ...(template as Record<string, unknown>),
-        id: "deadbeef",
-        pubkey: "00".repeat(32),
-        sig: "00".repeat(64),
-      }),
+      signEvent: (template: unknown) =>
+        Promise.resolve({
+          ...(template as Record<string, unknown>),
+          id: "deadbeef",
+          pubkey: "00".repeat(32),
+          sig: "00".repeat(64),
+        }),
     } as unknown as ISigner;
     const ev = await createAppListingEvent(
       stub,

--- a/tests/unit/napp/listing_test.ts
+++ b/tests/unit/napp/listing_test.ts
@@ -63,11 +63,15 @@ describe("createAppListingTemplate — required tags (minimal)", () => {
     assertEquals(t.content, "");
     assertEquals(typeof t.created_at, "number");
   });
-  it('name without lang has no 3rd element', () => {
+  it("name without lang has no 3rd element", () => {
     assertEquals(t.tags.find((x) => x[0] === "name"), ["name", "My App"]);
   });
   it("icon without country has no 4th element", () => {
-    assertEquals(t.tags.find((x) => x[0] === "icon"), ["icon", "iconhash", "image/png"]);
+    assertEquals(t.tags.find((x) => x[0] === "icon"), [
+      "icon",
+      "iconhash",
+      "image/png",
+    ]);
   });
   it('exactly one ["c","*"]', () => {
     const c = t.tags.filter((x) => x[0] === "c");
@@ -82,7 +86,11 @@ describe("createAppListingTemplate — required tags (minimal)", () => {
   });
   it("no optional tags when absent", () => {
     for (const k of ["summary", "description", "keyart", "screenshot", "t"]) {
-      assertEquals(t.tags.find((x) => x[0] === k), undefined, `unexpected ${k}`);
+      assertEquals(
+        t.tags.find((x) => x[0] === k),
+        undefined,
+        `unexpected ${k}`,
+      );
     }
   });
   it("client tag present", () => {
@@ -96,24 +104,41 @@ describe("createAppListingTemplate — optionals (full)", () => {
     assertEquals(t.tags.find((x) => x[0] === "name"), ["name", "My App", "en"]);
   });
   it("icon with country", () => {
-    assertEquals(t.tags.find((x) => x[0] === "icon"), ["icon", "iconhash", "image/png", "US"]);
+    assertEquals(t.tags.find((x) => x[0] === "icon"), [
+      "icon",
+      "iconhash",
+      "image/png",
+      "US",
+    ]);
   });
   it('countries ["US","DE"] -> two c tags, no "*"', () => {
     const c = t.tags.filter((x) => x[0] === "c");
     assertEquals(c, [["c", "US"], ["c", "DE"]]);
   });
   it("self emitted with the configured pubkey", () => {
-    assertEquals(t.tags.find((x) => x[0] === "self"), ["self", "ab".repeat(32)]);
+    assertEquals(t.tags.find((x) => x[0] === "self"), [
+      "self",
+      "ab".repeat(32),
+    ]);
   });
   it("summary + description with lang", () => {
-    assertEquals(t.tags.find((x) => x[0] === "summary"), ["summary", "a short summary", "en"]);
+    assertEquals(t.tags.find((x) => x[0] === "summary"), [
+      "summary",
+      "a short summary",
+      "en",
+    ]);
     assertEquals(
       t.tags.find((x) => x[0] === "description"),
       ["description", "a long description", "de"],
     );
   });
   it("keyart with country", () => {
-    assertEquals(t.tags.find((x) => x[0] === "keyart"), ["keyart", "keyhash", "image/jpeg", "GB"]);
+    assertEquals(t.tags.find((x) => x[0] === "keyart"), [
+      "keyart",
+      "keyhash",
+      "image/jpeg",
+      "GB",
+    ]);
   });
   it("two screenshots in order, trailing country dropped", () => {
     const s = t.tags.filter((x) => x[0] === "screenshot");
@@ -129,7 +154,10 @@ describe("createAppListingTemplate — optionals (full)", () => {
     ]);
   });
   it("two t tags", () => {
-    assertEquals(t.tags.filter((x) => x[0] === "t"), [["t", "foo"], ["t", "bar"]]);
+    assertEquals(t.tags.filter((x) => x[0] === "t"), [["t", "foo"], [
+      "t",
+      "bar",
+    ]]);
   });
 });
 
@@ -150,7 +178,13 @@ describe("createAppListingEvent", () => {
         sig: "00".repeat(64),
       }),
     } as unknown as ISigner;
-    const ev = await createAppListingEvent(stub, "pub", minimalNapp, "my-site", 42);
+    const ev = await createAppListingEvent(
+      stub,
+      "pub",
+      minimalNapp,
+      "my-site",
+      42,
+    );
     assertEquals(ev.kind, 37348);
     assertEquals(ev.id, "deadbeef");
     assertEquals(ev.sig, "00".repeat(64));
@@ -170,7 +204,7 @@ describe("deriveListingDTag", () => {
   it('config { id: null } -> ""', () => {
     assertEquals(deriveListingDTag({ id: null }), "");
   });
-  it('named manifest event with d tag -> that d', () => {
+  it("named manifest event with d tag -> that d", () => {
     const manifest = {
       kind: 35128,
       tags: [["d", "my-site"], ["client", "nsyte"]],

--- a/tests/unit/napp/listing_test.ts
+++ b/tests/unit/napp/listing_test.ts
@@ -1,0 +1,197 @@
+// Import test setup FIRST to block all system access
+import "../../test-setup-global.ts";
+
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import type { ISigner } from "applesauce-signers";
+import {
+  createAppListingEvent,
+  createAppListingTemplate,
+  deriveListingDTag,
+  NSITE_APP_LISTING_KIND,
+  NSITE_RELEASE_NOTE_KIND,
+} from "../../../src/lib/napp/listing.ts";
+import type { NappConfig } from "../../../src/lib/napp/types.ts";
+
+const minimalNapp: NappConfig = {
+  name: { value: "My App" },
+  icon: { hash: "iconhash", mime: "image/png" },
+  categories: ["napp.games:rpg"],
+  countries: ["*"],
+};
+
+const fullNapp: NappConfig = {
+  name: { value: "My App", lang: "en" },
+  icon: { hash: "iconhash", mime: "image/png", country: "US" },
+  categories: ["napp.games:rpg", "napp.tools:dev"],
+  countries: ["US", "DE"],
+  self: "ab".repeat(32),
+  summary: { value: "a short summary", lang: "en" },
+  description: { value: "a long description", lang: "de" },
+  keyart: { hash: "keyhash", mime: "image/jpeg", country: "GB" },
+  screenshots: [
+    { hash: "shot1", mime: "image/png" },
+    { hash: "shot2", mime: "image/webp", country: "FR" },
+  ],
+  tags: ["foo", "bar"],
+};
+
+describe("kind constants", () => {
+  it("NSITE_APP_LISTING_KIND is 37348", () => {
+    assertEquals(NSITE_APP_LISTING_KIND, 37348);
+  });
+  it("NSITE_RELEASE_NOTE_KIND is 39108", () => {
+    assertEquals(NSITE_RELEASE_NOTE_KIND, 39108);
+  });
+});
+
+describe("createAppListingTemplate — d tag", () => {
+  it('root-site napp ("") emits ["d", ""]', () => {
+    const t = createAppListingTemplate("pub", minimalNapp, "");
+    assertEquals(t.tags[0], ["d", ""]);
+  });
+  it('named-site napp emits ["d", "my-site"]', () => {
+    const t = createAppListingTemplate("pub", minimalNapp, "my-site");
+    assertEquals(t.tags[0], ["d", "my-site"]);
+  });
+});
+
+describe("createAppListingTemplate — required tags (minimal)", () => {
+  const t = createAppListingTemplate("pub", minimalNapp, "");
+  it("kind / content / created_at", () => {
+    assertEquals(t.kind, 37348);
+    assertEquals(t.content, "");
+    assertEquals(typeof t.created_at, "number");
+  });
+  it('name without lang has no 3rd element', () => {
+    assertEquals(t.tags.find((x) => x[0] === "name"), ["name", "My App"]);
+  });
+  it("icon without country has no 4th element", () => {
+    assertEquals(t.tags.find((x) => x[0] === "icon"), ["icon", "iconhash", "image/png"]);
+  });
+  it('exactly one ["c","*"]', () => {
+    const c = t.tags.filter((x) => x[0] === "c");
+    assertEquals(c, [["c", "*"]]);
+  });
+  it('one ["l","napp.games:rpg"]', () => {
+    const l = t.tags.filter((x) => x[0] === "l");
+    assertEquals(l, [["l", "napp.games:rpg"]]);
+  });
+  it("no self tag when self absent", () => {
+    assertEquals(t.tags.find((x) => x[0] === "self"), undefined);
+  });
+  it("no optional tags when absent", () => {
+    for (const k of ["summary", "description", "keyart", "screenshot", "t"]) {
+      assertEquals(t.tags.find((x) => x[0] === k), undefined, `unexpected ${k}`);
+    }
+  });
+  it("client tag present", () => {
+    assertEquals(t.tags.find((x) => x[0] === "client"), ["client", "nsyte"]);
+  });
+});
+
+describe("createAppListingTemplate — optionals (full)", () => {
+  const t = createAppListingTemplate("pub", fullNapp, "id");
+  it("name with lang", () => {
+    assertEquals(t.tags.find((x) => x[0] === "name"), ["name", "My App", "en"]);
+  });
+  it("icon with country", () => {
+    assertEquals(t.tags.find((x) => x[0] === "icon"), ["icon", "iconhash", "image/png", "US"]);
+  });
+  it('countries ["US","DE"] -> two c tags, no "*"', () => {
+    const c = t.tags.filter((x) => x[0] === "c");
+    assertEquals(c, [["c", "US"], ["c", "DE"]]);
+  });
+  it("self emitted with the configured pubkey", () => {
+    assertEquals(t.tags.find((x) => x[0] === "self"), ["self", "ab".repeat(32)]);
+  });
+  it("summary + description with lang", () => {
+    assertEquals(t.tags.find((x) => x[0] === "summary"), ["summary", "a short summary", "en"]);
+    assertEquals(
+      t.tags.find((x) => x[0] === "description"),
+      ["description", "a long description", "de"],
+    );
+  });
+  it("keyart with country", () => {
+    assertEquals(t.tags.find((x) => x[0] === "keyart"), ["keyart", "keyhash", "image/jpeg", "GB"]);
+  });
+  it("two screenshots in order, trailing country dropped", () => {
+    const s = t.tags.filter((x) => x[0] === "screenshot");
+    assertEquals(s, [
+      ["screenshot", "shot1", "image/png"],
+      ["screenshot", "shot2", "image/webp", "FR"],
+    ]);
+  });
+  it("two l tags", () => {
+    assertEquals(t.tags.filter((x) => x[0] === "l"), [
+      ["l", "napp.games:rpg"],
+      ["l", "napp.tools:dev"],
+    ]);
+  });
+  it("two t tags", () => {
+    assertEquals(t.tags.filter((x) => x[0] === "t"), [["t", "foo"], ["t", "bar"]]);
+  });
+});
+
+describe("createAppListingTemplate — createdAt override", () => {
+  it("uses provided createdAt", () => {
+    const t = createAppListingTemplate("pub", minimalNapp, "", 1234567890);
+    assertEquals(t.created_at, 1234567890);
+  });
+});
+
+describe("createAppListingEvent", () => {
+  it("returns a signed event with id/pubkey/sig", async () => {
+    const stub = {
+      signEvent: async (template: unknown) => ({
+        ...(template as Record<string, unknown>),
+        id: "deadbeef",
+        pubkey: "00".repeat(32),
+        sig: "00".repeat(64),
+      }),
+    } as unknown as ISigner;
+    const ev = await createAppListingEvent(stub, "pub", minimalNapp, "my-site", 42);
+    assertEquals(ev.kind, 37348);
+    assertEquals(ev.id, "deadbeef");
+    assertEquals(ev.sig, "00".repeat(64));
+    assertEquals(ev.pubkey, "00".repeat(32));
+    assertEquals(ev.created_at, 42);
+    assertEquals(ev.tags[0], ["d", "my-site"]);
+  });
+});
+
+describe("deriveListingDTag", () => {
+  it('config { id: "x" } -> "x"', () => {
+    assertEquals(deriveListingDTag({ id: "x" }), "x");
+  });
+  it('config {} -> ""', () => {
+    assertEquals(deriveListingDTag({}), "");
+  });
+  it('config { id: null } -> ""', () => {
+    assertEquals(deriveListingDTag({ id: null }), "");
+  });
+  it('named manifest event with d tag -> that d', () => {
+    const manifest = {
+      kind: 35128,
+      tags: [["d", "my-site"], ["client", "nsyte"]],
+      content: "",
+      created_at: 1,
+      pubkey: "p",
+      id: "i",
+      sig: "s",
+    };
+    assertEquals(deriveListingDTag(manifest as never), "my-site");
+  });
+  it('root manifest event (no d tag) -> ""', () => {
+    const manifest = {
+      kind: 15128,
+      tags: [["client", "nsyte"]],
+      content: "",
+      created_at: 1,
+      pubkey: "p",
+      id: "i",
+      sig: "s",
+    };
+    assertEquals(deriveListingDTag(manifest as never), "");
+  });
+});

--- a/tests/unit/napp/napp_assets_test.ts
+++ b/tests/unit/napp/napp_assets_test.ts
@@ -1,0 +1,279 @@
+import "../../test-setup-global.ts";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { calculateFileHash } from "../../../src/lib/files.ts";
+import type { UploadResponse } from "../../../src/lib/upload.ts";
+import type { FileEntry } from "../../../src/lib/nostr.ts";
+import type { ISigner } from "applesauce-signers";
+import {
+  classifyAssetInput,
+  deriveAssetMime,
+  isRootSite,
+  parseCategoriesInput,
+  parseCountriesInput,
+  resolveNappAsset,
+  rootSiteMigrationNotice,
+  uploadNappAsset,
+} from "../../../src/lib/napp/assets.ts";
+
+const HEX64 = "a".repeat(64);
+
+// A throwaway signer; uploadNappAsset never actually signs when processFn is faked.
+const fakeSigner = {} as unknown as ISigner;
+
+describe("classifyAssetInput (pure)", () => {
+  it("returns hash for a 64-char hex string", () => {
+    assertEquals(classifyAssetInput(HEX64), "hash");
+    assertEquals(classifyAssetInput("F".repeat(64)), "hash");
+  });
+
+  it("returns url for an http(s) string", () => {
+    assertEquals(classifyAssetInput("https://example.com/icon.png"), "url");
+    assertEquals(classifyAssetInput("http://example.com/icon.png"), "url");
+  });
+
+  it("returns path for everything else", () => {
+    assertEquals(classifyAssetInput("./icon.png"), "path");
+    assertEquals(classifyAssetInput("foo.png"), "path");
+    assertEquals(classifyAssetInput("/abs/icon.png"), "path");
+    assertEquals(classifyAssetInput("not-64-hex"), "path");
+  });
+});
+
+describe("deriveAssetMime (pure)", () => {
+  it("maps recognizable image extensions to their MIME", () => {
+    assertEquals(deriveAssetMime("x.png"), "image/png");
+    assertEquals(deriveAssetMime("x.svg"), "image/svg+xml");
+    assertEquals(deriveAssetMime("x.webp"), "image/webp");
+    assertEquals(deriveAssetMime("x.jpg"), "image/jpeg");
+    assertEquals(deriveAssetMime("x.jpeg"), "image/jpeg");
+    assertEquals(deriveAssetMime("x.gif"), "image/gif");
+    assertEquals(deriveAssetMime("x.avif"), "image/avif");
+  });
+
+  it("falls back to image/png for non-image / unknown extensions and hashes", () => {
+    assertEquals(deriveAssetMime(HEX64), "image/png");
+    assertEquals(deriveAssetMime("x.xyz"), "image/png");
+    assertEquals(deriveAssetMime("noext"), "image/png");
+  });
+});
+
+describe("parseCategoriesInput (pure)", () => {
+  it("prepends napp. only when missing, trims, drops blanks, preserves order", () => {
+    assertEquals(
+      parseCategoriesInput([
+        "social:network",
+        "napp.utilities:text editor",
+        "  ",
+        " games:rpg ",
+      ]),
+      ["napp.social:network", "napp.utilities:text editor", "napp.games:rpg"],
+    );
+  });
+
+  it("returns [] for an all-blank input", () => {
+    assertEquals(parseCategoriesInput(["", "   "]), []);
+  });
+});
+
+describe("parseCountriesInput (pure)", () => {
+  it('returns ["*"] for empty or wildcard input', () => {
+    assertEquals(parseCountriesInput(""), ["*"]);
+    assertEquals(parseCountriesInput("   "), ["*"]);
+    assertEquals(parseCountriesInput("*"), ["*"]);
+  });
+
+  it("splits on commas, trims, drops blanks", () => {
+    assertEquals(parseCountriesInput("US, de"), ["US", "de"]);
+    assertEquals(parseCountriesInput("US,,de , "), ["US", "de"]);
+  });
+});
+
+describe("isRootSite (pure)", () => {
+  it("is true when id is missing or empty, false otherwise", () => {
+    assertEquals(isRootSite({}), true);
+    assertEquals(isRootSite({ id: "" }), true);
+    assertEquals(isRootSite({ id: null }), true);
+    assertEquals(isRootSite({ id: "x" }), false);
+  });
+});
+
+describe("rootSiteMigrationNotice (pure)", () => {
+  it("names the kinds, orphaning, and gateway change", () => {
+    const notice = rootSiteMigrationNotice();
+    assert(notice.includes("15128"));
+    assert(notice.includes("35128"));
+    assert(notice.toLowerCase().includes("orphan"));
+    assert(notice.toLowerCase().includes("gateway"));
+  });
+});
+
+describe("resolveNappAsset (boundary)", () => {
+  it("returns {hash,mime} for a hash WITHOUT calling upload", async () => {
+    let called = false;
+    const failUpload = (_p: string): Promise<{ hash: string; mime: string }> => {
+      called = true;
+      return Promise.reject(new Error("upload should not be called"));
+    };
+    const asset = await resolveNappAsset(HEX64, failUpload);
+    assertEquals(asset, { hash: HEX64, mime: "image/png" });
+    assertEquals(called, false);
+  });
+
+  it("returns {hash,mime} for a URL WITHOUT calling upload", async () => {
+    let called = false;
+    const failUpload = (_p: string): Promise<{ hash: string; mime: string }> => {
+      called = true;
+      return Promise.reject(new Error("upload should not be called"));
+    };
+    const asset = await resolveNappAsset("https://x/icon.svg", failUpload);
+    assertEquals(asset, { hash: "https://x/icon.svg", mime: "image/svg+xml" });
+    assertEquals(called, false);
+  });
+
+  it("delegates a local path to the injected upload fn", async () => {
+    const fakeUpload = (p: string): Promise<{ hash: string; mime: string }> =>
+      Promise.resolve({ hash: "UPLOADED:" + p, mime: "image/png" });
+    const asset = await resolveNappAsset("./x.png", fakeUpload);
+    assertEquals(asset, { hash: "UPLOADED:./x.png", mime: "image/png" });
+  });
+});
+
+function successResponse(file: FileEntry): UploadResponse {
+  return {
+    file,
+    success: true,
+    serverResults: { "https://s": { success: true } },
+  };
+}
+
+function failedResponse(file: FileEntry): UploadResponse {
+  return {
+    file,
+    success: false,
+    error: "all servers failed",
+    serverResults: { "https://s": { success: false, error: "nope" } },
+  };
+}
+
+describe("uploadNappAsset (with fake processFn)", () => {
+  it("computes sha256+mime and returns them on success", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4]));
+      const expectedHash = await calculateFileHash(file);
+
+      let captured: FileEntry | undefined;
+      const fakeProcess = (entries: FileEntry[]) => {
+        captured = entries[0];
+        return Promise.resolve([successResponse(entries[0])]);
+      };
+
+      const asset = await uploadNappAsset(
+        file,
+        { servers: ["https://s"], relays: ["wss://r"], signer: fakeSigner },
+        fakeProcess,
+      );
+      assertEquals(asset, { hash: expectedHash, mime: "image/png" });
+      // FileEntry construction: sha256, contentType, data present.
+      assert(captured, "processFn should be called");
+      assertEquals(captured!.sha256, expectedHash);
+      assertEquals(captured!.contentType, "image/png");
+      assertEquals(captured!.size, 4);
+      assert(captured!.data instanceof Uint8Array);
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+
+  it("throws when servers is empty", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4]));
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            file,
+            { servers: [], relays: ["wss://r"], signer: fakeSigner },
+            () => Promise.resolve([]),
+          ),
+        Error,
+        "server",
+      );
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+
+  it("throws when relays is empty (pre-empts processUploads generic error)", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4]));
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            file,
+            { servers: ["https://s"], relays: [], signer: fakeSigner },
+            () => Promise.resolve([]),
+          ),
+        Error,
+        "relay",
+      );
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+
+  it("throws when the file is missing", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            `${dir}/nope.png`,
+            { servers: ["https://s"], relays: ["wss://r"], signer: fakeSigner },
+            () => Promise.resolve([]),
+          ),
+        Error,
+      );
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("throws when the file is empty", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            file,
+            { servers: ["https://s"], relays: ["wss://r"], signer: fakeSigner },
+            () => Promise.resolve([]),
+          ),
+        Error,
+        "empty",
+      );
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+
+  it("throws when the upload did not succeed", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4]));
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            file,
+            { servers: ["https://s"], relays: ["wss://r"], signer: fakeSigner },
+            (entries: FileEntry[]) => Promise.resolve([failedResponse(entries[0])]),
+          ),
+        Error,
+      );
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+});

--- a/tests/unit/napp/napp_command_test.ts
+++ b/tests/unit/napp/napp_command_test.ts
@@ -15,7 +15,9 @@ const validNapp = {
   countries: ["*"],
 };
 
-function nappProjectConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+function nappProjectConfig(
+  overrides: Partial<ProjectConfig> = {},
+): ProjectConfig {
   return {
     relays: [],
     servers: [],
@@ -46,19 +48,28 @@ describe("resolveNappIdentifier (pure helper)", () => {
 
   it("throws a clear error for a root site (empty id)", () => {
     const config = nappProjectConfig({ id: "" });
-    const err = assertThrows(() => resolveNappIdentifier(config, TEST_PUBKEY), Error);
+    const err = assertThrows(
+      () => resolveNappIdentifier(config, TEST_PUBKEY),
+      Error,
+    );
     assertStringIncludes(err.message, "named site");
   });
 
   it("throws a clear error for a root site (undefined id)", () => {
     const config = nappProjectConfig({ id: undefined });
-    const err = assertThrows(() => resolveNappIdentifier(config, TEST_PUBKEY), Error);
+    const err = assertThrows(
+      () => resolveNappIdentifier(config, TEST_PUBKEY),
+      Error,
+    );
     assertStringIncludes(err.message, "named site");
   });
 
   it("throws a clear error for a non-napp config", () => {
     const config = { relays: [], servers: [], id: "my-site" } as ProjectConfig;
-    const err = assertThrows(() => resolveNappIdentifier(config, TEST_PUBKEY), Error);
+    const err = assertThrows(
+      () => resolveNappIdentifier(config, TEST_PUBKEY),
+      Error,
+    );
     assertStringIncludes(err.message, "not a napp");
   });
 });

--- a/tests/unit/napp/napp_command_test.ts
+++ b/tests/unit/napp/napp_command_test.ts
@@ -1,0 +1,64 @@
+import "../../test-setup-global.ts";
+import { assertEquals, assertStringIncludes, assertThrows } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { resolveNappIdentifier } from "../../../src/commands/napp.ts";
+import { decodeNappIdentifier } from "../../../src/lib/napp/identifier.ts";
+import type { ProjectConfig } from "../../../src/lib/config.ts";
+
+const TEST_PUBKEY =
+  "5a8bc85694d8fbb4f30208649c1c52509636d1e6fdb1f0f4c84a3f10f9383ec9";
+
+const validNapp = {
+  name: { value: "My App" },
+  icon: { hash: "abc123", mime: "image/png" },
+  categories: ["napp.games:rpg"],
+  countries: ["*"],
+};
+
+function nappProjectConfig(overrides: Partial<ProjectConfig> = {}): ProjectConfig {
+  return {
+    relays: [],
+    servers: [],
+    napp: validNapp,
+    ...overrides,
+  } as ProjectConfig;
+}
+
+describe("resolveNappIdentifier (pure helper)", () => {
+  it("returns a + identifier for a named napp and round-trips", () => {
+    const config = nappProjectConfig({ id: "my-site" });
+    const result = resolveNappIdentifier(config, TEST_PUBKEY);
+    assertEquals(result.startsWith("+"), true);
+    const decoded = decodeNappIdentifier(result);
+    assertEquals(decoded.dTag, "my-site");
+    assertEquals(decoded.pubkey, TEST_PUBKEY);
+  });
+
+  it("includes only the first 2 configured relays as hints", () => {
+    const config = nappProjectConfig({
+      id: "my-site",
+      relays: ["wss://a", "wss://b", "wss://c"],
+    });
+    const result = resolveNappIdentifier(config, TEST_PUBKEY);
+    const decoded = decodeNappIdentifier(result);
+    assertEquals(decoded.relays, ["wss://a", "wss://b"]);
+  });
+
+  it("throws a clear error for a root site (empty id)", () => {
+    const config = nappProjectConfig({ id: "" });
+    const err = assertThrows(() => resolveNappIdentifier(config, TEST_PUBKEY), Error);
+    assertStringIncludes(err.message, "named site");
+  });
+
+  it("throws a clear error for a root site (undefined id)", () => {
+    const config = nappProjectConfig({ id: undefined });
+    const err = assertThrows(() => resolveNappIdentifier(config, TEST_PUBKEY), Error);
+    assertStringIncludes(err.message, "named site");
+  });
+
+  it("throws a clear error for a non-napp config", () => {
+    const config = { relays: [], servers: [], id: "my-site" } as ProjectConfig;
+    const err = assertThrows(() => resolveNappIdentifier(config, TEST_PUBKEY), Error);
+    assertStringIncludes(err.message, "not a napp");
+  });
+});

--- a/tests/unit/napp/napp_init_command_test.ts
+++ b/tests/unit/napp/napp_init_command_test.ts
@@ -2,14 +2,55 @@ import "../../test-setup-global.ts";
 import { assert, assertEquals, assertFalse } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
-import { registerNappCommand } from "../../../src/commands/napp.ts";
+import {
+  decideRootSiteId,
+  planNappInitFromFlags,
+  registerNappCommand,
+} from "../../../src/commands/napp.ts";
 import {
   buildNappConfigFromAnswers,
+  collectNappListing,
+  type NappAssetResolver,
   type ProjectConfig,
   readProjectFile,
   writeProjectFile,
 } from "../../../src/lib/config.ts";
 import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
+
+// A no-network resolver: hash/URL/path all return a deterministic asset so the
+// composition tests never touch real blossom servers or relays.
+const fakeResolver: NappAssetResolver = (value: string) =>
+  Promise.resolve({ hash: `resolved:${value}`, mime: "image/png" });
+
+// Mirror of nappInitAction's flag-driven, non-interactive path (no prompts, no exit):
+// plan flags -> collect listing (fake resolver) -> validate -> write/read round-trip.
+async function runFlagDrivenInit(
+  flags: Parameters<typeof planNappInitFromFlags>[0],
+  path: string,
+): Promise<ProjectConfig> {
+  const plan = planNappInitFromFlags(flags);
+  const projectConfig = readProjectFile(path)!;
+  if (isRootSiteId(projectConfig.id)) {
+    const decision = decideRootSiteId({
+      isRoot: true,
+      idFlag: plan.id,
+      interactive: false,
+    });
+    if (decision.setId !== undefined) projectConfig.id = decision.setId;
+  }
+  const napp = await collectNappListing({
+    prefill: plan.prefill,
+    interactive: false,
+    resolveAsset: fakeResolver,
+  });
+  const updated: ProjectConfig = { ...projectConfig, napp };
+  writeProjectFile(updated, path);
+  return readProjectFile(path)!;
+}
+
+function isRootSiteId(id: ProjectConfig["id"]): boolean {
+  return id === undefined || id === null || id === "";
+}
 
 const validNapp = {
   name: { value: "My App" },
@@ -76,6 +117,100 @@ describe("napp init retrofit round-trip (temp dir)", () => {
       assertEquals(read.relays, ["wss://r"]);
       assertEquals(read.servers, ["https://s"]);
       assertEquals(read.id, "my-site");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+});
+
+describe("napp init flag-driven write (temp dir, fake resolver)", () => {
+  it("writes a full napp section from flags, preserving unrelated keys", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, ".nsite", "config.json");
+      writeProjectFile({
+        relays: ["wss://r"],
+        servers: ["https://s"],
+        id: "my-site",
+      }, path);
+
+      const read = await runFlagDrivenInit({
+        name: "My App",
+        icon: "a".repeat(64),
+        iconMime: "image/png",
+        category: ["social:network", "games:rpg"],
+        countries: "US, de",
+        summary: "Short",
+        tag: ["nostr"],
+      }, path);
+
+      assert(isNapp(read), "flag-driven config should be a napp");
+      assertEquals(validateNappConfig(read.napp).length, 0);
+      assertEquals(read.napp!.name, { value: "My App" });
+      assertEquals(read.napp!.icon, {
+        hash: `resolved:${"a".repeat(64)}`,
+        mime: "image/png",
+      });
+      assertEquals(read.napp!.categories, [
+        "napp.social:network",
+        "napp.games:rpg",
+      ]);
+      assertEquals(read.napp!.countries, ["US", "de"]);
+      assertEquals(read.napp!.summary, { value: "Short" });
+      assertEquals(read.napp!.tags, ["nostr"]);
+      // Unrelated keys survive.
+      assertEquals(read.relays, ["wss://r"]);
+      assertEquals(read.id, "my-site");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("non-interactive missing-required surfaces via plan.missingRequired", () => {
+    const plan = planNappInitFromFlags({ name: "Only Name" });
+    assert(plan.missingRequired.length > 0);
+    assert(plan.missingRequired.includes("icon"));
+    assert(plan.missingRequired.includes("category"));
+  });
+
+  it("root-site + --id sets config.id (opt-in migration)", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, ".nsite", "config.json");
+      // Root site: id is empty.
+      writeProjectFile({ relays: ["wss://r"], servers: ["https://s"], id: "" }, path);
+
+      const read = await runFlagDrivenInit({
+        name: "App",
+        icon: "h",
+        category: ["games:rpg"],
+        id: "blog",
+      }, path);
+
+      assertEquals(read.id, "blog");
+      assert(isNapp(read));
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("root-site without --id (non-interactive) writes napp without setting id", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, ".nsite", "config.json");
+      writeProjectFile({ relays: ["wss://r"], servers: ["https://s"], id: "" }, path);
+
+      const read = await runFlagDrivenInit({
+        name: "App",
+        icon: "h",
+        category: ["games:rpg"],
+      }, path);
+
+      assertEquals(read.id, "");
+      assert(isNapp(read), "napp section still written");
+      // decideRootSiteId still signals the notice for non-interactive root sites.
+      const decision = decideRootSiteId({ isRoot: true, interactive: false });
+      assertEquals(decision, { printNotice: true });
     } finally {
       await Deno.remove(dir, { recursive: true });
     }

--- a/tests/unit/napp/napp_init_command_test.ts
+++ b/tests/unit/napp/napp_init_command_test.ts
@@ -1,0 +1,83 @@
+import "../../test-setup-global.ts";
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { registerNappCommand } from "../../../src/commands/napp.ts";
+import {
+  buildNappConfigFromAnswers,
+  type ProjectConfig,
+  readProjectFile,
+  writeProjectFile,
+} from "../../../src/lib/config.ts";
+import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
+
+const validNapp = {
+  name: { value: "My App" },
+  icon: { hash: "abc123", mime: "image/png" },
+  categories: ["napp.games:rpg"],
+  countries: ["*"],
+};
+
+describe("napp init subcommand registration", () => {
+  it("registerNappCommand() does not throw (registers id/release/init)", () => {
+    registerNappCommand();
+  });
+});
+
+describe("napp init guards", () => {
+  it("already-napp guard: isNapp(config-with-valid-napp) === true", () => {
+    const config: ProjectConfig = {
+      relays: [],
+      servers: [],
+      napp: validNapp,
+    } as ProjectConfig;
+    assert(isNapp(config));
+  });
+
+  it("no-config guard: readProjectFile(missing path) === null", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const missing = join(dir, "missing", "config.json");
+      assertEquals(readProjectFile(missing), null);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+});
+
+describe("napp init retrofit round-trip (temp dir)", () => {
+  it("retrofits a napp section onto a non-napp config, preserving other keys", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, ".nsite", "config.json");
+      // Write a non-napp config first.
+      writeProjectFile({
+        relays: ["wss://r"],
+        servers: ["https://s"],
+        id: "my-site",
+      }, path);
+
+      const cfg = readProjectFile(path)!;
+      assertFalse(isNapp(cfg));
+
+      // Retrofit using the SAME assembly helper the wizard uses.
+      cfg.napp = buildNappConfigFromAnswers({
+        name: "App",
+        iconHash: "h",
+        categories: ["napp.games:rpg"],
+        countries: ["*"],
+      });
+      writeProjectFile(cfg, path);
+
+      const read = readProjectFile(path)!;
+      assert(isNapp(read), "retrofitted config should be a napp");
+      assertEquals(validateNappConfig(read.napp).length, 0);
+      // Unrelated keys survive (T-24-01).
+      assertEquals(read.relays, ["wss://r"]);
+      assertEquals(read.servers, ["https://s"]);
+      assertEquals(read.id, "my-site");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+});

--- a/tests/unit/napp/napp_init_flags_test.ts
+++ b/tests/unit/napp/napp_init_flags_test.ts
@@ -1,0 +1,103 @@
+import "../../test-setup-global.ts";
+import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { decideRootSiteId, planNappInitFromFlags } from "../../../src/commands/napp.ts";
+
+describe("planNappInitFromFlags (pure)", () => {
+  it("parses full flags into answersFromFlags with no missing required", () => {
+    const plan = planNappInitFromFlags({
+      name: "My App",
+      icon: "a".repeat(64),
+      iconMime: "image/png",
+      category: ["social:network", "napp.games:rpg"],
+      countries: "US, de",
+      summary: "Short",
+      description: "Long",
+      self: "b".repeat(64),
+      keyart: "https://x/key.png",
+      screenshot: ["s1", "s2"],
+      tag: ["nostr", "social"],
+      indexerRelay: ["wss://indexer"],
+      id: "my-site",
+      yes: true,
+    });
+
+    assertEquals(plan.prefill.name, "My App");
+    assertEquals(plan.prefill.icon, "a".repeat(64));
+    assertEquals(plan.prefill.iconMime, "image/png");
+    assertEquals(plan.prefill.categories, [
+      "napp.social:network",
+      "napp.games:rpg",
+    ]);
+    assertEquals(plan.prefill.countries, ["US", "de"]);
+    assertEquals(plan.prefill.summary, "Short");
+    assertEquals(plan.prefill.description, "Long");
+    assertEquals(plan.prefill.self, "b".repeat(64));
+    assertEquals(plan.prefill.keyart, "https://x/key.png");
+    assertEquals(plan.prefill.screenshots, ["s1", "s2"]);
+    assertEquals(plan.prefill.tags, ["nostr", "social"]);
+    assertEquals(plan.prefill.indexerRelays, ["wss://indexer"]);
+    assertEquals(plan.id, "my-site");
+    assertEquals(plan.yes, true);
+    assertEquals(plan.missingRequired, []);
+  });
+
+  it("computes missingRequired when only --name is given", () => {
+    const plan = planNappInitFromFlags({ name: "Only Name" });
+    assert(plan.missingRequired.includes("icon"));
+    assert(plan.missingRequired.includes("category"));
+    assert(!plan.missingRequired.includes("name"));
+  });
+
+  it("keeps three repeated --category values", () => {
+    const plan = planNappInitFromFlags({
+      name: "n",
+      icon: "i",
+      category: ["a:b", "c:d", "e:f"],
+    });
+    assertEquals(plan.prefill.categories, ["napp.a:b", "napp.c:d", "napp.e:f"]);
+    assertEquals(plan.missingRequired, []);
+  });
+
+  it("is pure: returns plain data and does not touch the filesystem", () => {
+    const plan = planNappInitFromFlags({});
+    assertEquals(typeof plan, "object");
+    assert(Array.isArray(plan.missingRequired));
+  });
+});
+
+describe("decideRootSiteId (pure)", () => {
+  it("non-root: no notice, no setId", () => {
+    const d = decideRootSiteId({ isRoot: false, interactive: false });
+    assertEquals(d, { printNotice: false });
+  });
+
+  it("root + idFlag: setId and printNotice", () => {
+    const d = decideRootSiteId({ isRoot: true, idFlag: "x", interactive: false });
+    assertEquals(d, { setId: "x", printNotice: true });
+  });
+
+  it("root + no idFlag + non-interactive: printNotice, no setId", () => {
+    const d = decideRootSiteId({ isRoot: true, interactive: false });
+    assertEquals(d, { printNotice: true });
+  });
+
+  it("root + interactive + confirmed value: setId", () => {
+    const d = decideRootSiteId({
+      isRoot: true,
+      interactive: true,
+      confirmed: true,
+      confirmedValue: "blog",
+    });
+    assertEquals(d, { setId: "blog", printNotice: true });
+  });
+
+  it("root + interactive + declined: no setId, printNotice", () => {
+    const d = decideRootSiteId({
+      isRoot: true,
+      interactive: true,
+      confirmed: false,
+    });
+    assertEquals(d, { printNotice: true });
+  });
+});

--- a/tests/unit/napp/napp_release_command_test.ts
+++ b/tests/unit/napp/napp_release_command_test.ts
@@ -1,0 +1,97 @@
+// Import test setup FIRST to block all system access
+import "../../test-setup-global.ts";
+
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import type { NostrEvent } from "applesauce-core/helpers";
+import {
+  buildReleaseChangesFromFlags,
+  hasAnyChange,
+  registerNappCommand,
+  resolveManifestVersion,
+} from "../../../src/commands/napp.ts";
+
+describe("buildReleaseChangesFromFlags", () => {
+  it("includes only present, non-empty categories", () => {
+    const changes = buildReleaseChangesFromFlags({
+      fix: ["a"],
+      add: ["b"],
+      sub: undefined,
+    });
+    assertEquals(changes, { fix: ["a"], add: ["b"] });
+  });
+
+  it("omits empty arrays", () => {
+    const changes = buildReleaseChangesFromFlags({ fix: [], add: ["b"] });
+    assertEquals(changes, { add: ["b"] });
+  });
+
+  it("no flags -> empty changes object", () => {
+    assertEquals(buildReleaseChangesFromFlags({}), {});
+  });
+
+  it("collects all five categories when present", () => {
+    const changes = buildReleaseChangesFromFlags({
+      fix: ["f"],
+      add: ["a"],
+      try: ["t"],
+      cut: ["c"],
+      sub: ["s"],
+    });
+    assertEquals(changes, {
+      fix: ["f"],
+      add: ["a"],
+      try: ["t"],
+      cut: ["c"],
+      sub: ["s"],
+    });
+  });
+});
+
+describe("hasAnyChange", () => {
+  it("empty object is false", () => {
+    assertFalse(hasAnyChange({}));
+  });
+
+  it("a category with entries is true", () => {
+    assert(hasAnyChange({ cut: ["x"] }));
+  });
+
+  it("a category with an empty array is false", () => {
+    assertFalse(hasAnyChange({ add: [] }));
+  });
+});
+
+describe("resolveManifestVersion", () => {
+  it("pins id/d/created_at from a named-site manifest", () => {
+    const manifest = {
+      id: "f".repeat(64),
+      created_at: 1_700_000_000,
+      tags: [["d", "my-site"]],
+    } as unknown as NostrEvent;
+    assertEquals(resolveManifestVersion(manifest), {
+      manifestId: "f".repeat(64),
+      manifestDTag: "my-site",
+      manifestCreatedAt: 1_700_000_000,
+    });
+  });
+
+  it("root manifest (no d tag) yields empty manifestDTag", () => {
+    const manifest = {
+      id: "a".repeat(64),
+      created_at: 1_700_000_000,
+      tags: [["client", "nsyte"]],
+    } as unknown as NostrEvent;
+    assertEquals(resolveManifestVersion(manifest), {
+      manifestId: "a".repeat(64),
+      manifestDTag: "",
+      manifestCreatedAt: 1_700_000_000,
+    });
+  });
+});
+
+describe("registerNappCommand (safe registration)", () => {
+  it("does not throw", () => {
+    registerNappCommand();
+  });
+});

--- a/tests/unit/napp/napp_validate_command_test.ts
+++ b/tests/unit/napp/napp_validate_command_test.ts
@@ -1,0 +1,121 @@
+import "../../test-setup-global.ts";
+import { assert, assertEquals, assertFalse } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  assembleValidateReport,
+  detectNip07InText,
+  registerNappCommand,
+  scanDirForNip07Evidence,
+} from "../../../src/commands/napp.ts";
+import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
+
+describe("detectNip07InText (pure helper)", () => {
+  it("detects window.nostr / getPublicKey usage", () => {
+    assert(
+      detectNip07InText("if (window.nostr) { await window.nostr.getPublicKey(); }"),
+    );
+  });
+  it("detects nostr-login import", () => {
+    assert(detectNip07InText("import 'nostr-login'"));
+  });
+  it("detects nip07 token", () => {
+    assert(detectNip07InText("const x = nip07;"));
+  });
+  it("is case-insensitive", () => {
+    assert(detectNip07InText("WINDOW.NOSTR.GETPUBLICKEY()"));
+  });
+  it("returns false for plain text with no evidence", () => {
+    assertFalse(detectNip07InText("plain static html with no nostr"));
+  });
+});
+
+describe("scanDirForNip07Evidence (temp dir)", () => {
+  it("returns true when any scanned file contains an evidence token", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(
+        join(dir, "app.js"),
+        "const pk = await window.nostr.getPublicKey();",
+      );
+      assert(await scanDirForNip07Evidence(dir));
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("returns false when no scanned file contains a token", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      await Deno.writeTextFile(join(dir, "index.html"), "<html><body>hello</body></html>");
+      assertFalse(await scanDirForNip07Evidence(dir));
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("tolerates a nonexistent dir (returns false, no throw)", async () => {
+    const dir = await Deno.makeTempDir();
+    await Deno.remove(dir, { recursive: true });
+    assertFalse(await scanDirForNip07Evidence(join(dir, "gone")));
+  });
+});
+
+describe("assembleValidateReport (pure helper)", () => {
+  it("structural errors drive ok=false; NIP-07 only sets a note", () => {
+    assertEquals(
+      assembleValidateReport({ structuralErrors: [], nip07Found: false }),
+      { ok: true, structuralErrors: [], nip07: "warn" },
+    );
+    assertEquals(
+      assembleValidateReport({
+        structuralErrors: [{ path: "/napp/name", message: "is required" }],
+        nip07Found: true,
+      }),
+      {
+        ok: false,
+        structuralErrors: [{ path: "/napp/name", message: "is required" }],
+        nip07: "pass",
+      },
+    );
+  });
+
+  it("NIP-07 never flips ok to false", () => {
+    const r = assembleValidateReport({ structuralErrors: [], nip07Found: false });
+    assert(r.ok);
+    assertEquals(r.nip07, "warn");
+  });
+});
+
+describe("validate wiring (no action call)", () => {
+  it("non-napp config -> isNapp false", () => {
+    assertFalse(isNapp({ relays: [], servers: [] }));
+  });
+
+  it("napp with missing name -> structural errors -> ok=false", () => {
+    const errors = validateNappConfig({
+      icon: { hash: "h", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assert(errors.length > 0);
+    assertFalse(assembleValidateReport({ structuralErrors: errors, nip07Found: false }).ok);
+  });
+
+  it("valid napp -> no structural errors -> ok=true", () => {
+    const errors = validateNappConfig({
+      name: { value: "App" },
+      icon: { hash: "h", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(errors, []);
+    assert(assembleValidateReport({ structuralErrors: errors, nip07Found: false }).ok);
+  });
+});
+
+describe("napp validate subcommand registration", () => {
+  it("registerNappCommand() does not throw (registers validate)", () => {
+    registerNappCommand();
+  });
+});

--- a/tests/unit/napp/napp_validate_command_test.ts
+++ b/tests/unit/napp/napp_validate_command_test.ts
@@ -13,7 +13,9 @@ import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
 describe("detectNip07InText (pure helper)", () => {
   it("detects window.nostr / getPublicKey usage", () => {
     assert(
-      detectNip07InText("if (window.nostr) { await window.nostr.getPublicKey(); }"),
+      detectNip07InText(
+        "if (window.nostr) { await window.nostr.getPublicKey(); }",
+      ),
     );
   });
   it("detects nostr-login import", () => {
@@ -47,7 +49,10 @@ describe("scanDirForNip07Evidence (temp dir)", () => {
   it("returns false when no scanned file contains a token", async () => {
     const dir = await Deno.makeTempDir();
     try {
-      await Deno.writeTextFile(join(dir, "index.html"), "<html><body>hello</body></html>");
+      await Deno.writeTextFile(
+        join(dir, "index.html"),
+        "<html><body>hello</body></html>",
+      );
       assertFalse(await scanDirForNip07Evidence(dir));
     } finally {
       await Deno.remove(dir, { recursive: true });
@@ -81,7 +86,10 @@ describe("assembleValidateReport (pure helper)", () => {
   });
 
   it("NIP-07 never flips ok to false", () => {
-    const r = assembleValidateReport({ structuralErrors: [], nip07Found: false });
+    const r = assembleValidateReport({
+      structuralErrors: [],
+      nip07Found: false,
+    });
     assert(r.ok);
     assertEquals(r.nip07, "warn");
   });
@@ -99,7 +107,10 @@ describe("validate wiring (no action call)", () => {
       countries: ["*"],
     });
     assert(errors.length > 0);
-    assertFalse(assembleValidateReport({ structuralErrors: errors, nip07Found: false }).ok);
+    assertFalse(
+      assembleValidateReport({ structuralErrors: errors, nip07Found: false })
+        .ok,
+    );
   });
 
   it("valid napp -> no structural errors -> ok=true", () => {
@@ -110,7 +121,10 @@ describe("validate wiring (no action call)", () => {
       countries: ["*"],
     });
     assertEquals(errors, []);
-    assert(assembleValidateReport({ structuralErrors: errors, nip07Found: false }).ok);
+    assert(
+      assembleValidateReport({ structuralErrors: errors, nip07Found: false })
+        .ok,
+    );
   });
 });
 

--- a/tests/unit/napp/nip46_perms_test.ts
+++ b/tests/unit/napp/nip46_perms_test.ts
@@ -1,0 +1,35 @@
+// Import test setup FIRST to block all system access
+import "../../test-setup-global.ts";
+
+import { assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { PERMISSIONS } from "../../../src/lib/nip46.ts";
+import {
+  NSITE_APP_LISTING_KIND,
+  NSITE_RELEASE_NOTE_KIND,
+} from "../../../src/lib/napp/listing.ts";
+
+describe("NIP-46 PERMISSIONS — napp kinds", () => {
+  it("authorizes signing kind 37348 (app listing)", () => {
+    const has = PERMISSIONS.some((p) => p === `sign_event:${NSITE_APP_LISTING_KIND}`);
+    assertEquals(has, true, `missing sign_event:${NSITE_APP_LISTING_KIND} in ${PERMISSIONS.join(",")}`);
+  });
+
+  it("authorizes signing kind 39108 (release note)", () => {
+    const has = PERMISSIONS.some((p) => p === `sign_event:${NSITE_RELEASE_NOTE_KIND}`);
+    assertEquals(has, true, `missing sign_event:${NSITE_RELEASE_NOTE_KIND} in ${PERMISSIONS.join(",")}`);
+  });
+
+  it("preserves pre-existing authorized kinds (no regression)", () => {
+    assertEquals(
+      PERMISSIONS.some((p) => p === "sign_event:35128"),
+      true,
+      "named-site manifest kind 35128 no longer authorized",
+    );
+    assertEquals(
+      PERMISSIONS.some((p) => p === "sign_event:10002"),
+      true,
+      "relay-list kind 10002 no longer authorized",
+    );
+  });
+});

--- a/tests/unit/napp/nip46_perms_test.ts
+++ b/tests/unit/napp/nip46_perms_test.ts
@@ -11,13 +11,29 @@ import {
 
 describe("NIP-46 PERMISSIONS — napp kinds", () => {
   it("authorizes signing kind 37348 (app listing)", () => {
-    const has = PERMISSIONS.some((p) => p === `sign_event:${NSITE_APP_LISTING_KIND}`);
-    assertEquals(has, true, `missing sign_event:${NSITE_APP_LISTING_KIND} in ${PERMISSIONS.join(",")}`);
+    const has = PERMISSIONS.some((p) =>
+      p === `sign_event:${NSITE_APP_LISTING_KIND}`
+    );
+    assertEquals(
+      has,
+      true,
+      `missing sign_event:${NSITE_APP_LISTING_KIND} in ${
+        PERMISSIONS.join(",")
+      }`,
+    );
   });
 
   it("authorizes signing kind 39108 (release note)", () => {
-    const has = PERMISSIONS.some((p) => p === `sign_event:${NSITE_RELEASE_NOTE_KIND}`);
-    assertEquals(has, true, `missing sign_event:${NSITE_RELEASE_NOTE_KIND} in ${PERMISSIONS.join(",")}`);
+    const has = PERMISSIONS.some((p) =>
+      p === `sign_event:${NSITE_RELEASE_NOTE_KIND}`
+    );
+    assertEquals(
+      has,
+      true,
+      `missing sign_event:${NSITE_RELEASE_NOTE_KIND} in ${
+        PERMISSIONS.join(",")
+      }`,
+    );
   });
 
   it("preserves pre-existing authorized kinds (no regression)", () => {

--- a/tests/unit/napp/release_test.ts
+++ b/tests/unit/napp/release_test.ts
@@ -1,0 +1,211 @@
+// Import test setup FIRST to block all system access
+import "../../test-setup-global.ts";
+
+import { assertEquals, assertNotEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import type { NostrEvent } from "applesauce-core/helpers";
+import type { ISigner } from "applesauce-signers";
+import {
+  createReleaseNoteEvent,
+  createReleaseNoteTemplate,
+  NSITE_RELEASE_NOTE_KIND,
+  type ReleaseChanges,
+  SECONDS_IN_WEEK,
+  weekBucket,
+} from "../../../src/lib/napp/release.ts";
+import { NSITE_RELEASE_NOTE_KIND as LISTING_RELEASE_KIND } from "../../../src/lib/napp/listing.ts";
+
+/** 64-hex manifest event id used throughout. */
+const MANIFEST_ID = "ev".repeat(32);
+
+/**
+ * Minimal in-memory fake signer — echoes the template plus a fixed id/sig/pubkey.
+ * No real crypto, no network.
+ */
+const fakeSigner = {
+  // deno-lint-ignore require-await
+  async signEvent(t: { kind: number; created_at: number; tags: string[][]; content: string }) {
+    return {
+      ...t,
+      id: "f".repeat(64),
+      sig: "0".repeat(128),
+      pubkey: "a".repeat(64),
+    } as NostrEvent;
+  },
+} as unknown as ISigner;
+
+/** Find all values for a given tag name, in order. */
+function tagValues(tags: string[][], name: string): string[] {
+  return tags.filter((t) => t[0] === name).map((t) => t[1]);
+}
+
+describe("release: week math", () => {
+  it("SECONDS_IN_WEEK is 604800", () => {
+    assertEquals(SECONDS_IN_WEEK, 604800);
+  });
+
+  it("weekBucket is floor(ts / 604800)", () => {
+    assertEquals(weekBucket(604800), 1);
+    assertEquals(weekBucket(0), 0);
+    assertEquals(weekBucket(604799), 0);
+    // CORRECTED: 1_700_000_000 / 604800 = 2810.846… -> floor = 2810
+    assertEquals(weekBucket(1_700_000_000), Math.floor(1_700_000_000 / 604800));
+    assertEquals(weekBucket(1_700_000_000), 2810);
+  });
+});
+
+describe("release: kind constant single-definition reuse", () => {
+  it("NSITE_RELEASE_NOTE_KIND equals 39108", () => {
+    assertEquals(NSITE_RELEASE_NOTE_KIND, 39108);
+  });
+
+  it("re-exported kind is the SAME value as listing.ts (single definition)", () => {
+    assertEquals(NSITE_RELEASE_NOTE_KIND, LISTING_RELEASE_KIND);
+  });
+});
+
+describe("release: createReleaseNoteTemplate tag mapping", () => {
+  it("emits d/D/ts/w plus change entries in order, ts and w as STRINGS", () => {
+    const template = createReleaseNoteTemplate({
+      manifestId: MANIFEST_ID,
+      manifestDTag: "my-site",
+      manifestCreatedAt: 1_700_000_000,
+      changes: { fix: ["a"], add: ["b", "c"] },
+    });
+
+    assertEquals(template.kind, 39108);
+    assertEquals(template.content, "");
+    assertEquals(template.tags, [
+      ["d", MANIFEST_ID],
+      ["D", "my-site"],
+      ["ts", "1700000000"],
+      ["w", "2810"],
+      ["fix", "a"],
+      ["add", "b"],
+      ["add", "c"],
+    ]);
+  });
+
+  it("maps all five change categories, one tag per entry", () => {
+    const changes: ReleaseChanges = {
+      fix: ["f1"],
+      add: ["a1", "a2"],
+      try: ["t1"],
+      cut: ["c1"],
+      sub: ["s1", "s2"],
+    };
+    const template = createReleaseNoteTemplate({
+      manifestId: MANIFEST_ID,
+      manifestDTag: "my-site",
+      manifestCreatedAt: 0,
+      changes,
+    });
+
+    assertEquals(tagValues(template.tags, "fix"), ["f1"]);
+    assertEquals(tagValues(template.tags, "add"), ["a1", "a2"]);
+    assertEquals(tagValues(template.tags, "try"), ["t1"]);
+    assertEquals(tagValues(template.tags, "cut"), ["c1"]);
+    assertEquals(tagValues(template.tags, "sub"), ["s1", "s2"]);
+    // Fixed category order: fix, add, try, cut, sub.
+    const changeTags = template.tags.filter((t) =>
+      ["fix", "add", "try", "cut", "sub"].includes(t[0])
+    );
+    assertEquals(changeTags.map((t) => t[0]), [
+      "fix",
+      "add",
+      "add",
+      "try",
+      "cut",
+      "sub",
+      "sub",
+    ]);
+  });
+
+  it("empty changes emits d/D/ts/w and ZERO change tags", () => {
+    const template = createReleaseNoteTemplate({
+      manifestId: MANIFEST_ID,
+      manifestDTag: "my-site",
+      manifestCreatedAt: 1_700_000_000,
+      changes: {},
+    });
+    assertEquals(template.tags, [
+      ["d", MANIFEST_ID],
+      ["D", "my-site"],
+      ["ts", "1700000000"],
+      ["w", "2810"],
+    ]);
+  });
+
+  it("all-undefined changes emits zero change tags", () => {
+    const template = createReleaseNoteTemplate({
+      manifestId: MANIFEST_ID,
+      manifestDTag: "my-site",
+      manifestCreatedAt: 1_700_000_000,
+      changes: { fix: undefined, add: undefined },
+    });
+    const changeTags = template.tags.filter((t) =>
+      ["fix", "add", "try", "cut", "sub"].includes(t[0])
+    );
+    assertEquals(changeTags.length, 0);
+  });
+
+  it("root-site empty manifestDTag is still emitted as ['D','']", () => {
+    const template = createReleaseNoteTemplate({
+      manifestId: MANIFEST_ID,
+      manifestDTag: "",
+      manifestCreatedAt: 1_700_000_000,
+      changes: {},
+    });
+    assertEquals(tagValues(template.tags, "D"), [""]);
+  });
+});
+
+describe("release: created_at handling", () => {
+  it("createdAt override is honored verbatim", () => {
+    const template = createReleaseNoteTemplate({
+      manifestId: MANIFEST_ID,
+      manifestDTag: "my-site",
+      manifestCreatedAt: 1_700_000_000,
+      changes: {},
+      createdAt: 1234,
+    });
+    assertEquals(template.created_at, 1234);
+  });
+
+  it("omitting createdAt defaults to ~now (positive integer, not the manifest ts)", () => {
+    const template = createReleaseNoteTemplate({
+      manifestId: MANIFEST_ID,
+      manifestDTag: "my-site",
+      manifestCreatedAt: 1_700_000_000,
+      changes: {},
+    });
+    assertEquals(Number.isInteger(template.created_at), true);
+    assertEquals(template.created_at > 0, true);
+    // Should be a real "now", not the override path and not the manifest ts.
+    assertNotEquals(template.created_at, 1234);
+  });
+});
+
+describe("release: createReleaseNoteEvent signing wrapper", () => {
+  it("returns the fake signer's signed event for a kind-39108 template", async () => {
+    const event = await createReleaseNoteEvent(fakeSigner, {
+      manifestId: MANIFEST_ID,
+      manifestDTag: "my-site",
+      manifestCreatedAt: 1_700_000_000,
+      changes: { fix: ["a"] },
+    });
+    assertEquals(event.kind, 39108);
+    assertEquals(event.id, "f".repeat(64));
+    assertEquals(event.sig, "0".repeat(128));
+    assertEquals(event.pubkey, "a".repeat(64));
+    assertEquals(tagValues(event.tags, "fix"), ["a"]);
+  });
+});
+
+describe("release: spec discrepancy comment", () => {
+  it("source documents both 39108 (authoritative) and 31908", () => {
+    const src = Deno.readTextFileSync("src/lib/napp/release.ts");
+    assertEquals(src.includes("39108"), true);
+    assertEquals(src.includes("31908"), true);
+  });
+});

--- a/tests/unit/napp/release_test.ts
+++ b/tests/unit/napp/release_test.ts
@@ -24,7 +24,9 @@ const MANIFEST_ID = "ev".repeat(32);
  */
 const fakeSigner = {
   // deno-lint-ignore require-await
-  async signEvent(t: { kind: number; created_at: number; tags: string[][]; content: string }) {
+  async signEvent(
+    t: { kind: number; created_at: number; tags: string[][]; content: string },
+  ) {
     return {
       ...t,
       id: "f".repeat(64),

--- a/tests/unit/napp/schema_test.ts
+++ b/tests/unit/napp/schema_test.ts
@@ -31,7 +31,8 @@ Deno.test("validateConfig - plain config (no napp) is valid (zero regression)", 
 Deno.test("validateConfig - plain full config still valid (zero regression)", () => {
   const result = validateConfig({
     ...plainConfig(),
-    bunkerPubkey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    bunkerPubkey:
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     id: "blog",
     title: "My Blog",
     description: "A blog",
@@ -103,7 +104,10 @@ Deno.test("readProjectFile - round-trips a valid napp config via temp dir", () =
     const nsiteDir = join(tmp, ".nsite");
     Deno.mkdirSync(nsiteDir);
     const configPath = join(nsiteDir, "config.json");
-    Deno.writeTextFileSync(configPath, JSON.stringify(validNappConfig(), null, 2));
+    Deno.writeTextFileSync(
+      configPath,
+      JSON.stringify(validNappConfig(), null, 2),
+    );
 
     const loaded = readProjectFile(configPath);
     assertEquals(loaded !== null, true);

--- a/tests/unit/napp/schema_test.ts
+++ b/tests/unit/napp/schema_test.ts
@@ -1,0 +1,115 @@
+import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import { join } from "@std/path";
+import { validateConfig } from "../../../src/lib/config-validator.ts";
+import { readProjectFile } from "../../../src/lib/config.ts";
+
+function plainConfig() {
+  return {
+    relays: ["wss://relay.damus.io"],
+    servers: ["https://cdn.hzrd149.com"],
+  };
+}
+
+function validNappConfig() {
+  return {
+    ...plainConfig(),
+    napp: {
+      name: { value: "My App" },
+      icon: { hash: "abc123", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    },
+  };
+}
+
+Deno.test("validateConfig - plain config (no napp) is valid (zero regression)", () => {
+  const result = validateConfig(plainConfig());
+  assertEquals(result.valid, true);
+  assertEquals(result.errors.length, 0);
+});
+
+Deno.test("validateConfig - plain full config still valid (zero regression)", () => {
+  const result = validateConfig({
+    ...plainConfig(),
+    bunkerPubkey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    id: "blog",
+    title: "My Blog",
+    description: "A blog",
+  });
+  assertEquals(result.valid, true);
+});
+
+Deno.test("validateConfig - valid napp section is valid", () => {
+  const result = validateConfig(validNappConfig());
+  assertEquals(result.valid, true);
+  assertEquals(result.errors.length, 0);
+});
+
+Deno.test("validateConfig - napp missing name is invalid under /napp", () => {
+  const config = validNappConfig() as Record<string, unknown>;
+  const napp = config.napp as Record<string, unknown>;
+  delete napp.name;
+  const result = validateConfig(config);
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.some((e) => e.path.includes("/napp")), true);
+});
+
+Deno.test("validateConfig - napp with unknown property is invalid", () => {
+  const config = validNappConfig() as Record<string, unknown>;
+  (config.napp as Record<string, unknown>).bogus = "nope";
+  const result = validateConfig(config);
+  assertEquals(result.valid, false);
+});
+
+Deno.test("validateConfig - napp.categories with unknown label is invalid", () => {
+  const config = validNappConfig();
+  config.napp.categories = ["napp.bogus:rpg"];
+  const result = validateConfig(config);
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.some((e) => e.message.includes("bogus")), true);
+});
+
+Deno.test("validateConfig - napp with 4 categories is invalid", () => {
+  const config = validNappConfig();
+  config.napp.categories = [
+    "napp.games:rpg",
+    "napp.money:wallet",
+    "napp.social:blog",
+    "napp.shopping:store",
+  ];
+  const result = validateConfig(config);
+  assertEquals(result.valid, false);
+});
+
+Deno.test("validateConfig - napp countries ['*','US'] is rejected (mixed wildcard)", () => {
+  // Schema pattern alone permits this; structural validateNappConfig rejects it.
+  const config = validNappConfig();
+  config.napp.countries = ["*", "US"];
+  const result = validateConfig(config);
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.some((e) => e.path === "/napp/countries"), true);
+});
+
+Deno.test("validateConfig - napp icon missing hash is invalid", () => {
+  const config = validNappConfig();
+  config.napp.icon = { mime: "image/png" } as { hash: string; mime: string };
+  const result = validateConfig(config);
+  assertEquals(result.valid, false);
+});
+
+Deno.test("readProjectFile - round-trips a valid napp config via temp dir", () => {
+  const tmp = Deno.makeTempDirSync({ prefix: "nsyte-test-napp-" });
+  try {
+    const nsiteDir = join(tmp, ".nsite");
+    Deno.mkdirSync(nsiteDir);
+    const configPath = join(nsiteDir, "config.json");
+    Deno.writeTextFileSync(configPath, JSON.stringify(validNappConfig(), null, 2));
+
+    const loaded = readProjectFile(configPath);
+    assertEquals(loaded !== null, true);
+    assertEquals(loaded!.napp?.name.value, "My App");
+    assertEquals(loaded!.napp?.categories, ["napp.games:rpg"]);
+  } finally {
+    Deno.removeSync(tmp, { recursive: true });
+  }
+});

--- a/tests/unit/napp/schema_test.ts
+++ b/tests/unit/napp/schema_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.220.0/assert/mod.ts";
+import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { validateConfig } from "../../../src/lib/config-validator.ts";
 import { readProjectFile } from "../../../src/lib/config.ts";
@@ -31,8 +31,7 @@ Deno.test("validateConfig - plain config (no napp) is valid (zero regression)", 
 Deno.test("validateConfig - plain full config still valid (zero regression)", () => {
   const result = validateConfig({
     ...plainConfig(),
-    bunkerPubkey:
-      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    bunkerPubkey: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     id: "blog",
     title: "My Blog",
     description: "A blog",

--- a/tests/unit/napp/schema_test.ts
+++ b/tests/unit/napp/schema_test.ts
@@ -90,6 +90,14 @@ Deno.test("validateConfig - napp countries ['*','US'] is rejected (mixed wildcar
   assertEquals(result.errors.some((e) => e.path === "/napp/countries"), true);
 });
 
+Deno.test("validateConfig - napp indexerRelays reject non-relay URLs", () => {
+  const config = validNappConfig();
+  config.napp.indexerRelays = ["https://relay.example.com", "nope"];
+  const result = validateConfig(config);
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.some((e) => e.path === "/napp/indexerRelays"), true);
+});
+
 Deno.test("validateConfig - napp icon missing hash is invalid", () => {
   const config = validNappConfig();
   config.napp.icon = { mime: "image/png" } as { hash: string; mime: string };


### PR DESCRIPTION
## Summary

Adds **napp** (NIP-5B "Nostr App") publishing to nsyte. A napp is a NIP-5A site (manifest kind 15128 root / 35128 named) advertised as a discoverable app via a kind-37348 **App Listing** event, optional kind-39108 **Release Notes**, a base-62 `+`-prefixed app **identifier**, and publishing to **indexer relays**.

Closes #126. Implements [NIP-5B](https://github.com/nostr-protocol/nips/pull/2282) (`5B.md`).

### UX model (hybrid, zero new friction)
- A `napp` section in `.nsite/config.json` **is** the detection mechanism (`isNapp()`).
- `nsyte deploy` auto-detects a napp and publishes the kind-37348 listing after the manifest, behind an info line — **no prompt, no new required flags**.
- `nsyte napp <id|release|init|validate>` for napp-specific operations.
- `nsyte init` gains a project-type step (default **nsite**); `nsyte napp init` retrofits existing projects.

### What's included
- **Config + detection** — optional `napp` section (name/icon/categories/countries + optional self/summary/description/keyart/screenshots/tags/indexerRelays), JSON-schema validated, with the fixed NIP-5B category table enforced.
- **App Listing (kind 37348)** — builder with full tag mapping, shares the manifest's `d` tag (`config.id ?? ""`), wired into deploy + `--dry-run`. NIP-46 signing permissions extended for 37348/39108.
- **App identifier** — base-62 TLV encoder/decoder ported faithfully from the spec's reference implementation; verified against the spec's own published vector `+cA99Kn…`. `nsyte napp id` prints the shareable `+` identifier.
- **Indexer relays** — default `wss://relay.44billion.net`, config-overridable; deploy publishes the listing to indexer ∪ write relays.
- **Release notes (kind 39108)** — builder (d=manifest id, D=manifest d tag, ts, week bucket, fix/add/try/cut/sub) + `nsyte napp release`.
- **Onboarding** — init project-type step, `napp init` retrofit, `napp validate` (required fields, category validation, best-effort NIP-07 heuristic).
- **Docs** — terse `docs/usage/commands/napp.md` covering only the napp deltas.

### Zero regressions (hard requirement)
Every napp code path is gated on `isNapp(config)`; a non-napp config takes the identical pre-existing path and emits the identical event set (no kind 37348). Proven by regression tests in both the dry-run collector and the deploy listing path.

## Testing
- `deno task test` → **299 passed, 0 failed, 9 ignored**
- `deno task check-doc-drift` → **exit 0** (source/docs aligned)
- `deno check src/cli.ts` → clean build
- `deno fmt --check` + `deno lint` → clean
- **End-to-end smoke (temp dir):** `napp id --pubkey` prints a valid `+` identifier; `napp validate` reports structural validity + detects NIP-07 without prompting; `deploy --dry-run` emits `App Listing (kind 37348)`.

## Notes — spec draft inconsistencies (handled defensively)
- Release Note kind is **39108** per the event definition (the REQ example's `31908` is a draft typo) — documented in code.
- Release Note `d` = manifest **event id**; `D` = manifest **d tag** — kept distinct.
- The base-62 `+` identifier is only defined for named sites (kind 35128); root sites have no `d` tag and are rejected with a clear message.