### PR TITLE
feat(napp): turnkey nsite→napp conversion — root-site guidance, local asset uploads, scriptable init, full field coverage

### DIFF
--- a/docs/usage/commands/napp.md
+++ b/docs/usage/commands/napp.md
@@ -43,7 +43,7 @@ See the [configuration reference](../configuration.md) for the full schema.
 - `id` — Print the shareable `+` app identifier for this napp.
 - `release` — Publish a kind-39108 changelog for the current app version.
 - `init` — Retrofit a `napp` section onto an existing project's config
-  (interactive).
+  (interactive, or fully scriptable via flags).
 - `validate` — Check napp readiness: required fields, categories, and a NIP-07
   heuristic.
 
@@ -69,7 +69,42 @@ See the [configuration reference](../configuration.md) for the full schema.
 
 ## init Options
 
-`init` is interactive and takes no options beyond the global options.
+`init` retrofits a `napp` section onto an existing project's config. With no
+flags it prompts interactively; flags pre-fill answers (fully-specified flags
+skip prompts entirely), and missing fields are prompted for — or, when
+non-interactive (`--yes` or no TTY), reported as an error and the command exits
+non-zero rather than hanging.
+
+- `--name <name>` — app display name.
+- `--icon <icon>` — app icon: a sha256 hash, a URL, OR a local file path. Local
+  files are uploaded to your configured blossom servers (requiring `--sec` or a
+  stored bunker); the resulting sha256 + MIME are captured.
+- `--icon-mime <mime>` — icon MIME type for hash/URL icon inputs (default
+  `image/png`).
+- `--category <label>` — `napp.<cat>:<sub>` category label (repeatable, max 3; a
+  bare `<cat>:<sub>` is normalized to `napp.<cat>:<sub>`).
+- `--countries <csv>` — comma-separated ISO 3166-1 alpha-2 codes, or `*` for
+  worldwide.
+- `--summary <text>` — short summary.
+- `--description <text>` — long description.
+- `--keyart <keyart>` — key art asset: a sha256 hash, a URL, or a local file
+  path (uploaded like `--icon`).
+- `--screenshot <shot>` — screenshot asset: a sha256 hash, a URL, or a local
+  file path (repeatable; uploaded like `--icon`).
+- `--self <pubkey>` — author pubkey (64-hex).
+- `--tag <tag>` — free-form tag (repeatable).
+- `--indexer-relay <relay>` — indexer relay URL the listing is also published to
+  (repeatable).
+- `--id <id>` — set a named-site identifier. napps need a NAMED site to be
+  discoverable; setting an id republishes the manifest from kind 15128 (root) to
+  kind 35128 (named) and orphans the old root manifest. This is OPT-IN — nsyte
+  never auto-migrates. On a root site with neither `--id` nor an interactive
+  confirmation, the napp section is still written but the id stays unset (and
+  `nsyte napp id` will not work until it is set).
+- `--sec <secret>` — key (nsec/hex, nbunksec, or `bunker://`) used to sign
+  local-file asset uploads. Not needed when all assets are hashes/URLs.
+- `--yes` — non-interactive: never prompt; error and exit non-zero if required
+  fields (`--name`, `--icon`, `--category`) are missing.
 
 ## validate Arguments
 

--- a/src/commands/napp.ts
+++ b/src/commands/napp.ts
@@ -15,15 +15,24 @@ import { Input, Select } from "@cliffy/prompt";
 import { walk } from "@std/fs";
 import type { NostrEvent } from "applesauce-core/helpers";
 import {
-  buildNappConfigFromAnswers,
-  categoryLabel,
+  collectNappListing,
+  type NappAssetResolver,
+  type NappListingPrefill,
   type ProjectConfig,
   readProjectFile,
   writeProjectFile,
 } from "../lib/config.ts";
 import { getErrorMessage } from "../lib/error-utils.ts";
 import { createLogger } from "../lib/logger.ts";
-import { NAPP_CATEGORIES } from "../lib/napp/categories.ts";
+import {
+  classifyAssetInput,
+  deriveAssetMime,
+  isRootSite,
+  parseCategoriesInput,
+  parseCountriesInput,
+  rootSiteMigrationNotice,
+  uploadNappAsset,
+} from "../lib/napp/assets.ts";
 import { isNapp, validateNappConfig } from "../lib/napp/detect.ts";
 import { nappIdentifier, resolveIndexerRelays } from "../lib/napp/identifier.ts";
 import { createReleaseNoteEvent, type ReleaseChanges } from "../lib/napp/release.ts";
@@ -303,69 +312,112 @@ async function nappReleaseAction(
 // `napp init` — retrofit a napp section onto an existing project config
 // ---------------------------------------------------------------------------
 
+/** Raw `napp init` flags as they arrive from Cliffy (repeatables are `collect:true`). */
+export interface NappInitFlags {
+  name?: string;
+  icon?: string;
+  iconMime?: string;
+  category?: string[];
+  countries?: string;
+  summary?: string;
+  description?: string;
+  keyart?: string;
+  screenshot?: string[];
+  self?: string;
+  tag?: string[];
+  indexerRelay?: string[];
+  id?: string;
+  yes?: boolean;
+}
+
+/** The result of parsing `napp init` flags into a listing prefill + control bits. */
+export interface NappInitPlan {
+  prefill: NappListingPrefill;
+  id?: string;
+  yes: boolean;
+  missingRequired: string[];
+}
+
 /**
- * Collect napp listing answers via the SAME prompt sequence as the init wizard, then
- * shape them with the SINGLE assembly helper. Interactive (not unit-tested); the pure
- * assembly/validation it feeds is covered by the wizard + init tests.
+ * PURE: parse `napp init` flags into a {@link NappListingPrefill} + control bits. Asset
+ * fields stay as raw input strings (the resolver turns them into NappAssets later).
+ * `missingRequired` is the subset of `name`/`icon`/`category` that flags did not supply.
+ * No prompting, no IO.
  */
-async function collectNappAnswers(): Promise<
-  ReturnType<typeof buildNappConfigFromAnswers>
-> {
-  const name = await Input.prompt({
-    message: "App name:",
-    validate: (v: string) => v.trim().length > 0 || "Name is required",
-  });
-  const iconHash = await Input.prompt({
-    message: "Icon (sha256 hash or URL):",
-    validate: (v: string) => v.trim().length > 0 || "Icon is required",
-  });
-  const iconMime = await Input.prompt({
-    message: "Icon MIME type:",
-    default: "image/png",
-  });
+export function planNappInitFromFlags(flags: NappInitFlags): NappInitPlan {
+  const categories = flags.category && flags.category.length > 0
+    ? parseCategoriesInput(flags.category)
+    : undefined;
+  const countries = flags.countries !== undefined
+    ? parseCountriesInput(flags.countries)
+    : undefined;
 
-  const category = await Select.prompt<string>({
-    message: "Category",
-    options: Object.keys(NAPP_CATEGORIES).map((c) => ({ name: c, value: c })),
-  });
-  const subcategory = await Select.prompt<string>({
-    message: "Subcategory",
-    options: NAPP_CATEGORIES[category].map((s) => ({ name: s, value: s })),
-  });
-  const label = categoryLabel(category, subcategory);
+  const prefill: NappListingPrefill = {};
+  if (flags.name !== undefined) prefill.name = flags.name;
+  if (flags.icon !== undefined) prefill.icon = flags.icon;
+  if (flags.iconMime !== undefined) prefill.iconMime = flags.iconMime;
+  if (categories !== undefined) prefill.categories = categories;
+  if (countries !== undefined) prefill.countries = countries;
+  if (flags.summary !== undefined) prefill.summary = flags.summary;
+  if (flags.description !== undefined) prefill.description = flags.description;
+  if (flags.self !== undefined) prefill.self = flags.self;
+  if (flags.keyart !== undefined) prefill.keyart = flags.keyart;
+  if (flags.screenshot !== undefined) prefill.screenshots = flags.screenshot;
+  if (flags.tag !== undefined) prefill.tags = flags.tag;
+  if (flags.indexerRelay !== undefined) prefill.indexerRelays = flags.indexerRelay;
 
-  const countriesInput = await Input.prompt({
-    message: "Countries (comma-separated ISO codes, or * for worldwide):",
-    default: "*",
-  });
-  const countries = countriesInput.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+  const missingRequired: string[] = [];
+  if (!flags.name || !flags.name.trim()) missingRequired.push("name");
+  if (!flags.icon || !flags.icon.trim()) missingRequired.push("icon");
+  if (!categories || categories.length === 0) missingRequired.push("category");
 
-  const summary = await Input.prompt({ message: "Summary (optional):" });
-  const description = await Input.prompt({
-    message: "Description (optional):",
-  });
+  return { prefill, id: flags.id, yes: flags.yes === true, missingRequired };
+}
 
-  return buildNappConfigFromAnswers({
-    name,
-    iconHash,
-    iconMime,
-    categories: [label],
-    countries: (countries.length === 0 ||
-        (countries.length === 1 && countries[0] === "*"))
-      ? ["*"]
-      : countries,
-    summary,
-    description,
-  });
+/** Inputs to the pure root-site id decision. */
+export interface RootSiteIdInput {
+  isRoot: boolean;
+  idFlag?: string;
+  interactive: boolean;
+  confirmed?: boolean;
+  confirmedValue?: string;
+}
+
+/** Output of the pure root-site id decision. */
+export interface RootSiteIdDecision {
+  setId?: string;
+  printNotice: boolean;
+}
+
+/**
+ * PURE: decide whether to set an id on a root site, never auto-migrating. An id is set
+ * ONLY when `--id` is passed OR (interactive) the user explicitly confirmed and supplied
+ * a value. With neither, the napp section is still written without an id. Non-root sites
+ * get no notice and no id change.
+ */
+export function decideRootSiteId(input: RootSiteIdInput): RootSiteIdDecision {
+  if (!input.isRoot) return { printNotice: false };
+  if (input.idFlag && input.idFlag.trim()) {
+    return { setId: input.idFlag.trim(), printNotice: true };
+  }
+  if (
+    input.interactive && input.confirmed &&
+    input.confirmedValue && input.confirmedValue.trim()
+  ) {
+    return { setId: input.confirmedValue.trim(), printNotice: true };
+  }
+  return { printNotice: true };
 }
 
 /**
  * `napp init` action: read the existing project config, refuse to overwrite an existing
- * napp, collect listing answers, validate, and write `{ ...projectConfig, napp }` back —
- * the spread preserves all unrelated keys (T-24-01).
+ * napp, parse flags, apply root-site guidance, collect listing answers (prompting only for
+ * what flags didn't supply, or erroring non-interactively when required fields are missing),
+ * validate, and write `{ ...projectConfig, napp }` back — the spread preserves all
+ * unrelated keys (T-24-01).
  */
 async function nappInitAction(
-  options: { config?: string | boolean },
+  options: NappInitFlags & { config?: string | boolean; sec?: string },
 ): Promise<void> {
   const configPath = typeof options.config === "string" ? options.config : undefined;
   const projectConfig = readProjectFile(configPath);
@@ -388,7 +440,112 @@ async function nappInitAction(
     return;
   }
 
-  const napp = await collectNappAnswers();
+  const plan = planNappInitFromFlags(options);
+  const interactive = getDisplayManager().isInteractive() && !plan.yes;
+
+  // Root-site guidance: warn + opt-in id (never auto-migrate). With --id, set it directly.
+  // Interactive without --id: print the notice and offer to set an id. Non-interactive
+  // without --id: print the notice and leave id unset.
+  if (isRootSite(projectConfig)) {
+    const flagDecision = decideRootSiteId({
+      isRoot: true,
+      idFlag: plan.id,
+      interactive,
+    });
+    if (flagDecision.printNotice) {
+      console.log(colors.yellow(rootSiteMigrationNotice()));
+    }
+    if (flagDecision.setId !== undefined) {
+      projectConfig.id = flagDecision.setId;
+    } else if (interactive) {
+      const setIdNow = await Select.prompt<string>({
+        message: "Set a site identifier now? (required for `nsyte napp id`)",
+        options: [
+          { name: "No — leave as a root site for now", value: "no" },
+          { name: "Yes — set a named site identifier", value: "yes" },
+        ],
+        default: "no",
+      });
+      let confirmedValue: string | undefined;
+      if (setIdNow === "yes") {
+        confirmedValue = (await Input.prompt({
+          message: "Enter site identifier (lowercase, max 13 chars):",
+          validate: (v: string) => v.trim().length > 0 || "Identifier is required",
+        })).trim();
+      }
+      const decision = decideRootSiteId({
+        isRoot: true,
+        interactive: true,
+        confirmed: setIdNow === "yes",
+        confirmedValue,
+      });
+      if (decision.setId !== undefined) {
+        projectConfig.id = decision.setId;
+      } else {
+        console.log(
+          colors.yellow(
+            "Leaving this as a root site — `nsyte napp id` will not work until you set an id.",
+          ),
+        );
+      }
+    } else {
+      console.log(
+        colors.yellow(
+          "Leaving this as a root site — `nsyte napp id` will not work until you set an id.",
+        ),
+      );
+    }
+  }
+
+  // Non-interactive with missing required fields: error clearly and exit non-zero (never hang).
+  if (!interactive && plan.missingRequired.length > 0) {
+    console.error(
+      colors.red(
+        `Missing required napp fields: ${
+          plan.missingRequired.join(", ")
+        }. Provide --name, --icon, and at least one --category (or run interactively).`,
+      ),
+    );
+    Deno.exit(1);
+  }
+
+  // Asset resolver: hash/URL pass through; a local path is uploaded via a lazily-created
+  // signer + the configured servers/relays. Hash/URL inputs never construct a signer.
+  let cachedSigner: import("applesauce-signers").ISigner | undefined;
+  const resolveAsset: NappAssetResolver = async (value: string) => {
+    if (classifyAssetInput(value) !== "path") {
+      return { hash: value, mime: deriveAssetMime(value) };
+    }
+    if (!projectConfig.servers || projectConfig.servers.length === 0) {
+      throw new Error(
+        `Cannot upload "${value}": configure blossom servers (or paste a sha256 hash / URL).`,
+      );
+    }
+    if (!cachedSigner) {
+      const signerResult = await createSigner({
+        sec: options.sec,
+        bunkerPubkey: projectConfig.bunkerPubkey,
+      });
+      if ("error" in signerResult) {
+        throw new Error(
+          `Cannot upload "${value}": ${signerResult.error} (pass --sec, or paste a sha256 hash / URL).`,
+        );
+      }
+      cachedSigner = signerResult.signer;
+    }
+    return await uploadNappAsset(value, {
+      servers: projectConfig.servers,
+      relays: projectConfig.relays,
+      signer: cachedSigner,
+    });
+  };
+
+  const napp = await collectNappListing({
+    prefill: plan.prefill,
+    interactive,
+    resolveAsset,
+  });
+
   const errors = validateNappConfig(napp);
   if (errors.length > 0) {
     for (const e of errors) {
@@ -639,11 +796,67 @@ export function registerNappCommand(): void {
         },
       );
     })
-    // init subcommand — interactive retrofit; NO `.option` (honors only global -c/--config).
+    // init subcommand — scriptable retrofit. Flags fully specify the listing (skip
+    // prompts) or partially specify it (prompt for the rest, or error non-interactively).
     .reset()
     .command("init", "Retrofit a napp section onto this project's config")
+    .option("--name <name:string>", "App display name")
+    .option(
+      "--icon <icon:string>",
+      "App icon: sha256 hash, URL, or local file path (local files are uploaded)",
+    )
+    .option(
+      "--icon-mime <mime:string>",
+      "Icon MIME type (used for hash/URL icon inputs; default image/png)",
+    )
+    .option(
+      "--category <label:string>",
+      "Category label napp.<cat>:<sub> (repeatable, max 3)",
+      { collect: true },
+    )
+    .option(
+      "--countries <csv:string>",
+      "Comma-separated ISO 3166-1 alpha-2 codes, or * for worldwide",
+    )
+    .option("--summary <text:string>", "Short summary")
+    .option("--description <text:string>", "Long description")
+    .option(
+      "--keyart <keyart:string>",
+      "Key art: sha256 hash, URL, or local file path",
+    )
+    .option(
+      "--screenshot <shot:string>",
+      "Screenshot: sha256 hash, URL, or local file path (repeatable)",
+      { collect: true },
+    )
+    .option("--self <pubkey:string>", "Author pubkey (64-hex)")
+    .option("--tag <tag:string>", "Free-form tag (repeatable)", {
+      collect: true,
+    })
+    .option(
+      "--indexer-relay <relay:string>",
+      "Indexer relay URL the listing is also published to (repeatable)",
+      { collect: true },
+    )
+    .option(
+      "--id <id:string>",
+      "Set a named-site identifier (opt-in root-site migration; never automatic)",
+    )
+    .option(
+      "--sec <secret:string>",
+      "Private key (nsec/hex), nbunksec, or bunker:// URL to sign asset uploads with",
+    )
+    .option(
+      "--yes",
+      "Non-interactive: never prompt; error if required fields are missing",
+    )
     .action(async (options) => {
-      await nappInitAction(options as unknown as { config?: string | boolean });
+      await nappInitAction(
+        options as unknown as NappInitFlags & {
+          config?: string | boolean;
+          sec?: string;
+        },
+      );
     })
     // validate subcommand (LAST — no trailing .reset()). Positional [dir] only, NO `.option`.
     .reset()

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -3,14 +3,11 @@ import { Input, Secret, Select } from "@cliffy/prompt";
 import { ensureDirSync } from "@std/fs/ensure-dir";
 import { dirname, isAbsolute, join, resolve } from "@std/path";
 import { NostrConnectSigner } from "applesauce-signers";
-import {
-  formatValidationErrors,
-  validateConfigWithFeedback,
-} from "./config-validator.ts";
+import { formatValidationErrors, validateConfigWithFeedback } from "./config-validator.ts";
 import { createLogger } from "./logger.ts";
 import { suggestIdentifier, validateDTag } from "./nip5a.ts";
 import { getNbunkString, initiateNostrConnect } from "./nip46.ts";
-import type { NappConfig } from "./napp/types.ts";
+import type { LangText, NappAsset, NappConfig } from "./napp/types.ts";
 import { NAPP_CATEGORIES } from "./napp/categories.ts";
 import { validateNappConfig } from "./napp/detect.ts";
 import { generateKeyPair } from "./nostr.ts";
@@ -113,9 +110,7 @@ export const defaultConfig: ProjectConfig = {
 function resolveConfigPath(customPath?: string): string {
   if (customPath) {
     // If custom path is provided, resolve it relative to CWD
-    return isAbsolute(customPath)
-      ? customPath
-      : resolve(Deno.cwd(), customPath);
+    return isAbsolute(customPath) ? customPath : resolve(Deno.cwd(), customPath);
   }
   // Default: .nsite/config.json in CWD
   return join(Deno.cwd(), configDir, projectFile);
@@ -182,9 +177,7 @@ export function writeProjectFile(
 
   // If a configPath is provided but resolves to the real project .nsite dir, block in tests
   if (isTestEnv && configPath) {
-    const resolved = isAbsolute(configPath)
-      ? configPath
-      : resolve(cwd, configPath);
+    const resolved = isAbsolute(configPath) ? configPath : resolve(cwd, configPath);
     // Block if the resolved path is inside the actual nsyte project directory
     if (
       !resolved.includes("nsyte-test-") && !resolved.startsWith("/tmp/") &&
@@ -458,9 +451,7 @@ async function connectToBunkerWithQR(): Promise<NostrConnectSigner> {
   ) {
     chosenRelays = defaultRelays;
   } else {
-    chosenRelays = relayInput.split(",").map((r) => r.trim()).filter((r) =>
-      r.length > 0
-    );
+    chosenRelays = relayInput.split(",").map((r) => r.trim()).filter((r) => r.length > 0);
   }
 
   if (chosenRelays.length === 0) {
@@ -470,9 +461,7 @@ async function connectToBunkerWithQR(): Promise<NostrConnectSigner> {
 
   console.log(
     colors.cyan(
-      `Initiating Nostr Connect as '${appName}' on relays: ${
-        chosenRelays.join(", ")
-      }`,
+      `Initiating Nostr Connect as '${appName}' on relays: ${chosenRelays.join(", ")}`,
     ),
   );
   return initiateNostrConnect(appName, chosenRelays);
@@ -503,9 +492,7 @@ async function newBunker(): Promise<NostrConnectSigner | undefined> {
   });
 
   try {
-    signer = choice === "qr"
-      ? await connectToBunkerWithQR()
-      : await connectToBunkerWithURI();
+    signer = choice === "qr" ? await connectToBunkerWithQR() : await connectToBunkerWithURI();
 
     if (!signer) {
       throw new Error("Failed to establish signer connection");
@@ -516,9 +503,7 @@ async function newBunker(): Promise<NostrConnectSigner | undefined> {
     log.error(`Failed to connect to bunker: ${error}`);
     console.error(
       colors.red(
-        `Failed to connect to bunker: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Failed to connect to bunker: ${error instanceof Error ? error.message : String(error)}`,
       ),
     );
     Deno.exit(1);
@@ -666,39 +651,75 @@ export function categoryLabel(category: string, subcategory: string): string {
  * {@link validateNappConfig} on the result before writing, warning (wizard) or
  * refusing to write (`napp init`) on errors.
  *
- * - `name` -> `{ value }`
+ * - `name` -> `{ value, lang? }` (lang only when provided)
  * - `icon.mime` defaults to `"image/png"` when omitted/blank
  * - `countries` defaults to `["*"]` when omitted/empty
- * - `summary`/`description` are included ONLY when non-empty (never `{ value: "" }`)
+ * - `summary`/`description` are included ONLY when non-empty (never `{ value: "" }`),
+ *   each carrying `lang` only when provided
+ * - `self`/`keyart`/`screenshots`/`tags`/`indexerRelays` are included ONLY when present
+ *   and non-empty
+ *
+ * All Phase-25 fields are OPTIONAL so every pre-existing call site keeps working unchanged.
  */
 export function buildNappConfigFromAnswers(answers: {
   name: string;
+  nameLang?: string;
   iconHash: string;
   iconMime?: string;
   categories: string[];
   countries?: string[];
   summary?: string;
+  summaryLang?: string;
   description?: string;
+  descriptionLang?: string;
+  self?: string;
+  keyart?: NappAsset;
+  screenshots?: NappAsset[];
+  tags?: string[];
+  indexerRelays?: string[];
 }): NappConfig {
+  const name: LangText = { value: answers.name };
+  if (answers.nameLang && answers.nameLang.trim()) {
+    name.lang = answers.nameLang;
+  }
+
   const napp: NappConfig = {
-    name: { value: answers.name },
+    name,
     icon: {
       hash: answers.iconHash,
-      mime: answers.iconMime && answers.iconMime.trim()
-        ? answers.iconMime
-        : "image/png",
+      mime: answers.iconMime && answers.iconMime.trim() ? answers.iconMime : "image/png",
     },
     categories: answers.categories,
-    countries: (answers.countries && answers.countries.length)
-      ? answers.countries
-      : ["*"],
+    countries: (answers.countries && answers.countries.length) ? answers.countries : ["*"],
   };
 
   if (answers.summary && answers.summary.trim()) {
     napp.summary = { value: answers.summary };
+    if (answers.summaryLang && answers.summaryLang.trim()) {
+      napp.summary.lang = answers.summaryLang;
+    }
   }
   if (answers.description && answers.description.trim()) {
     napp.description = { value: answers.description };
+    if (answers.descriptionLang && answers.descriptionLang.trim()) {
+      napp.description.lang = answers.descriptionLang;
+    }
+  }
+
+  if (answers.self && answers.self.trim()) {
+    napp.self = answers.self;
+  }
+  if (answers.keyart) {
+    napp.keyart = answers.keyart;
+  }
+  if (answers.screenshots && answers.screenshots.length > 0) {
+    napp.screenshots = answers.screenshots;
+  }
+  if (answers.tags && answers.tags.length > 0) {
+    napp.tags = answers.tags;
+  }
+  if (answers.indexerRelays && answers.indexerRelays.length > 0) {
+    napp.indexerRelays = answers.indexerRelays;
   }
 
   return napp;
@@ -774,10 +795,9 @@ async function interactiveSetup(): Promise<ProjectContext> {
         const defaultRelays = ["wss://relay.nsec.app"];
 
         const relayInput = await Input.prompt({
-          message:
-            `Enter relays (comma-separated), or press Enter for default (${
-              defaultRelays.join(", ")
-            }):`,
+          message: `Enter relays (comma-separated), or press Enter for default (${
+            defaultRelays.join(", ")
+          }):`,
           default: defaultRelays.join(", "),
         });
 
@@ -802,9 +822,7 @@ async function interactiveSetup(): Promise<ProjectContext> {
 
         console.log(
           colors.cyan(
-            `Initiating Nostr Connect as '${appName}' on relays: ${
-              chosenRelays.join(", ")
-            }`,
+            `Initiating Nostr Connect as '${appName}' on relays: ${chosenRelays.join(", ")}`,
           ),
         );
         signer = await initiateNostrConnect(appName, chosenRelays);
@@ -839,9 +857,7 @@ Generated and stored nbunksec string.`,
       log.error(`Failed to connect to bunker: ${error}`);
       console.error(
         colors.red(
-          `Failed to connect to bunker: ${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `Failed to connect to bunker: ${error instanceof Error ? error.message : String(error)}`,
         ),
       );
       Deno.exit(1);
@@ -893,8 +909,7 @@ Generated and stored nbunksec string.`,
   let siteId: string | null | undefined;
   if (siteType === "named") {
     const identifier = await Input.prompt({
-      message:
-        "Enter site identifier (lowercase, max 13 chars, e.g., blog, my-site):",
+      message: "Enter site identifier (lowercase, max 13 chars, e.g., blog, my-site):",
       validate: (input: string) => {
         const trimmed = input.trim();
         if (!trimmed) {
@@ -903,9 +918,7 @@ Generated and stored nbunksec string.`,
         const result = validateDTag(trimmed);
         if (!result.valid) {
           const suggestion = suggestIdentifier(trimmed);
-          return `${result.error}${
-            suggestion !== trimmed ? `. Try "${suggestion}"` : ""
-          }`;
+          return `${result.error}${suggestion !== trimmed ? `. Try "${suggestion}"` : ""}`;
         }
         return true;
       },

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -8,8 +8,16 @@ import { createLogger } from "./logger.ts";
 import { suggestIdentifier, validateDTag } from "./nip5a.ts";
 import { getNbunkString, initiateNostrConnect } from "./nip46.ts";
 import type { LangText, NappAsset, NappConfig } from "./napp/types.ts";
-import { NAPP_CATEGORIES } from "./napp/categories.ts";
+import { MAX_NAPP_CATEGORIES, NAPP_CATEGORIES } from "./napp/categories.ts";
 import { validateNappConfig } from "./napp/detect.ts";
+import {
+  classifyAssetInput,
+  deriveAssetMime,
+  isRootSite,
+  rootSiteMigrationNotice,
+  uploadNappAsset,
+} from "./napp/assets.ts";
+import { createSigner } from "./auth/signer-factory.ts";
 import { generateKeyPair } from "./nostr.ts";
 import { SecretsManager } from "./secrets/mod.ts";
 
@@ -726,6 +734,191 @@ export function buildNappConfigFromAnswers(answers: {
 }
 
 /**
+ * Flag/wizard-provided values fed into {@link collectNappListing}. Asset fields carry the
+ * RAW input string (a sha256 hash, a URL, or a local path); the injected `resolveAsset`
+ * turns each into a {@link NappAsset}. Already-parsed listing fields (categories as labels,
+ * countries as an array) are passed through verbatim.
+ */
+export interface NappListingPrefill {
+  name?: string;
+  nameLang?: string;
+  icon?: string;
+  iconMime?: string;
+  categories?: string[];
+  countries?: string[];
+  summary?: string;
+  summaryLang?: string;
+  description?: string;
+  descriptionLang?: string;
+  self?: string;
+  keyart?: string;
+  screenshots?: string[];
+  tags?: string[];
+  indexerRelays?: string[];
+}
+
+/** A resolver turning a raw asset input (hash/URL/path) into a {@link NappAsset}. */
+export type NappAssetResolver = (value: string) => Promise<NappAsset>;
+
+/**
+ * The SHARED napp-listing collector used by BOTH `nsyte napp init` (prefill = parsed flags,
+ * resolveAsset uploads) and the `nsyte init` wizard napp branch (prefill = {}, interactive,
+ * resolveAsset = hash/URL-or-upload). For each field: use prefill when present; else, when
+ * `interactive`, prompt; else leave unset. Asset strings are turned into {@link NappAsset}
+ * via the injected `resolveAsset`. Returns the assembled config via
+ * {@link buildNappConfigFromAnswers} (PURE assembly; validation is the caller's job).
+ *
+ * Dependency-light by design: `resolveAsset` is injected so this module never imports
+ * upload.ts.
+ */
+export async function collectNappListing(opts: {
+  prefill: NappListingPrefill;
+  interactive: boolean;
+  resolveAsset: NappAssetResolver;
+}): Promise<NappConfig> {
+  const { prefill, interactive, resolveAsset } = opts;
+
+  // --- name ---
+  let name = prefill.name;
+  if (name === undefined && interactive) {
+    name = await Input.prompt({
+      message: "App name:",
+      validate: (v: string) => v.trim().length > 0 || "Name is required",
+    });
+  }
+
+  // --- icon (raw input) ---
+  let iconInput = prefill.icon;
+  let iconMime = prefill.iconMime;
+  if (iconInput === undefined && interactive) {
+    iconInput = await Input.prompt({
+      message: "Icon (sha256 hash, URL, or local file path):",
+      validate: (v: string) => v.trim().length > 0 || "Icon is required",
+    });
+    iconMime = await Input.prompt({
+      message: "Icon MIME type (used for hash/URL inputs):",
+      default: "image/png",
+    });
+  }
+
+  // --- categories (labels) ---
+  let categories = prefill.categories;
+  if ((categories === undefined || categories.length === 0) && interactive) {
+    categories = [];
+    while (categories.length < MAX_NAPP_CATEGORIES) {
+      const category = await Select.prompt<string>({
+        message: categories.length === 0
+          ? "Category"
+          : `Category (${categories.length}/${MAX_NAPP_CATEGORIES}, choose "done" to finish)`,
+        options: [
+          ...Object.keys(NAPP_CATEGORIES).map((c) => ({ name: c, value: c })),
+          ...(categories.length > 0 ? [{ name: "done", value: "__done__" }] : []),
+        ],
+      });
+      if (category === "__done__") break;
+      const subcategory = await Select.prompt<string>({
+        message: "Subcategory",
+        options: NAPP_CATEGORIES[category].map((s) => ({ name: s, value: s })),
+      });
+      categories.push(categoryLabel(category, subcategory));
+    }
+  }
+
+  // --- countries ---
+  let countries = prefill.countries;
+  if ((countries === undefined || countries.length === 0) && interactive) {
+    const countriesInput = await Input.prompt({
+      message: "Countries (comma-separated ISO codes, or * for worldwide):",
+      default: "*",
+    });
+    const parts = countriesInput.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+    countries = (parts.length === 0 || (parts.length === 1 && parts[0] === "*")) ? ["*"] : parts;
+  }
+
+  // --- summary / description ---
+  let summary = prefill.summary;
+  let description = prefill.description;
+  if (summary === undefined && interactive) {
+    summary = await Input.prompt({ message: "Summary (optional):" });
+  }
+  if (description === undefined && interactive) {
+    description = await Input.prompt({ message: "Description (optional):" });
+  }
+
+  // --- self ---
+  let self = prefill.self;
+  if (self === undefined && interactive) {
+    const v = await Input.prompt({
+      message: "Author pubkey (64-hex, optional):",
+    });
+    self = v.trim() || undefined;
+  }
+
+  // --- keyart / screenshots (raw inputs) ---
+  let keyartInput = prefill.keyart;
+  let screenshotInputs = prefill.screenshots;
+  if (keyartInput === undefined && interactive) {
+    const v = await Input.prompt({
+      message: "Key art (sha256 hash, URL, or local path; optional):",
+    });
+    keyartInput = v.trim() || undefined;
+  }
+  if (screenshotInputs === undefined && interactive) {
+    const collected: string[] = [];
+    while (true) {
+      const v = await Input.prompt({
+        message: "Screenshot (hash/URL/path; blank to finish):",
+      });
+      if (!v || !v.trim()) break;
+      collected.push(v.trim());
+    }
+    screenshotInputs = collected;
+  }
+
+  // --- tags / indexerRelays ---
+  let tags = prefill.tags;
+  if (tags === undefined && interactive) {
+    const v = await Input.prompt({
+      message: "Tags (comma-separated, optional):",
+    });
+    tags = v.split(",").map((t) => t.trim()).filter((t) => t.length > 0);
+  }
+  const indexerRelays = prefill.indexerRelays;
+
+  // --- resolve assets via the injected resolver ---
+  let icon: NappAsset | undefined;
+  if (iconInput && iconInput.trim()) {
+    icon = await resolveAsset(iconInput.trim());
+  }
+  let keyart: NappAsset | undefined;
+  if (keyartInput && keyartInput.trim()) {
+    keyart = await resolveAsset(keyartInput.trim());
+  }
+  const screenshots: NappAsset[] = [];
+  for (const s of screenshotInputs ?? []) {
+    if (s && s.trim()) screenshots.push(await resolveAsset(s.trim()));
+  }
+
+  return buildNappConfigFromAnswers({
+    name: name ?? "",
+    nameLang: prefill.nameLang,
+    iconHash: icon?.hash ?? "",
+    iconMime: icon?.mime ?? iconMime,
+    categories: categories ?? [],
+    countries,
+    summary,
+    summaryLang: prefill.summaryLang,
+    description,
+    descriptionLang: prefill.descriptionLang,
+    self,
+    keyart,
+    screenshots: screenshots.length > 0 ? screenshots : undefined,
+    tags: tags && tags.length > 0 ? tags : undefined,
+    indexerRelays: indexerRelays && indexerRelays.length > 0 ? indexerRelays : undefined,
+  });
+}
+
+/**
  * Interactive project setup
  */
 async function interactiveSetup(): Promise<ProjectContext> {
@@ -970,70 +1163,103 @@ Generated and stored nbunksec string.`,
   });
 
   if (projectType === "napp") {
-    const name = await Input.prompt({
-      message: "App name:",
-      validate: (v: string) => v.trim().length > 0 || "Name is required",
-    });
-    const iconHash = await Input.prompt({
-      message: "Icon (sha256 hash or URL):",
-      validate: (v: string) => v.trim().length > 0 || "Icon is required",
-    });
-    const iconMime = await Input.prompt({
-      message: "Icon MIME type:",
-      default: "image/png",
-    });
-
-    const category = await Select.prompt<string>({
-      message: "Category",
-      options: Object.keys(NAPP_CATEGORIES).map((c) => ({ name: c, value: c })),
-    });
-    const subcategory = await Select.prompt<string>({
-      message: "Subcategory",
-      options: NAPP_CATEGORIES[category].map((s) => ({ name: s, value: s })),
-    });
-    const label = categoryLabel(category, subcategory);
-
-    const countriesInput = await Input.prompt({
-      message: "Countries (comma-separated ISO codes, or * for worldwide):",
-      default: "*",
-    });
-    const countries = countriesInput
-      .split(",")
-      .map((c) => c.trim())
-      .filter((c) => c.length > 0);
-
-    const summary = await Input.prompt({ message: "Summary (optional):" });
-    const description = await Input.prompt({
-      message: "Description (optional):",
-    });
-
-    const napp = buildNappConfigFromAnswers({
-      name,
-      iconHash,
-      iconMime,
-      categories: [label],
-      countries: (countries.length === 0 ||
-          (countries.length === 1 && countries[0] === "*"))
-        ? ["*"]
-        : countries,
-      summary,
-      description,
-    });
-
-    // Validate before writing. On errors, WARN but still attach the scaffold so the
-    // author can fix `.nsite/config.json` by hand rather than losing their answers.
-    const nappErrors = validateNappConfig(napp);
-    if (nappErrors.length > 0) {
-      for (const e of nappErrors) {
-        console.log(colors.yellow(`  ${e.path}: ${e.message}`));
+    // Plan-check #4: the napp branch MUST degrade gracefully. An asset/upload failure
+    // WARNS and still lets `nsyte init` finish (consistent with warn-but-write); it must
+    // NOT throw out of interactiveSetup and abort the whole `nsyte init`.
+    try {
+      // Root-site guidance: a napp needs a NAMED site to be discoverable. We WARN and
+      // (interactive) offer to set an id, but NEVER auto-migrate (no consent => no id).
+      if (isRootSite(config)) {
+        console.log(colors.yellow(rootSiteMigrationNotice()));
+        const setIdNow = await Select.prompt<string>({
+          message: "Set a site identifier now? (required for `nsyte napp id`)",
+          options: [
+            { name: "No — leave as a root site for now", value: "no" },
+            { name: "Yes — set a named site identifier", value: "yes" },
+          ],
+          default: "no",
+        });
+        if (setIdNow === "yes") {
+          const identifier = await Input.prompt({
+            message: "Enter site identifier (lowercase, max 13 chars):",
+            validate: (input: string) => {
+              const trimmed = input.trim();
+              if (!trimmed) return "Site identifier is required";
+              const result = validateDTag(trimmed);
+              if (!result.valid) {
+                const suggestion = suggestIdentifier(trimmed);
+                return `${result.error}${suggestion !== trimmed ? `. Try "${suggestion}"` : ""}`;
+              }
+              return true;
+            },
+          });
+          config.id = identifier.trim();
+        } else {
+          console.log(
+            colors.yellow(
+              "Leaving this as a root site — `nsyte napp id` will not work until you set an id.",
+            ),
+          );
+        }
       }
+
+      // Wizard asset resolver: hash/URL pass through ({hash, mime}); a local path is
+      // uploaded via uploadNappAsset when blossom servers + a signer are available, else
+      // a clear error tells the author to configure servers or paste a hash/URL.
+      const resolveAsset: NappAssetResolver = async (value: string) => {
+        if (classifyAssetInput(value) !== "path") {
+          return { hash: value, mime: deriveAssetMime(value) };
+        }
+        if (!config.servers || config.servers.length === 0) {
+          throw new Error(
+            `Cannot upload "${value}": configure blossom servers (or paste a sha256 hash / URL) for assets.`,
+          );
+        }
+        const signerResult = await createSigner({
+          sec: privateKey,
+          bunkerPubkey,
+        });
+        if ("error" in signerResult) {
+          throw new Error(
+            `Cannot upload "${value}": ${signerResult.error} (or paste a sha256 hash / URL).`,
+          );
+        }
+        return await uploadNappAsset(value, {
+          servers: config.servers,
+          relays: config.relays,
+          signer: signerResult.signer,
+        });
+      };
+
+      const napp = await collectNappListing({
+        prefill: {},
+        interactive: true,
+        resolveAsset,
+      });
+
+      // Validate before writing. On errors, WARN but still attach the scaffold so the
+      // author can fix `.nsite/config.json` by hand rather than losing their answers.
+      const nappErrors = validateNappConfig(napp);
+      if (nappErrors.length > 0) {
+        for (const e of nappErrors) {
+          console.log(colors.yellow(`  ${e.path}: ${e.message}`));
+        }
+        console.log(
+          colors.yellow(
+            "The napp section may need manual fixes in .nsite/config.json before deploying.",
+          ),
+        );
+      }
+      config.napp = napp;
+    } catch (e) {
+      // Graceful degradation: warn and still finish `nsyte init`.
+      const msg = e instanceof Error ? e.message : String(e);
       console.log(
         colors.yellow(
-          "The napp section may need manual fixes in .nsite/config.json before deploying.",
+          `Skipped napp section (you can add it later with \`nsyte napp init\`): ${msg}`,
         ),
       );
     }
-    config.napp = napp;
   }
 
   return { config, privateKey };

--- a/src/lib/napp/assets.ts
+++ b/src/lib/napp/assets.ts
@@ -1,0 +1,189 @@
+/**
+ * napp asset-input classification + local-file upload helper.
+ *
+ * Pure helpers (`classifyAssetInput`/`deriveAssetMime`/`parseCategoriesInput`/
+ * `parseCountriesInput`/`isRootSite`/`rootSiteMigrationNotice`) plus the upload boundary
+ * (`resolveNappAsset`/`uploadNappAsset`). The boundary keeps the existing paste-a-hash/URL
+ * path working while making local-path uploads unit-testable via an injected upload fn.
+ */
+import { contentType } from "@std/media-types";
+import { basename, dirname, extname } from "@std/path";
+import { calculateFileHash } from "../files.ts";
+import { processUploads, type UploadResponse } from "../upload.ts";
+import type { FileEntry } from "../nostr.ts";
+import type { ISigner } from "applesauce-signers";
+import type { NappAsset } from "./types.ts";
+
+const HEX64 = /^[0-9a-fA-F]{64}$/;
+
+/** Classify a raw asset-input string into hash / url / path (anything else). PURE. */
+export function classifyAssetInput(value: string): "hash" | "url" | "path" {
+  if (HEX64.test(value)) return "hash";
+  if (/^https?:\/\//i.test(value)) return "url";
+  return "path";
+}
+
+/**
+ * Map a recognizable image extension to its MIME via `@std/media-types`, falling back to
+ * `"image/png"`. GUARD: `contentType` returns NON-image types for many extensions
+ * (e.g. `.xyz`→`chemical/x-xyz`), so the result is used ONLY when it starts with
+ * `"image/"`. PURE.
+ */
+export function deriveAssetMime(value: string): string {
+  const ext = extname(value);
+  if (ext) {
+    const mime = contentType(ext);
+    if (mime && mime.startsWith("image/")) {
+      // Strip any parameters (e.g. "; charset=...") that may be appended.
+      return mime.split(";")[0].trim();
+    }
+  }
+  return "image/png";
+}
+
+/**
+ * Normalize raw category inputs into `napp.<cat>:<sub>` labels: prepend `napp.` only when
+ * missing, trim, drop blanks, preserve order. Validation / the ≤3 cap is left to
+ * `validateNappConfig`/`validateCategories`. PURE.
+ */
+export function parseCategoriesInput(values: string[]): string[] {
+  const out: string[] = [];
+  for (const raw of values) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    out.push(trimmed.startsWith("napp.") ? trimmed : `napp.${trimmed}`);
+  }
+  return out;
+}
+
+/**
+ * Split a comma-separated countries string: trim, drop blanks; return `["*"]` when the
+ * result is empty or exactly `["*"]`. Mirrors the existing wizard logic. PURE.
+ */
+export function parseCountriesInput(csv: string): string[] {
+  const parts = csv.split(",").map((c) => c.trim()).filter((c) => c.length > 0);
+  if (parts.length === 0 || (parts.length === 1 && parts[0] === "*")) {
+    return ["*"];
+  }
+  return parts;
+}
+
+/** True iff `config.id` is missing/empty (a root site, kind 15128). PURE. */
+export function isRootSite(config: { id?: string | null }): boolean {
+  return config.id === undefined || config.id === null || config.id === "";
+}
+
+/** Multi-line warning shown before converting a ROOT site into a named napp. PURE. */
+export function rootSiteMigrationNotice(): string {
+  return [
+    "This is a ROOT site (no id). napps require a NAMED site to be discoverable.",
+    "Setting an id republishes your manifest from kind 15128 (root) to kind 35128 (named).",
+    "The old root manifest is then ORPHANED — it is not deleted, just no longer your live site.",
+    "Your gateway URLs change (e.g. npub1….nsite.lol → {id}.npub1….nsite.lol).",
+    "nsyte never auto-migrates: an id is set ONLY when you pass --id or explicitly confirm.",
+  ].join("\n");
+}
+
+/** Context the upload helper needs (servers/relays/signer). */
+export interface UploadAssetContext {
+  servers: string[];
+  relays: string[];
+  signer: ISigner;
+}
+
+/** Injectable upload boundary signature (default = real processUploads). */
+export type ProcessFn = (
+  files: FileEntry[],
+  baseDir: string,
+  servers: string[],
+  signer: ISigner,
+  relays: string[],
+) => Promise<UploadResponse[]>;
+
+/**
+ * Resolve a raw asset input into a {@link NappAsset}. For hash/url it returns
+ * `{ hash: value, mime: deriveAssetMime(value) }` WITHOUT calling `upload`; for a local
+ * path it returns `await upload(value)`.
+ */
+export async function resolveNappAsset(
+  value: string,
+  upload: (localPath: string) => Promise<{ hash: string; mime: string }>,
+): Promise<NappAsset> {
+  const kind = classifyAssetInput(value);
+  if (kind === "path") {
+    const result = await upload(value);
+    return { hash: result.hash, mime: result.mime };
+  }
+  return { hash: value, mime: deriveAssetMime(value) };
+}
+
+/**
+ * Read a local file, compute its sha256 + mime, upload it to blossom, and return
+ * `{ hash, mime }` ONLY when the upload succeeded. Throws a clear, distinct error when
+ * servers/relays are empty, the file is missing/empty, or the upload did not succeed.
+ *
+ * `processFn` is injectable (default = the real {@link processUploads}) so tests can
+ * verify FileEntry construction + success/failure handling without real blossom/relays.
+ */
+export async function uploadNappAsset(
+  localPath: string,
+  ctx: UploadAssetContext,
+  processFn: ProcessFn = processUploads,
+): Promise<{ hash: string; mime: string }> {
+  if (!ctx.servers || ctx.servers.length === 0) {
+    throw new Error(
+      `Cannot upload "${localPath}": no blossom servers configured. ` +
+        "Add servers to .nsite/config.json, or paste a sha256 hash / URL instead.",
+    );
+  }
+  // Pre-empt processUploads' generic "No relays" error with our own clear message.
+  if (!ctx.relays || ctx.relays.length === 0) {
+    throw new Error(
+      `Cannot upload "${localPath}": no relays configured. ` +
+        "Add relays to .nsite/config.json, or paste a sha256 hash / URL instead.",
+    );
+  }
+
+  let raw: Uint8Array;
+  try {
+    raw = await Deno.readFile(localPath);
+  } catch {
+    throw new Error(`Cannot upload "${localPath}": file not found or unreadable.`);
+  }
+  if (raw.length === 0) {
+    throw new Error(`Cannot upload "${localPath}": file is empty.`);
+  }
+  // FileEntry.data is ByteArray (Uint8Array<ArrayBuffer>); Deno.readFile may return a
+  // SharedArrayBuffer-backed view — copy into a plain ArrayBuffer to satisfy the type.
+  const data = new Uint8Array(raw);
+
+  const sha256 = await calculateFileHash(localPath);
+  const mime = deriveAssetMime(localPath);
+  const baseDir = dirname(localPath);
+  const entry: FileEntry = {
+    path: basename(localPath),
+    sha256,
+    data,
+    size: data.length,
+    contentType: mime,
+  };
+
+  const results = await processFn(
+    [entry],
+    baseDir,
+    ctx.servers,
+    ctx.signer,
+    ctx.relays,
+  );
+
+  const result = results.find((r) => r.file.sha256 === sha256) ?? results[0];
+  if (!result || result.success !== true) {
+    throw new Error(
+      `Upload of "${localPath}" failed${
+        result?.error ? `: ${result.error}` : " on all configured servers."
+      }`,
+    );
+  }
+
+  return { hash: sha256, mime };
+}

--- a/tests/unit/config/napp_wizard_test.ts
+++ b/tests/unit/config/napp_wizard_test.ts
@@ -4,6 +4,8 @@ import { describe, it } from "@std/testing/bdd";
 import {
   buildNappConfigFromAnswers,
   categoryLabel,
+  collectNappListing,
+  type NappAssetResolver,
   type ProjectConfig,
 } from "../../../src/lib/config.ts";
 import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
@@ -209,6 +211,54 @@ describe("buildNappConfigFromAnswers full NIP-5B field coverage", () => {
     assert(!("screenshots" in result), "screenshots absent");
     assert(!("tags" in result), "tags absent");
     assert(!("indexerRelays" in result), "indexerRelays absent");
+  });
+});
+
+describe("collectNappListing minimal-prefill regression (no upload, non-interactive)", () => {
+  it("preserves the pre-phase minimal single-field shape", async () => {
+    // A no-upload resolver: hash inputs round-trip via the boundary semantics.
+    const noUpload: NappAssetResolver = (value: string) =>
+      Promise.resolve({ hash: value, mime: "image/png" });
+
+    const napp = await collectNappListing({
+      prefill: {
+        name: "My App",
+        icon: "abc123",
+        iconMime: "image/png",
+        categories: ["napp.games:rpg"],
+        countries: ["*"],
+      },
+      interactive: false,
+      resolveAsset: noUpload,
+    });
+
+    assertEquals(napp, {
+      name: { value: "My App" },
+      icon: { hash: "abc123", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(validateNappConfig(napp), []);
+  });
+
+  it("never calls the resolver when no asset inputs are present", async () => {
+    let called = false;
+    const failResolver: NappAssetResolver = (_v: string) => {
+      called = true;
+      return Promise.reject(new Error("should not resolve"));
+    };
+    const napp = await collectNappListing({
+      prefill: {
+        name: "App",
+        categories: ["napp.games:rpg"],
+        countries: ["*"],
+      },
+      interactive: false,
+      resolveAsset: failResolver,
+    });
+    assertEquals(called, false);
+    // icon stays empty (invalid) — validation is the caller's job, not the collector's.
+    assertEquals(napp.icon.hash, "");
   });
 });
 

--- a/tests/unit/config/napp_wizard_test.ts
+++ b/tests/unit/config/napp_wizard_test.ts
@@ -117,6 +117,101 @@ describe("buildNappConfigFromAnswers (pure assembly helper)", () => {
   });
 });
 
+describe("buildNappConfigFromAnswers full NIP-5B field coverage", () => {
+  const SELF = "a".repeat(64);
+
+  it("assembles every optional field and passes validateNappConfig with 0 errors", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "My App",
+      nameLang: "en",
+      iconHash: "h",
+      iconMime: "image/png",
+      categories: ["napp.games:rpg", "napp.social:network"],
+      countries: ["US", "de"],
+      summary: "Short",
+      summaryLang: "en",
+      description: "Long text",
+      descriptionLang: "de",
+      self: SELF,
+      keyart: { hash: "k", mime: "image/png" },
+      screenshots: [
+        { hash: "s1", mime: "image/png" },
+        { hash: "s2", mime: "image/webp" },
+      ],
+      tags: ["nostr", "social"],
+      indexerRelays: ["wss://indexer"],
+    });
+
+    assertEquals(validateNappConfig(result), []);
+    assertEquals(result.name, { value: "My App", lang: "en" });
+    assertEquals(result.summary, { value: "Short", lang: "en" });
+    assertEquals(result.description, { value: "Long text", lang: "de" });
+    assertEquals(result.self, SELF);
+    assertEquals(result.keyart, { hash: "k", mime: "image/png" });
+    assertEquals(result.screenshots, [
+      { hash: "s1", mime: "image/png" },
+      { hash: "s2", mime: "image/webp" },
+    ]);
+    assertEquals(result.tags, ["nostr", "social"]);
+    assertEquals(result.indexerRelays, ["wss://indexer"]);
+    assertEquals(result.categories, ["napp.games:rpg", "napp.social:network"]);
+    assertEquals(result.countries, ["US", "de"]);
+  });
+
+  it("minimal answers still produce the SAME object as before (regression anchor)", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "My App",
+      iconHash: "abc123",
+      iconMime: "image/png",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+    assertEquals(result, {
+      name: { value: "My App" },
+      icon: { hash: "abc123", mime: "image/png" },
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+    });
+  });
+
+  it("omits lang keys when not provided", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+      summary: "Short",
+      description: "Long",
+    });
+    assert(!("lang" in result.name), "name.lang absent");
+    assertEquals(result.summary, { value: "Short" });
+    assertEquals(result.description, { value: "Long" });
+    assert(!("lang" in (result.summary as object)), "summary.lang absent");
+  });
+
+  it("omits empty optional collections and blank summary/description", () => {
+    const result = buildNappConfigFromAnswers({
+      name: "App",
+      iconHash: "h",
+      categories: ["napp.games:rpg"],
+      countries: ["*"],
+      summary: "",
+      description: "   ",
+      self: "",
+      screenshots: [],
+      tags: [],
+      indexerRelays: [],
+    });
+    assert(!("summary" in result), "summary absent");
+    assert(!("description" in result), "description absent");
+    assert(!("self" in result), "self absent");
+    assert(!("keyart" in result), "keyart absent");
+    assert(!("screenshots" in result), "screenshots absent");
+    assert(!("tags" in result), "tags absent");
+    assert(!("indexerRelays" in result), "indexerRelays absent");
+  });
+});
+
 describe("nsite path unchanged (additive-branch reasoning anchor)", () => {
   it("a plain nsite ProjectConfig (no napp section) is not a napp", () => {
     const nsiteConfig: ProjectConfig = {

--- a/tests/unit/napp/napp_assets_test.ts
+++ b/tests/unit/napp/napp_assets_test.ts
@@ -1,0 +1,279 @@
+import "../../test-setup-global.ts";
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { calculateFileHash } from "../../../src/lib/files.ts";
+import type { UploadResponse } from "../../../src/lib/upload.ts";
+import type { FileEntry } from "../../../src/lib/nostr.ts";
+import type { ISigner } from "applesauce-signers";
+import {
+  classifyAssetInput,
+  deriveAssetMime,
+  isRootSite,
+  parseCategoriesInput,
+  parseCountriesInput,
+  resolveNappAsset,
+  rootSiteMigrationNotice,
+  uploadNappAsset,
+} from "../../../src/lib/napp/assets.ts";
+
+const HEX64 = "a".repeat(64);
+
+// A throwaway signer; uploadNappAsset never actually signs when processFn is faked.
+const fakeSigner = {} as unknown as ISigner;
+
+describe("classifyAssetInput (pure)", () => {
+  it("returns hash for a 64-char hex string", () => {
+    assertEquals(classifyAssetInput(HEX64), "hash");
+    assertEquals(classifyAssetInput("F".repeat(64)), "hash");
+  });
+
+  it("returns url for an http(s) string", () => {
+    assertEquals(classifyAssetInput("https://example.com/icon.png"), "url");
+    assertEquals(classifyAssetInput("http://example.com/icon.png"), "url");
+  });
+
+  it("returns path for everything else", () => {
+    assertEquals(classifyAssetInput("./icon.png"), "path");
+    assertEquals(classifyAssetInput("foo.png"), "path");
+    assertEquals(classifyAssetInput("/abs/icon.png"), "path");
+    assertEquals(classifyAssetInput("not-64-hex"), "path");
+  });
+});
+
+describe("deriveAssetMime (pure)", () => {
+  it("maps recognizable image extensions to their MIME", () => {
+    assertEquals(deriveAssetMime("x.png"), "image/png");
+    assertEquals(deriveAssetMime("x.svg"), "image/svg+xml");
+    assertEquals(deriveAssetMime("x.webp"), "image/webp");
+    assertEquals(deriveAssetMime("x.jpg"), "image/jpeg");
+    assertEquals(deriveAssetMime("x.jpeg"), "image/jpeg");
+    assertEquals(deriveAssetMime("x.gif"), "image/gif");
+    assertEquals(deriveAssetMime("x.avif"), "image/avif");
+  });
+
+  it("falls back to image/png for non-image / unknown extensions and hashes", () => {
+    assertEquals(deriveAssetMime(HEX64), "image/png");
+    assertEquals(deriveAssetMime("x.xyz"), "image/png");
+    assertEquals(deriveAssetMime("noext"), "image/png");
+  });
+});
+
+describe("parseCategoriesInput (pure)", () => {
+  it("prepends napp. only when missing, trims, drops blanks, preserves order", () => {
+    assertEquals(
+      parseCategoriesInput([
+        "social:network",
+        "napp.utilities:text editor",
+        "  ",
+        " games:rpg ",
+      ]),
+      ["napp.social:network", "napp.utilities:text editor", "napp.games:rpg"],
+    );
+  });
+
+  it("returns [] for an all-blank input", () => {
+    assertEquals(parseCategoriesInput(["", "   "]), []);
+  });
+});
+
+describe("parseCountriesInput (pure)", () => {
+  it('returns ["*"] for empty or wildcard input', () => {
+    assertEquals(parseCountriesInput(""), ["*"]);
+    assertEquals(parseCountriesInput("   "), ["*"]);
+    assertEquals(parseCountriesInput("*"), ["*"]);
+  });
+
+  it("splits on commas, trims, drops blanks", () => {
+    assertEquals(parseCountriesInput("US, de"), ["US", "de"]);
+    assertEquals(parseCountriesInput("US,,de , "), ["US", "de"]);
+  });
+});
+
+describe("isRootSite (pure)", () => {
+  it("is true when id is missing or empty, false otherwise", () => {
+    assertEquals(isRootSite({}), true);
+    assertEquals(isRootSite({ id: "" }), true);
+    assertEquals(isRootSite({ id: null }), true);
+    assertEquals(isRootSite({ id: "x" }), false);
+  });
+});
+
+describe("rootSiteMigrationNotice (pure)", () => {
+  it("names the kinds, orphaning, and gateway change", () => {
+    const notice = rootSiteMigrationNotice();
+    assert(notice.includes("15128"));
+    assert(notice.includes("35128"));
+    assert(notice.toLowerCase().includes("orphan"));
+    assert(notice.toLowerCase().includes("gateway"));
+  });
+});
+
+describe("resolveNappAsset (boundary)", () => {
+  it("returns {hash,mime} for a hash WITHOUT calling upload", async () => {
+    let called = false;
+    const failUpload = (_p: string): Promise<{ hash: string; mime: string }> => {
+      called = true;
+      return Promise.reject(new Error("upload should not be called"));
+    };
+    const asset = await resolveNappAsset(HEX64, failUpload);
+    assertEquals(asset, { hash: HEX64, mime: "image/png" });
+    assertEquals(called, false);
+  });
+
+  it("returns {hash,mime} for a URL WITHOUT calling upload", async () => {
+    let called = false;
+    const failUpload = (_p: string): Promise<{ hash: string; mime: string }> => {
+      called = true;
+      return Promise.reject(new Error("upload should not be called"));
+    };
+    const asset = await resolveNappAsset("https://x/icon.svg", failUpload);
+    assertEquals(asset, { hash: "https://x/icon.svg", mime: "image/svg+xml" });
+    assertEquals(called, false);
+  });
+
+  it("delegates a local path to the injected upload fn", async () => {
+    const fakeUpload = (p: string): Promise<{ hash: string; mime: string }> =>
+      Promise.resolve({ hash: "UPLOADED:" + p, mime: "image/png" });
+    const asset = await resolveNappAsset("./x.png", fakeUpload);
+    assertEquals(asset, { hash: "UPLOADED:./x.png", mime: "image/png" });
+  });
+});
+
+function successResponse(file: FileEntry): UploadResponse {
+  return {
+    file,
+    success: true,
+    serverResults: { "https://s": { success: true } },
+  };
+}
+
+function failedResponse(file: FileEntry): UploadResponse {
+  return {
+    file,
+    success: false,
+    error: "all servers failed",
+    serverResults: { "https://s": { success: false, error: "nope" } },
+  };
+}
+
+describe("uploadNappAsset (with fake processFn)", () => {
+  it("computes sha256+mime and returns them on success", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4]));
+      const expectedHash = await calculateFileHash(file);
+
+      let captured: FileEntry | undefined;
+      const fakeProcess = (entries: FileEntry[]) => {
+        captured = entries[0];
+        return Promise.resolve([successResponse(entries[0])]);
+      };
+
+      const asset = await uploadNappAsset(
+        file,
+        { servers: ["https://s"], relays: ["wss://r"], signer: fakeSigner },
+        fakeProcess,
+      );
+      assertEquals(asset, { hash: expectedHash, mime: "image/png" });
+      // FileEntry construction: sha256, contentType, data present.
+      assert(captured, "processFn should be called");
+      assertEquals(captured!.sha256, expectedHash);
+      assertEquals(captured!.contentType, "image/png");
+      assertEquals(captured!.size, 4);
+      assert(captured!.data instanceof Uint8Array);
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+
+  it("throws when servers is empty", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4]));
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            file,
+            { servers: [], relays: ["wss://r"], signer: fakeSigner },
+            () => Promise.resolve([]),
+          ),
+        Error,
+        "server",
+      );
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+
+  it("throws when relays is empty (pre-empts processUploads generic error)", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4]));
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            file,
+            { servers: ["https://s"], relays: [], signer: fakeSigner },
+            () => Promise.resolve([]),
+          ),
+        Error,
+        "relay",
+      );
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+
+  it("throws when the file is missing", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            `${dir}/nope.png`,
+            { servers: ["https://s"], relays: ["wss://r"], signer: fakeSigner },
+            () => Promise.resolve([]),
+          ),
+        Error,
+      );
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("throws when the file is empty", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            file,
+            { servers: ["https://s"], relays: ["wss://r"], signer: fakeSigner },
+            () => Promise.resolve([]),
+          ),
+        Error,
+        "empty",
+      );
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+
+  it("throws when the upload did not succeed", async () => {
+    const file = await Deno.makeTempFile({ suffix: ".png" });
+    try {
+      await Deno.writeFile(file, new Uint8Array([1, 2, 3, 4]));
+      await assertRejects(
+        () =>
+          uploadNappAsset(
+            file,
+            { servers: ["https://s"], relays: ["wss://r"], signer: fakeSigner },
+            (entries: FileEntry[]) => Promise.resolve([failedResponse(entries[0])]),
+          ),
+        Error,
+      );
+    } finally {
+      await Deno.remove(file);
+    }
+  });
+});

--- a/tests/unit/napp/napp_init_command_test.ts
+++ b/tests/unit/napp/napp_init_command_test.ts
@@ -2,14 +2,55 @@ import "../../test-setup-global.ts";
 import { assert, assertEquals, assertFalse } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
-import { registerNappCommand } from "../../../src/commands/napp.ts";
+import {
+  decideRootSiteId,
+  planNappInitFromFlags,
+  registerNappCommand,
+} from "../../../src/commands/napp.ts";
 import {
   buildNappConfigFromAnswers,
+  collectNappListing,
+  type NappAssetResolver,
   type ProjectConfig,
   readProjectFile,
   writeProjectFile,
 } from "../../../src/lib/config.ts";
 import { isNapp, validateNappConfig } from "../../../src/lib/napp/detect.ts";
+
+// A no-network resolver: hash/URL/path all return a deterministic asset so the
+// composition tests never touch real blossom servers or relays.
+const fakeResolver: NappAssetResolver = (value: string) =>
+  Promise.resolve({ hash: `resolved:${value}`, mime: "image/png" });
+
+// Mirror of nappInitAction's flag-driven, non-interactive path (no prompts, no exit):
+// plan flags -> collect listing (fake resolver) -> validate -> write/read round-trip.
+async function runFlagDrivenInit(
+  flags: Parameters<typeof planNappInitFromFlags>[0],
+  path: string,
+): Promise<ProjectConfig> {
+  const plan = planNappInitFromFlags(flags);
+  const projectConfig = readProjectFile(path)!;
+  if (isRootSiteId(projectConfig.id)) {
+    const decision = decideRootSiteId({
+      isRoot: true,
+      idFlag: plan.id,
+      interactive: false,
+    });
+    if (decision.setId !== undefined) projectConfig.id = decision.setId;
+  }
+  const napp = await collectNappListing({
+    prefill: plan.prefill,
+    interactive: false,
+    resolveAsset: fakeResolver,
+  });
+  const updated: ProjectConfig = { ...projectConfig, napp };
+  writeProjectFile(updated, path);
+  return readProjectFile(path)!;
+}
+
+function isRootSiteId(id: ProjectConfig["id"]): boolean {
+  return id === undefined || id === null || id === "";
+}
 
 const validNapp = {
   name: { value: "My App" },
@@ -76,6 +117,100 @@ describe("napp init retrofit round-trip (temp dir)", () => {
       assertEquals(read.relays, ["wss://r"]);
       assertEquals(read.servers, ["https://s"]);
       assertEquals(read.id, "my-site");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+});
+
+describe("napp init flag-driven write (temp dir, fake resolver)", () => {
+  it("writes a full napp section from flags, preserving unrelated keys", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, ".nsite", "config.json");
+      writeProjectFile({
+        relays: ["wss://r"],
+        servers: ["https://s"],
+        id: "my-site",
+      }, path);
+
+      const read = await runFlagDrivenInit({
+        name: "My App",
+        icon: "a".repeat(64),
+        iconMime: "image/png",
+        category: ["social:network", "games:rpg"],
+        countries: "US, de",
+        summary: "Short",
+        tag: ["nostr"],
+      }, path);
+
+      assert(isNapp(read), "flag-driven config should be a napp");
+      assertEquals(validateNappConfig(read.napp).length, 0);
+      assertEquals(read.napp!.name, { value: "My App" });
+      assertEquals(read.napp!.icon, {
+        hash: `resolved:${"a".repeat(64)}`,
+        mime: "image/png",
+      });
+      assertEquals(read.napp!.categories, [
+        "napp.social:network",
+        "napp.games:rpg",
+      ]);
+      assertEquals(read.napp!.countries, ["US", "de"]);
+      assertEquals(read.napp!.summary, { value: "Short" });
+      assertEquals(read.napp!.tags, ["nostr"]);
+      // Unrelated keys survive.
+      assertEquals(read.relays, ["wss://r"]);
+      assertEquals(read.id, "my-site");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("non-interactive missing-required surfaces via plan.missingRequired", () => {
+    const plan = planNappInitFromFlags({ name: "Only Name" });
+    assert(plan.missingRequired.length > 0);
+    assert(plan.missingRequired.includes("icon"));
+    assert(plan.missingRequired.includes("category"));
+  });
+
+  it("root-site + --id sets config.id (opt-in migration)", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, ".nsite", "config.json");
+      // Root site: id is empty.
+      writeProjectFile({ relays: ["wss://r"], servers: ["https://s"], id: "" }, path);
+
+      const read = await runFlagDrivenInit({
+        name: "App",
+        icon: "h",
+        category: ["games:rpg"],
+        id: "blog",
+      }, path);
+
+      assertEquals(read.id, "blog");
+      assert(isNapp(read));
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  it("root-site without --id (non-interactive) writes napp without setting id", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, ".nsite", "config.json");
+      writeProjectFile({ relays: ["wss://r"], servers: ["https://s"], id: "" }, path);
+
+      const read = await runFlagDrivenInit({
+        name: "App",
+        icon: "h",
+        category: ["games:rpg"],
+      }, path);
+
+      assertEquals(read.id, "");
+      assert(isNapp(read), "napp section still written");
+      // decideRootSiteId still signals the notice for non-interactive root sites.
+      const decision = decideRootSiteId({ isRoot: true, interactive: false });
+      assertEquals(decision, { printNotice: true });
     } finally {
       await Deno.remove(dir, { recursive: true });
     }

--- a/tests/unit/napp/napp_init_flags_test.ts
+++ b/tests/unit/napp/napp_init_flags_test.ts
@@ -1,0 +1,103 @@
+import "../../test-setup-global.ts";
+import { assert, assertEquals } from "@std/assert";
+import { describe, it } from "@std/testing/bdd";
+import { decideRootSiteId, planNappInitFromFlags } from "../../../src/commands/napp.ts";
+
+describe("planNappInitFromFlags (pure)", () => {
+  it("parses full flags into answersFromFlags with no missing required", () => {
+    const plan = planNappInitFromFlags({
+      name: "My App",
+      icon: "a".repeat(64),
+      iconMime: "image/png",
+      category: ["social:network", "napp.games:rpg"],
+      countries: "US, de",
+      summary: "Short",
+      description: "Long",
+      self: "b".repeat(64),
+      keyart: "https://x/key.png",
+      screenshot: ["s1", "s2"],
+      tag: ["nostr", "social"],
+      indexerRelay: ["wss://indexer"],
+      id: "my-site",
+      yes: true,
+    });
+
+    assertEquals(plan.prefill.name, "My App");
+    assertEquals(plan.prefill.icon, "a".repeat(64));
+    assertEquals(plan.prefill.iconMime, "image/png");
+    assertEquals(plan.prefill.categories, [
+      "napp.social:network",
+      "napp.games:rpg",
+    ]);
+    assertEquals(plan.prefill.countries, ["US", "de"]);
+    assertEquals(plan.prefill.summary, "Short");
+    assertEquals(plan.prefill.description, "Long");
+    assertEquals(plan.prefill.self, "b".repeat(64));
+    assertEquals(plan.prefill.keyart, "https://x/key.png");
+    assertEquals(plan.prefill.screenshots, ["s1", "s2"]);
+    assertEquals(plan.prefill.tags, ["nostr", "social"]);
+    assertEquals(plan.prefill.indexerRelays, ["wss://indexer"]);
+    assertEquals(plan.id, "my-site");
+    assertEquals(plan.yes, true);
+    assertEquals(plan.missingRequired, []);
+  });
+
+  it("computes missingRequired when only --name is given", () => {
+    const plan = planNappInitFromFlags({ name: "Only Name" });
+    assert(plan.missingRequired.includes("icon"));
+    assert(plan.missingRequired.includes("category"));
+    assert(!plan.missingRequired.includes("name"));
+  });
+
+  it("keeps three repeated --category values", () => {
+    const plan = planNappInitFromFlags({
+      name: "n",
+      icon: "i",
+      category: ["a:b", "c:d", "e:f"],
+    });
+    assertEquals(plan.prefill.categories, ["napp.a:b", "napp.c:d", "napp.e:f"]);
+    assertEquals(plan.missingRequired, []);
+  });
+
+  it("is pure: returns plain data and does not touch the filesystem", () => {
+    const plan = planNappInitFromFlags({});
+    assertEquals(typeof plan, "object");
+    assert(Array.isArray(plan.missingRequired));
+  });
+});
+
+describe("decideRootSiteId (pure)", () => {
+  it("non-root: no notice, no setId", () => {
+    const d = decideRootSiteId({ isRoot: false, interactive: false });
+    assertEquals(d, { printNotice: false });
+  });
+
+  it("root + idFlag: setId and printNotice", () => {
+    const d = decideRootSiteId({ isRoot: true, idFlag: "x", interactive: false });
+    assertEquals(d, { setId: "x", printNotice: true });
+  });
+
+  it("root + no idFlag + non-interactive: printNotice, no setId", () => {
+    const d = decideRootSiteId({ isRoot: true, interactive: false });
+    assertEquals(d, { printNotice: true });
+  });
+
+  it("root + interactive + confirmed value: setId", () => {
+    const d = decideRootSiteId({
+      isRoot: true,
+      interactive: true,
+      confirmed: true,
+      confirmedValue: "blog",
+    });
+    assertEquals(d, { setId: "blog", printNotice: true });
+  });
+
+  it("root + interactive + declined: no setId, printNotice", () => {
+    const d = decideRootSiteId({
+      isRoot: true,
+      interactive: true,
+      confirmed: false,
+    });
+    assertEquals(d, { printNotice: true });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the four gaps in the nsite→napp conversion path, building on the napp/NIP-5B work in #137. Conversion is now turnkey: root sites are guided, assets upload from a local file, `nsyte napp init` is fully scriptable, and the wizard + `napp init` cover every NIP-5B listing field — with **zero regressions** to existing nsite and napp behavior.

> Stacked on `feat/napp-support` (base of #137). Rebase onto `main` once #137 merges.

## What changed

**1. Root-site guidance (NAPP-UX-01)** — `napp init`/wizard detect a root site (no `config.id`, kind 15128) and print a migration caveat (republishes 15128→35128, old root manifest orphaned, gateway URLs change). An `id` is set **only** on explicit `--id` or interactive confirmation — never auto-migrated. Pure `decideRootSiteId` encodes the consent rule.

**2. Local-path asset upload (NAPP-UX-02)** — `--icon`/`--keyart`/`--screenshot` (and the interactive path option) accept a sha256 hash, a URL, **or a local file path**. Local files are uploaded to the configured blossom servers via the existing `processUploads` plumbing; sha256 + MIME are captured into the asset. The paste-a-hash/URL path is unchanged.

**3. Scriptable `napp init` (NAPP-UX-03)** — new flags: `--name --icon --icon-mime --category (×≤3) --countries --summary --description --keyart --screenshot (×N) --self --tag (×N) --indexer-relay (×N) --id --sec --yes`. Fully-specified valid flags skip all prompts; missing fields prompt, or error clearly when non-interactive (no hang). Every flag is documented; `check-doc-drift` is green.

**4. Full NIP-5B field coverage (NAPP-UX-04)** — wizard + `napp init` (via a shared `collectNappListing` collector) now support multiple categories (≤3), optional lang codes on name/summary/description, `self`, `keyart`, `screenshots[]`, `tags[]`, `indexerRelays[]`, all validated via `validateNappConfig`.

## Architecture

- New pure module `src/lib/napp/assets.ts`: `classifyAssetInput`, `deriveAssetMime` (image/ guard), `parseCategoriesInput`/`parseCountriesInput`, `isRootSite`, `rootSiteMigrationNotice`, the `resolveNappAsset` boundary, and `uploadNappAsset` (injectable `processFn`, clear errors for empty servers/relays/file/failed upload).
- `buildNappConfigFromAnswers` extended with optional full-field params (backward-compatible).
- Shared `collectNappListing({ prefill, interactive, resolveAsset })` drives both the `nsyte init` wizard napp branch and `nsyte napp init`. The wizard's **nsite branch is byte-for-byte unchanged**.

## Tests & gates

- 52 new test steps (pure helpers, flag planning, root-site decision, asset resolution/upload with fakes, full-field assembly, flag-driven init via temp dirs). No test touches the real `.nsite/config.json` or any real blossom/relay.
- `deno task test`: **312 passed, 0 failed, 9 ignored**
- `deno task check-doc-drift`: **exit 0** (22/22 flag alignment)
- `deno check src/cli.ts`: clean · `deno fmt --check`/`deno lint` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
