### PR TITLE
Let nsite deploy fallback credential run after primary timeout

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,6 +78,7 @@ jobs:
       - name: deploy nsite 1
         uses: sandwichfarm/nsite-action@v0.5.1
         id: nsite_deploy
+        continue-on-error: true
         timeout-minutes: 15
         with:
           nbunksec: ${{ secrets.NBUNK_SECRET }}
@@ -101,6 +102,7 @@ jobs:
       - name: deploy nsite 2
         uses: sandwichfarm/nsite-action@v0.5.1
         id: nsite_deploy2
+        continue-on-error: true
         timeout-minutes: 15
         with:
           nbunksec: ${{ secrets.NBUNK_SECRET_MAINTAINER }}
@@ -121,3 +123,14 @@ jobs:
           publish_server_list: "false"
           publish_relay_list: "false"
           publish_profile: "false"
+
+      - name: Verify nsite deploy
+        if: always() && (steps.nsite_deploy.outcome != 'skipped' || steps.nsite_deploy2.outcome != 'skipped')
+        run: |
+          echo "deploy nsite 1 outcome: ${{ steps.nsite_deploy.outcome }}"
+          echo "deploy nsite 2 outcome: ${{ steps.nsite_deploy2.outcome }}"
+
+          if [[ "${{ steps.nsite_deploy.outcome }}" != "success" && "${{ steps.nsite_deploy2.outcome }}" != "success" ]]; then
+            echo "::error::Both nsite deploy attempts failed."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- keep both docs workflow nsite publish attempts independent
- add a final verifier that fails only if both nsite deploy attempts fail
- preserves failure signal for a complete nsite publishing outage while allowing the maintainer credential path to run after the primary NBUNK_SECRET bunker timeout

## Root cause evidence
- Run https://github.com/sandwichfarm/nsyte/actions/runs/29090096683 failed in `deploy nsite 1` on `main` at `d04e08548415b2f0310c257659212cd22abf2003`.
- The nsyte command timed out establishing the NIP-46 bunker session from `NBUNK_SECRET` after 30 seconds, so `deploy nsite 2` was skipped.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); puts "yaml ok"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs.yml`\n- `deno task site:build`\n\n## Remaining risk\n- This cannot prove `NBUNK_SECRET_MAINTAINER` works locally because GitHub Actions secrets are unavailable outside Actions. If both bunker credentials are offline or stale, the new verifier will still fail the job.