### PR TITLE
Harden napp init validation and docs build

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -101,8 +101,8 @@ PATs expire. When `RELEASE_TOKEN` expires, the next release silently fails to tr
 4. Verify with `gh secret list -R sandwichfarm/nsyte` or by triggering a test release.
 
 You do not need to rename the secret — updating the value in place is sufficient. Active workflows
-mid-run that reference `${{ secrets.RELEASE_TOKEN }}` will continue to use the old value until their
-run completes; only new runs pick up the new value.
+mid-run that reference <code v-pre>${{ secrets.RELEASE_TOKEN }}</code> will continue to use the old
+value until their run completes; only new runs pick up the new value.
 
 ---
 
@@ -113,8 +113,9 @@ run completes; only new runs pick up the new value.
 Check in this order:
 
 1. **`release.yml` step still uses `GITHUB_TOKEN`** — verify line 446 of
-   `.github/workflows/release.yml` reads `token: ${{ secrets.RELEASE_TOKEN }}`, not
-   `${{ secrets.GITHUB_TOKEN }}`. This is the most common cause.
+   `.github/workflows/release.yml` reads `token:` followed by
+   <code v-pre>${{ secrets.RELEASE_TOKEN }}</code>, not
+   <code v-pre>${{ secrets.GITHUB_TOKEN }}</code>. This is the most common cause.
 2. **`RELEASE_TOKEN` secret not set** — confirm it is present in Settings → Secrets and variables →
    Actions.
 3. **`RELEASE_TOKEN` expired or revoked** — create a new PAT and update the secret.

--- a/src/lib/napp/detect.ts
+++ b/src/lib/napp/detect.ts
@@ -77,6 +77,7 @@ function validateAsset(
 
 const HEX64 = /^[0-9a-fA-F]{64}$/;
 const ALPHA2 = /^[A-Za-z]{2}$/;
+const RELAY_URL = /^wss?:\/\//;
 
 /**
  * Structurally validate a napp section. Returns an array of errors (empty = valid).
@@ -138,8 +139,7 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
     if (countries.length === 0) {
       errors.push({
         path: "/napp/countries",
-        message:
-          'must be ["*"] (worldwide) or at least one ISO 3166-1 alpha-2 code',
+        message: 'must be ["*"] (worldwide) or at least one ISO 3166-1 alpha-2 code',
       });
     } else if (
       hasWildcard && !(countries.length === 1 && countries[0] === "*")
@@ -151,8 +151,7 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
     } else if (!hasWildcard && !countries.every((c) => ALPHA2.test(c))) {
       errors.push({
         path: "/napp/countries",
-        message:
-          'each entry must be a 2-letter ISO 3166-1 alpha-2 code (or use ["*"])',
+        message: 'each entry must be a 2-letter ISO 3166-1 alpha-2 code (or use ["*"])',
       });
     }
   }
@@ -200,6 +199,19 @@ export function validateNappConfig(napp: unknown): ValidationError[] {
       errors.push({
         path: "/napp/tags",
         message: "must be an array of strings",
+      });
+    }
+  }
+
+  // indexerRelays (optional ws/wss relay URL strings)
+  if (napp.indexerRelays !== undefined) {
+    if (
+      !Array.isArray(napp.indexerRelays) ||
+      !napp.indexerRelays.every((relay) => typeof relay === "string" && RELAY_URL.test(relay))
+    ) {
+      errors.push({
+        path: "/napp/indexerRelays",
+        message: "must be an array of ws:// or wss:// relay URLs",
       });
     }
   }

--- a/tests/unit/napp/detect_test.ts
+++ b/tests/unit/napp/detect_test.ts
@@ -160,3 +160,19 @@ Deno.test("validateNappConfig - tags must be string[]", () => {
   });
   assertEquals(errs.some((e) => e.path === "/napp/tags"), true);
 });
+
+Deno.test("validateNappConfig - indexerRelays must be ws/wss relay URLs", () => {
+  const errs = validateNappConfig({
+    ...validNapp(),
+    indexerRelays: ["nope", "https://relay.example.com"],
+  });
+  assertEquals(errs.some((e) => e.path === "/napp/indexerRelays"), true);
+  assertEquals(
+    isNapp({
+      relays: [],
+      servers: [],
+      napp: { ...validNapp(), indexerRelays: ["nope"] },
+    }),
+    false,
+  );
+});

--- a/tests/unit/napp/schema_test.ts
+++ b/tests/unit/napp/schema_test.ts
@@ -90,6 +90,14 @@ Deno.test("validateConfig - napp countries ['*','US'] is rejected (mixed wildcar
   assertEquals(result.errors.some((e) => e.path === "/napp/countries"), true);
 });
 
+Deno.test("validateConfig - napp indexerRelays reject non-relay URLs", () => {
+  const config = validNappConfig();
+  config.napp.indexerRelays = ["https://relay.example.com", "nope"];
+  const result = validateConfig(config);
+  assertEquals(result.valid, false);
+  assertEquals(result.errors.some((e) => e.path === "/napp/indexerRelays"), true);
+});
+
 Deno.test("validateConfig - napp icon missing hash is invalid", () => {
   const config = validNappConfig();
   config.napp.icon = { mime: "image/png" } as { hash: string; mime: string };


### PR DESCRIPTION
## Review findings fixed

- Reject malformed `napp.indexerRelays` in structural validation so `nsyte napp init --indexer-relay nope` cannot write a config that later fails schema loading.
- Escape GitHub Actions expressions in `docs/RELEASING.md` with `v-pre` so VitePress SSR does not evaluate `secrets.RELEASE_TOKEN`.

## Verification

- `deno test --allow-all --no-check tests/unit/napp/detect_test.ts tests/unit/napp/schema_test.ts tests/unit/napp/napp_init_command_test.ts`
- Invalid `napp init --indexer-relay nope` repro exits 1 and leaves config unchanged
- `deno task test`
- `deno task check-doc-drift`
- `deno lint src/lib/napp/detect.ts tests/unit/napp/detect_test.ts tests/unit/napp/schema_test.ts`
- `deno fmt --check src/lib/napp/detect.ts tests/unit/napp/detect_test.ts tests/unit/napp/schema_test.ts`
- `deno task site:build`
- `deno task compile`
- `git diff --check`

## Notes

- Live relay publish of kind 37348/39108 was not tested.
