### PR TITLE
Keep Linux release packaging alive when UPX fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,11 +70,19 @@ jobs:
           cp dist/nsyte-linux dist/nsyte-linux-compressed
 
       - name: Compress with UPX
+        id: compress_linux
+        continue-on-error: true
         uses: svenstaro/upx-action@v2
         with:
           files: dist/nsyte-linux-compressed
           args: --best --lzma
           strip: false
+
+      - name: Restore Linux compressed artifact if UPX fails
+        if: ${{ steps.compress_linux.outcome != 'success' }}
+        run: |
+          echo "UPX compression failed on Linux; shipping uncompressed copy as the compressed artifact."
+          cp dist/nsyte-linux dist/nsyte-linux-compressed
 
       - name: Rename binaries
         run: |


### PR DESCRIPTION
## Summary
- Make the Linux UPX compression step non-blocking.
- Restore the original Linux binary to the expected compressed artifact filename when UPX cannot pack it.
- Preserve release artifact names so the downstream release job can still upload standard and compressed-path binaries.

## Failure verified
- Run 29083986039 failed only in `Build Linux Binary` -> `Compress with UPX`.
- Linux compile succeeded, then UPX 4.2.2 failed with `CantPackException: bad e_phoff`.
- Windows, macOS Intel, macOS Apple Silicon, and JSR publish succeeded; release creation was skipped because Linux artifacts were missing.

## Validation
- `deno task compile:linux`
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parses"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`\n\n## Recovery note\nAfter this merges, rerun the release via `workflow_dispatch` with version `0.27.3` and `replace_release=true` if a release object was already created. The original tag workflow uses the workflow file from tag commit `172ccdc`, so rerunning that exact failed run will not pick up this fix.