### PR TITLE
Use retryable Bunny storage uploads for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,18 +45,11 @@ jobs:
           # Remove executable permissions from remaining files
           chmod 644 dist/install.txt dist/get/install.sh dist/get/install.txt || true
       - name: Deploy to Bunny
-        uses: R-J-dev/bunny-deploy@v2.0.3
-        with:
-          access-key: ${{ secrets.BUNNY_ACCESS_KEY }}
-          directory-to-upload: "./dist"
-          storage-endpoint: "https://storage.bunnycdn.com"
-          storage-zone-name: "nsyte"
-          storage-zone-password: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
-          concurrency: "10"
-          enable-delete-action: true
-          enable-purge-pull-zone: true
-          pull-zone-id: ${{ secrets.BUNNY_PULLZONE_ID }}
-          replication-timeout: "15000"
+        env:
+          BUNNY_STORAGE_ENDPOINT: "https://storage.bunnycdn.com"
+          BUNNY_STORAGE_PASSWORD: ${{ secrets.BUNNY_STORAGE_PASSWORD }}
+          BUNNY_STORAGE_ZONE: "nsyte"
+        run: ./scripts/deploy-bunny-storage.sh ./dist
 
       # - name: Deploy to Bunny.net CDN
       #   uses: ayeressian/bunnycdn-storage-deploy@v2.2.2

--- a/scripts/deploy-bunny-storage.sh
+++ b/scripts/deploy-bunny-storage.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 directory="${1:-dist}"
+directory="${directory%/}"
 endpoint="${BUNNY_STORAGE_ENDPOINT:-https://storage.bunnycdn.com}"
 zone="${BUNNY_STORAGE_ZONE:-nsyte}"
 

--- a/scripts/deploy-bunny-storage.sh
+++ b/scripts/deploy-bunny-storage.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+directory="${1:-dist}"
+endpoint="${BUNNY_STORAGE_ENDPOINT:-https://storage.bunnycdn.com}"
+zone="${BUNNY_STORAGE_ZONE:-nsyte}"
+
+: "${BUNNY_STORAGE_PASSWORD:?BUNNY_STORAGE_PASSWORD is required}"
+
+if [[ ! -d "$directory" ]]; then
+  echo "Directory not found: $directory" >&2
+  exit 1
+fi
+
+endpoint="${endpoint%/}"
+
+files=()
+while IFS= read -r -d "" file; do
+  files+=("$file")
+done < <(find "$directory" -type f -print0 | sort -z)
+
+if (( ${#files[@]} == 0 )); then
+  echo "No files found in $directory" >&2
+  exit 1
+fi
+
+echo "Uploading ${#files[@]} files from $directory to Bunny storage zone $zone"
+
+upload_file() {
+  local file="$1"
+  local remote_path="${file#"$directory"/}"
+  local url="$endpoint/$zone/$remote_path"
+
+  echo "Uploading $remote_path"
+
+  if [[ "${DRY_RUN:-}" == "1" ]]; then
+    return 0
+  fi
+
+  curl --fail --show-error --silent \
+    --connect-timeout 20 \
+    --max-time 120 \
+    --retry 8 \
+    --retry-all-errors \
+    --retry-delay 2 \
+    --retry-max-time 600 \
+    --request PUT \
+    --header "AccessKey: $BUNNY_STORAGE_PASSWORD" \
+    --header "Content-Type: application/octet-stream" \
+    --data-binary "@$file" \
+    "$url" >/dev/null
+}
+
+for file in "${files[@]}"; do
+  upload_file "$file"
+done
+
+echo "Bunny storage upload complete"


### PR DESCRIPTION
## Summary
- replace `R-J-dev/bunny-deploy@v2.0.3` in `docs.yml` with a repo-owned `curl` uploader
- keep Bunny deploy required; failures still fail the workflow
- keep the existing Bunny CDN purge step after upload

## Root cause evidence
- Run https://github.com/sandwichfarm/nsyte/actions/runs/29092943547 failed in `Deploy to Bunny` after PR #147 reduced action concurrency to `10`.
- The action still failed with `TimeoutError: Timeout awaiting request for 5000ms`, before nsite deploy steps could run.
- `R-J-dev/bunny-deploy@v2.0.3` hardcodes `timeout.request: 5000` in its got client and has no request-timeout input.

## Verification
- `bash -n scripts/deploy-bunny-storage.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docs.yml"); puts "yaml ok"'`\n- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs.yml`\n- `deno task site:build`\n- `DRY_RUN=1 BUNNY_STORAGE_PASSWORD=dummy BUNNY_STORAGE_ENDPOINT=https://storage.bunnycdn.com BUNNY_STORAGE_ZONE=nsyte ./scripts/deploy-bunny-storage.sh ./dist`\n- `git diff --check`\n\n## Notes\n- The new uploader uploads every built file and relies on the existing CDN purge. It does not delete stale remote assets; that is preferable to keeping the current fixed-timeout action in the critical deploy path.\n- Live Bunny upload proof requires this to run on `main` because the Bunny credentials are only available in GitHub Actions.