### PR TITLE
Resolve CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Deploy Site

--- a/.github/workflows/release-simple.yml
+++ b/.github/workflows/release-simple.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   build-and-release:
     name: Build All Binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     name: Build Linux Binary

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -8,6 +8,9 @@ on:
       - "src/**"
       - "deno.json"
 
+permissions:
+  contents: read
+
 jobs:
   test-build-linux:
     name: Test Linux Build

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -428,7 +428,7 @@ export async function deployCommand(
 
     if ("error" in signerResult) {
       statusDisplay.error(`Signer: ${signerResult.error}`);
-      log.error(`Signer initialization failed: ${signerResult.error}`);
+      log.error("Signer initialization failed.");
       return Deno.exit(1);
     }
 

--- a/src/lib/auth/signer-factory.ts
+++ b/src/lib/auth/signer-factory.ts
@@ -71,9 +71,10 @@ export async function createSigner(
           return { signer: privateKeySigner, pubkey };
         }
       }
-    } catch (e: unknown) {
+    } catch {
+      log.debug("Failed to use --sec parameter.");
       return {
-        error: `Failed to use secret from --sec parameter: ${getErrorMessage(e)}`,
+        error: "Failed to use secret from --sec parameter.",
       };
     }
   }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -64,6 +64,19 @@ export function setProgressMode(enabled: boolean): void {
  * Store logs that occur during progress mode
  */
 const queuedLogs: Array<{ level: string; namespace: string; message: string }> = [];
+const REDACTED_LOG_MESSAGE = "[redacted sensitive log message]";
+const SENSITIVE_LOG_PATTERNS = [
+  /\bnsec1[qpzry9x8gf2tvdw0s3jn54khce6mua7l]{20,}\b/i,
+  /\bnbunksec1[a-z0-9]{20,}\b/i,
+  /\bbunker:\/\/\S+/i,
+  /\b[0-9a-f]{64}\b/i,
+];
+
+function redactSensitiveLogMessage(message: string): string {
+  return SENSITIVE_LOG_PATTERNS.some((pattern) => pattern.test(message))
+    ? REDACTED_LOG_MESSAGE
+    : message;
+}
 
 /**
  * Flush queued logs
@@ -140,60 +153,65 @@ export function createLogger(namespace: string) {
   return {
     debug(message: string): void {
       if (shouldLog("debug")) {
+        const safeMessage = redactSensitiveLogMessage(message);
         // Always write debug messages to file if file logging is enabled
-        writeToLogFile("debug", namespace, message);
+        writeToLogFile("debug", namespace, safeMessage);
 
         if (shouldShowLog("debug")) {
-          console.log(formatLogMessage("debug", namespace, message));
+          console.log(formatLogMessage("debug", namespace, safeMessage));
         }
       }
     },
 
     info(message: string): void {
       if (shouldLog("info")) {
+        const safeMessage = redactSensitiveLogMessage(message);
         // Always write to file if file logging is enabled
-        writeToLogFile("info", namespace, message);
+        writeToLogFile("info", namespace, safeMessage);
 
         if (inProgressMode) {
-          queuedLogs.push({ level: "info", namespace, message });
+          queuedLogs.push({ level: "info", namespace, message: safeMessage });
         } else if (shouldShowLog("info")) {
-          console.log(formatLogMessage("info", namespace, message));
+          console.log(formatLogMessage("info", namespace, safeMessage));
         }
       }
     },
 
     warn(message: string): void {
       if (shouldLog("warn")) {
+        const safeMessage = redactSensitiveLogMessage(message);
         // Always write to file if file logging is enabled
-        writeToLogFile("warn", namespace, message);
+        writeToLogFile("warn", namespace, safeMessage);
 
         if (inProgressMode) {
-          queuedLogs.push({ level: "warn", namespace, message });
+          queuedLogs.push({ level: "warn", namespace, message: safeMessage });
         } else if (shouldShowLog("warn")) {
-          console.log(formatLogMessage("warn", namespace, message));
+          console.log(formatLogMessage("warn", namespace, safeMessage));
         }
       }
     },
 
     error(message: string): void {
       if (shouldLog("error")) {
+        const safeMessage = redactSensitiveLogMessage(message);
         // Always write to file if file logging is enabled
-        writeToLogFile("error", namespace, message);
+        writeToLogFile("error", namespace, safeMessage);
 
         if (inProgressMode) {
-          queuedLogs.push({ level: "error", namespace, message });
+          queuedLogs.push({ level: "error", namespace, message: safeMessage });
         } else if (shouldShowLog("error")) {
-          console.error(formatLogMessage("error", namespace, message));
+          console.error(formatLogMessage("error", namespace, safeMessage));
         }
       }
     },
 
     success(message: string): void {
+      const safeMessage = redactSensitiveLogMessage(message);
       // Always write to file if file logging is enabled
-      writeToLogFile("success", namespace, message);
+      writeToLogFile("success", namespace, safeMessage);
 
       if (shouldShowLog("success")) {
-        console.log(formatLogMessage("success", namespace, message));
+        console.log(formatLogMessage("success", namespace, safeMessage));
       }
     },
   };

--- a/tests/unit/constants_test.ts
+++ b/tests/unit/constants_test.ts
@@ -5,6 +5,13 @@ import {
   RELAY_DISCOVERY_RELAYS,
 } from "../../src/lib/constants.ts";
 
+function hasUrlOrigin(urls: readonly string[], protocol: string, hostname: string): boolean {
+  return urls.some((value) => {
+    const url = new URL(value);
+    return url.protocol === protocol && url.hostname === hostname;
+  });
+}
+
 Deno.test("Constants - NSYTE_BROADCAST_RELAYS", async (t) => {
   await t.step("should have default broadcast relays", () => {
     assertEquals(Array.isArray(NSYTE_BROADCAST_RELAYS), true);
@@ -19,8 +26,8 @@ Deno.test("Constants - NSYTE_BROADCAST_RELAYS", async (t) => {
 
   await t.step("should include expected relays", () => {
     // Check for some expected relays
-    assertEquals(NSYTE_BROADCAST_RELAYS.includes("wss://relay.damus.io"), true);
-    assertEquals(NSYTE_BROADCAST_RELAYS.includes("wss://nos.lol"), true);
+    assertEquals(hasUrlOrigin(NSYTE_BROADCAST_RELAYS, "wss:", "relay.damus.io"), true);
+    assertEquals(hasUrlOrigin(NSYTE_BROADCAST_RELAYS, "wss:", "nos.lol"), true);
   });
 });
 
@@ -56,7 +63,7 @@ Deno.test("Constants - DEFAULT_BLOSSOM_SERVERS", async (t) => {
 
   await t.step("should include expected servers", () => {
     // Check for expected blossom servers
-    assertEquals(DEFAULT_BLOSSOM_SERVERS.includes("https://blossom.primal.net"), true);
+    assertEquals(hasUrlOrigin(DEFAULT_BLOSSOM_SERVERS, "https:", "blossom.primal.net"), true);
   });
 });
 

--- a/tests/unit/logger_test.ts
+++ b/tests/unit/logger_test.ts
@@ -96,6 +96,32 @@ describe("logger - comprehensive branch coverage", () => {
       assertStringIncludes(logOutput[0], "test");
       assertStringIncludes(logOutput[0], ": test");
     });
+
+    it("should redact secret-like values before logging", () => {
+      const logger = createLogger("test");
+      const privateKey = "a".repeat(64);
+
+      logger.info(`private key: ${privateKey}`);
+
+      assertStringIncludes(logOutput[0], "[redacted sensitive log message]");
+      assertEquals(logOutput[0].includes(privateKey), false);
+    });
+
+    it("should redact queued progress logs before flushing", () => {
+      const logger = createLogger("test");
+      const bunkerSecret = "nbunksec1" + "q".repeat(24);
+
+      setProgressMode(true);
+      logger.warn(`bunker secret: ${bunkerSecret}`);
+
+      assertEquals(logOutput.length, 0);
+
+      setProgressMode(false);
+      flushQueuedLogs();
+
+      assertStringIncludes(logOutput[0], "[redacted sensitive log message]");
+      assertEquals(logOutput[0].includes(bunkerSecret), false);
+    });
   });
 
   describe("shouldShowLog", () => {

--- a/tests/unit/output_helpers_test.ts
+++ b/tests/unit/output_helpers_test.ts
@@ -1,6 +1,6 @@
-import { assertEquals, assertExists, type assertMatch } from "@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
-import { restore, stub } from "@std/testing/mock";
+import { restore, type Stub, stub } from "@std/testing/mock";
 import {
   displayColorfulHeader,
   displayUploadConfigTable,
@@ -15,8 +15,30 @@ import {
   getUploadSections,
 } from "../../src/ui/output-helpers.ts";
 
+function stripAnsiCodes(output: string): string {
+  const escape = String.fromCharCode(27);
+  return output.replace(new RegExp(`${escape}\\[[0-9;]*m`, "g"), "");
+}
+
+function exactHostTokens(output: string): Set<string> {
+  return new Set(stripAnsiCodes(output).split(/[^A-Za-z0-9.-]+/).filter(Boolean));
+}
+
+function urlOrigins(output: string): Set<string> {
+  const origins = new Set<string>();
+  for (const token of stripAnsiCodes(output).split(/\s+/)) {
+    const candidate = token.replace(/^[^\w]+|[^\w./:-]+$/g, "");
+    try {
+      origins.add(new URL(candidate).origin);
+    } catch {
+      // Non-URL token.
+    }
+  }
+  return origins;
+}
+
 describe("Output Helpers - comprehensive branch coverage", () => {
-  let mathRandomStub: any;
+  let mathRandomStub: Stub;
 
   beforeEach(() => {
     // Mock Math.random for consistent testing
@@ -119,8 +141,9 @@ describe("Output Helpers - comprehensive branch coverage", () => {
       const content = result.join(" ");
       assertEquals(content.includes("Upload Configuration"), true);
       assertEquals(content.includes("npub1test123"), true);
-      assertEquals(content.includes("relay1.com"), true);
-      assertEquals(content.includes("server1.com"), true);
+      const origins = urlOrigins(content);
+      assertEquals(origins.has("wss://relay1.com"), true);
+      assertEquals(origins.has("https://server1.com"), true);
     });
 
     it("should handle minimal configuration", () => {
@@ -280,7 +303,7 @@ describe("Output Helpers - comprehensive branch coverage", () => {
       assertExists(result);
       assertEquals(typeof result, "string");
       assertEquals(result.includes("✓"), true);
-      assertEquals(result.includes("server.com"), true);
+      assertEquals(exactHostTokens(result).has("server.com"), true);
       assertEquals(result.includes("5/5"), true);
       assertEquals(result.includes("100%"), true);
     });

--- a/tests/unit/put_command_test.ts
+++ b/tests/unit/put_command_test.ts
@@ -5,6 +5,19 @@ import { assertEquals } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import { formatPutSuccessOutput, resolvePutRemotePath } from "../../src/commands/put.ts";
 
+function urlOrigins(lines: readonly string[]): Set<string> {
+  const origins = new Set<string>();
+  for (const token of lines.join(" ").split(/\s+/)) {
+    const candidate = token.replace(/^[^\w]+|[^\w./:-]+$/g, "");
+    try {
+      origins.add(new URL(candidate).origin);
+    } catch {
+      // Non-URL token.
+    }
+  }
+  return origins;
+}
+
 describe("resolvePutRemotePath", () => {
   it("treats extensionless remote paths as directories", () => {
     assertEquals(resolvePutRemotePath("./assets/logo.svg", "/img"), "/img/logo.svg");
@@ -32,7 +45,8 @@ describe("formatPutSuccessOutput", () => {
 
     assertEquals(lines.some((line) => line.includes("abc123")), true);
     assertEquals(lines.some((line) => line.includes("event123")), true);
-    assertEquals(lines.some((line) => line.includes("https://b1.example")), true);
-    assertEquals(lines.some((line) => line.includes("wss://r1.example")), true);
+    const origins = urlOrigins(lines);
+    assertEquals(origins.has("https://b1.example"), true);
+    assertEquals(origins.has("wss://r1.example"), true);
   });
 });

--- a/tests/unit/ui_progress_test.ts
+++ b/tests/unit/ui_progress_test.ts
@@ -24,6 +24,10 @@ function stripAnsiCodes(output: string): string {
   return output.replace(new RegExp(`${escape}\\[[0-9;]*m`, "g"), "");
 }
 
+function exactHostTokens(output: string): Set<string> {
+  return new Set(stripAnsiCodes(output).split(/[^A-Za-z0-9.-]+/).filter(Boolean));
+}
+
 function extractFirstBar(output: string): string {
   const match = stripAnsiCodes(output).match(/\[([█░]+)\]/);
   assertExists(match);
@@ -1013,8 +1017,9 @@ Deno.test("UI Progress - ProgressRenderer server bar rendering", async (t) => {
       allOutput += new TextDecoder().decode(call.args[0]);
     }
     // server1 should appear, server2 should not (no data for it)
-    assertStringIncludes(allOutput, "server1.com");
-    assertEquals(allOutput.includes("server2.com"), false);
+    const hosts = exactHostTokens(allOutput);
+    assertEquals(hosts.has("server1.com"), true);
+    assertEquals(hosts.has("server2.com"), false);
 
     consoleSizeStub.restore();
     stdoutStub.restore();

--- a/tests/unit/upload_existence_test.ts
+++ b/tests/unit/upload_existence_test.ts
@@ -287,7 +287,9 @@ describe({
     ): Promise<Response> => {
       const urlStr = url.toString();
       const method = options?.method || "GET";
-      const server = urlStr.startsWith(slowServer) ? slowServer : fastServer;
+      const server = new URL(urlStr).origin === new URL(slowServer).origin
+        ? slowServer
+        : fastServer;
       const hash = urlStr.slice(urlStr.lastIndexOf("/") + 1);
       const serverBlobs = storedBlobs.get(server);
 

--- a/tests/unit/utils_expanded_test.ts
+++ b/tests/unit/utils_expanded_test.ts
@@ -11,6 +11,10 @@ import {
   truncateString,
 } from "../../src/lib/utils.ts";
 
+function relayHosts(relays: readonly string[]): Set<string> {
+  return new Set(relays.map((relay) => new URL(relay).hostname));
+}
+
 function makeEvent(tags: string[][]): NostrEvent {
   return {
     id: "test",
@@ -95,21 +99,23 @@ describe("parseRelayInput", () => {
     // relaySet from applesauce may normalize URLs (e.g. add trailing slash)
     assertEquals(Array.isArray(result), true);
     assertEquals(result.length >= 1, true);
-    assertEquals(result.some((r) => r.includes("relay1.example.com")), true);
+    assertEquals(relayHosts(result).has("relay1.example.com"), true);
   });
 
   it("splits comma-separated relays and trims whitespace", () => {
     const result = parseRelayInput("wss://r1.com, wss://r2.com");
     assertEquals(result.length >= 2, true);
-    assertEquals(result.some((r) => r.includes("r1.com")), true);
-    assertEquals(result.some((r) => r.includes("r2.com")), true);
+    const hosts = relayHosts(result);
+    assertEquals(hosts.has("r1.com"), true);
+    assertEquals(hosts.has("r2.com"), true);
   });
 
   it("filters empty segments from double-comma input", () => {
     const result = parseRelayInput("wss://r1.com,,wss://r2.com");
     assertEquals(result.length >= 2, true);
-    assertEquals(result.some((r) => r.includes("r1.com")), true);
-    assertEquals(result.some((r) => r.includes("r2.com")), true);
+    const hosts = relayHosts(result);
+    assertEquals(hosts.has("r1.com"), true);
+    assertEquals(hosts.has("r2.com"), true);
   });
 });
 
@@ -151,7 +157,7 @@ describe("detectSourceUrl", () => {
   });
 
   it("returns undefined when git command fails", async () => {
-    const commandStub = stub(Deno, "Command" as any, () => ({
+    const commandStub = stub(Deno, "Command", () => ({
       output: () => Promise.resolve({ success: false, stdout: new Uint8Array() }),
     }));
     try {
@@ -164,7 +170,7 @@ describe("detectSourceUrl", () => {
 
   it("returns HTTPS URL from git remote (strips .git suffix)", async () => {
     const encoder = new TextEncoder();
-    const commandStub = stub(Deno, "Command" as any, () => ({
+    const commandStub = stub(Deno, "Command", () => ({
       output: () =>
         Promise.resolve({
           success: true,
@@ -181,7 +187,7 @@ describe("detectSourceUrl", () => {
 
   it("converts SSH remote to HTTPS", async () => {
     const encoder = new TextEncoder();
-    const commandStub = stub(Deno, "Command" as any, () => ({
+    const commandStub = stub(Deno, "Command", () => ({
       output: () =>
         Promise.resolve({
           success: true,
@@ -197,7 +203,7 @@ describe("detectSourceUrl", () => {
   });
 
   it("returns undefined when git remote output is empty", async () => {
-    const commandStub = stub(Deno, "Command" as any, () => ({
+    const commandStub = stub(Deno, "Command", () => ({
       output: () =>
         Promise.resolve({
           success: true,
@@ -213,7 +219,7 @@ describe("detectSourceUrl", () => {
   });
 
   it("returns undefined when Deno.Command throws", async () => {
-    const commandStub = stub(Deno, "Command" as any, () => {
+    const commandStub = stub(Deno, "Command", () => {
       throw new Error("Command not found");
     });
     try {
@@ -231,7 +237,7 @@ describe("truncateString", () => {
   });
 
   it("returns empty string for falsy input (undefined)", () => {
-    assertEquals(truncateString(undefined as any), "");
+    assertEquals(truncateString(undefined as unknown as string), "");
   });
 
   it("returns original string when shorter than prefix+suffix+3", () => {


### PR DESCRIPTION
## Summary
- add explicit workflow token permissions for the workflows flagged by CodeQL
- stop logging secret-derived signer initialization details and redact secret-shaped logger messages before console/file/queued output
- replace URL substring test assertions with parsed URL origin checks or exact host-token checks

## Verification
- deno test --allow-all --no-check tests/unit/constants_test.ts tests/unit/logger_test.ts tests/unit/output_helpers_test.ts tests/unit/put_command_test.ts tests/unit/ui_progress_test.ts tests/unit/upload_existence_test.ts tests/unit/utils_expanded_test.ts
- deno lint src/commands/deploy.ts src/lib/auth/signer-factory.ts src/lib/logger.ts tests/unit/constants_test.ts tests/unit/logger_test.ts tests/unit/output_helpers_test.ts tests/unit/put_command_test.ts tests/unit/ui_progress_test.ts tests/unit/upload_existence_test.ts tests/unit/utils_expanded_test.ts
- deno fmt --check .github/workflows/docs.yml .github/workflows/release-simple.yml .github/workflows/release.yml .github/workflows/test-release.yml src/commands/deploy.ts src/lib/auth/signer-factory.ts src/lib/logger.ts tests/unit/constants_test.ts tests/unit/logger_test.ts tests/unit/output_helpers_test.ts tests/unit/put_command_test.ts tests/unit/ui_progress_test.ts tests/unit/upload_existence_test.ts tests/unit/utils_expanded_test.ts
- deno task test

## Notes
- local CodeQL CLI is not installed, so GitHub CodeQL is the final scanner proof.