### PR TITLE
Treat nsite mirror publish as best-effort

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -117,13 +117,21 @@ jobs:
           publish_relay_list: "false"
           publish_profile: "false"
 
-      - name: Verify nsite deploy
-        if: always() && (steps.nsite_deploy.outcome != 'skipped' || steps.nsite_deploy2.outcome != 'skipped')
+      - name: Summarize nsite deploy
+        if: ${{ !cancelled() && (steps.nsite_deploy.outcome != 'skipped' || steps.nsite_deploy2.outcome != 'skipped') }}
         run: |
-          echo "deploy nsite 1 outcome: ${{ steps.nsite_deploy.outcome }}"
-          echo "deploy nsite 2 outcome: ${{ steps.nsite_deploy2.outcome }}"
+          nsite1="${{ steps.nsite_deploy.outcome }}"
+          nsite2="${{ steps.nsite_deploy2.outcome }}"
 
-          if [[ "${{ steps.nsite_deploy.outcome }}" != "success" && "${{ steps.nsite_deploy2.outcome }}" != "success" ]]; then
-            echo "::error::Both nsite deploy attempts failed."
-            exit 1
+          echo "deploy nsite 1 outcome: ${nsite1}"
+          echo "deploy nsite 2 outcome: ${nsite2}"
+
+          {
+            echo "### nsite deploy"
+            echo "- deploy nsite 1: ${nsite1}"
+            echo "- deploy nsite 2: ${nsite2}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "${nsite1}" != "success" && "${nsite2}" != "success" ]]; then
+            echo "::warning::Both nsite deploy attempts failed. Bunny deploy already completed; check NBUNK_SECRET and NBUNK_SECRET_MAINTAINER bunker availability."
           fi


### PR DESCRIPTION
## Summary
- keep docs deploy success tied to the required Bunny deploy and CDN purge
- change the nsite post-check into a summary/warning step instead of a hard failure
- preserve both nsite action attempts and record their outcomes in the job summary

## Live failure evidence
Run https://github.com/sandwichfarm/nsyte/actions/runs/29094064786 reached a successful Bunny deploy and CDN purge, then failed only in the verifier because both nsite attempts reported outcome=failure.

Both nsite attempts are backed by nbunksec secrets, and the logs show NIP-46 bunker timeouts / unavailable configured bunker state. That secret or bunker availability cannot be repaired from workflow code, so this keeps the mirror publish visible without blocking the primary docs deploy.

## Validation
- ruby YAML load .github/workflows/docs.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/docs.yml
- git diff --check
- bash -n scripts/deploy-bunny-storage.sh
- deno task site:build