### PR TITLE
Fix clean docs deploy Vue resolution

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,7 @@
     "docs:preview": "cd .. && docs/node_modules/.bin/vitepress preview docs"
   },
   "devDependencies": {
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.4",
+    "vue": "^3.5.39"
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.55.2)(postcss@8.5.16)(search-insights@2.17.3)
+      vue:
+        specifier: ^3.5.39
+        version: 3.5.39
 
 packages:
 


### PR DESCRIPTION
## Summary
- Add `vue` as an explicit docs dev dependency.
- Update the docs lock importer so clean docs-only installs link Vue at `docs/node_modules/vue`.

## Failure evidence
Run 29085429520 (`deploy site`) now passes Node/pnpm setup and dependency install, then fails in `Build Site`:

```text
[vite]: Rollup failed to resolve import "vue/server-renderer" from "docs/PACKAGE_MANAGERS.md"
```

The failure happens because the deploy job installs only the docs workspace. VitePress generates markdown modules that import `vue/server-renderer`, but Vue was only available transitively under pnpm’s strict layout. Local builds were masked by this checkout’s root `node_modules/vue`.

## Validation
- `git diff --check`
- `deno fmt --check docs/package.json`
- Clean temp worktree from `origin/main` reproduced the failure with `pnpm --dir docs install --frozen-lockfile && ./scripts/build-site.sh`
- Same clean temp worktree plus this diff passed `pnpm --dir docs install --frozen-lockfile && ./scripts/build-site.sh`
- Local `pnpm --dir docs install --frozen-lockfile`
- Local `./scripts/build-site.sh`