### PR TITLE
Reduce docs Bunny deploy concurrency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
           storage-endpoint: "https://storage.bunnycdn.com"
           storage-zone-name: "nsyte"
           storage-zone-password: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
-          concurrency: "50"
+          concurrency: "10"
           enable-delete-action: true
           enable-purge-pull-zone: true
           pull-zone-id: ${{ secrets.BUNNY_PULLZONE_ID }}


### PR DESCRIPTION
## Summary
- lower `R-J-dev/bunny-deploy` concurrency from `50` to `10` in `docs.yml`
- keep Bunny upload, delete, and purge semantics required; this does not make primary site deploy best-effort

## Root cause evidence
- Post-merge run https://github.com/sandwichfarm/nsyte/actions/runs/29091463361 failed in `Deploy to Bunny` before nsite deploy steps ran.
- The Bunny action retried multiple files until retry #4, then failed with `TimeoutError: Timeout awaiting request for 5000ms`.
- `R-J-dev/bunny-deploy@v2.0.3` exposes a `concurrency` input but no request-timeout input.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); puts "yaml ok"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs.yml`\n- `git diff --check`\n\n## Remaining risk\n- Live Bunny upload cannot be proven until this lands on `main`, because credentials are only available inside GitHub Actions. If timeouts persist, the next reduction should be more aggressive or the workflow should move to an uploader with configurable request timeouts.