### PR TITLE
Fix site deploy Node version and release recovery

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Set up pnpm
         run: |
           if command -v corepack >/dev/null 2>&1; then
@@ -26,7 +26,7 @@ jobs:
       - name: Set up pnpm cache
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "pnpm"
           cache-dependency-path: "docs/pnpm-lock.yaml"
       - name: Install site dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,7 +360,18 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: deno run --allow-read --allow-write --allow-env scripts/sync-version.ts "${{ env.VERSION }}"
 
+      - name: Check existing JSR version
+        id: jsr_version
+        run: |
+          if curl -fsSL "https://jsr.io/@nsyte/cli/${VERSION}_meta.json" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "JSR version ${VERSION} already exists; skipping publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Check JSR publish (dry run)
+        if: ${{ steps.jsr_version.outputs.exists != 'true' }}
         run: |
           echo "Running JSR publish dry run to check for issues..."
           deno publish --dry-run --allow-dirty
@@ -371,12 +382,16 @@ jobs:
           echo "✅ JSR publish dry run successful"
 
       - name: Publish to JSR
+        if: ${{ steps.jsr_version.outputs.exists != 'true' }}
         run: deno publish --allow-dirty
 
   release:
     name: Create Release
     needs: [build-linux, build-macos-intel, build-macos-arm, build-windows, publish-jsr]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -392,10 +407,20 @@ jobs:
           NORMALIZED_VERSION="${RAW_VERSION#v}"
           echo "VERSION=${NORMALIZED_VERSION}" >> $GITHUB_ENV
 
+      - name: Validate release token
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          if [ -z "$RELEASE_TOKEN" ]; then
+            echo "::error::Missing RELEASE_TOKEN repository secret. release.yml uses a PAT so the publish-packages release event fires."
+            echo "::error::Create a PAT with repo scope, store it as RELEASE_TOKEN, then rerun with workflow_dispatch."
+            exit 1
+          fi
+
       - name: Remove existing release if requested
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.replace_release == 'true' }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             TAG_NAME="v${{ env.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -391,7 +391,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Move the deploy-site workflow from Node 20 to Node 22 so pnpm 11.3.0 can run during cache setup and docs deploy.
- Skip JSR dry-run/publish when the requested version already exists, allowing recovery after a partial release.
- Add an explicit `RELEASE_TOKEN` validation step and keep release deletion/creation on the PAT path required by `publish-packages.yml`.

## Failure evidence
- Run 29084456927 (`deploy site`) failed at `Set up pnpm cache`: pnpm 11.3.0 warned it requires Node >=22.13, then Node 20.20.2 failed on missing built-in module `node:sqlite`.
- Run 29084491041 (`build & release`) built/uploaded all binaries and published `@nsyte/cli@0.27.4`, then failed in `Create GitHub Release` with `Parameter token or opts.auth is required`.
- `gh secret list --repo sandwichfarm/nsyte` shows no `RELEASE_TOKEN` secret currently configured.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; %w[.github/workflows/docs.yml .github/workflows/release.yml].each { |f| YAML.load_file(f); puts "#{f} parses" }'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs.yml .github/workflows/release.yml`\n- `pnpm --dir docs install --frozen-lockfile`\n- `./scripts/build-site.sh`\n- `deno task compile:linux`\n- `curl -fsSL https://jsr.io/@nsyte/cli/0.27.4_meta.json`\n\n## Release recovery\n`v0.27.4` is half-published: JSR exists, GitHub Release does not. The durable fix is to add a PAT secret named `RELEASE_TOKEN` because package publication depends on the `release: published` event. Without that secret, the patched workflow will fail early with an explicit error instead of failing inside `softprops/action-gh-release`.