### PR TITLE
fix: safely support absolute deploy paths

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -1,7 +1,7 @@
 import { colors } from "@cliffy/ansi/colors";
 import { Confirm, Input, Select } from "@cliffy/prompt";
 import { hexToBytes } from "@noble/hashes/utils";
-import { join } from "@std/path";
+import { dirname, isAbsolute, join, resolve } from "@std/path";
 import { getOutboxes, naddrEncode, npubEncode, relaySet } from "applesauce-core/helpers";
 import { loadAsyncMap } from "applesauce-loaders/helpers";
 import { type ISigner, NostrConnectSigner } from "applesauce-signers";
@@ -125,6 +125,94 @@ interface DeploymentState {
   resolvedServers: string[];
   targetDir: string;
   fallbackFileEntry: FileEntry | null;
+}
+
+interface AbsoluteDeploySafetyOptions {
+  config?: string | false;
+  nonInteractive: boolean;
+}
+
+interface AbsoluteDeploySafetyDependencies {
+  cwd?: () => string;
+  realPath?: (path: string) => Promise<string>;
+  readConfig?: (path: string) => ProjectConfig | null;
+  scanFiles?: (path: string) => Promise<{ includedFiles: FileEntry[] }>;
+  confirm?: (message: string) => Promise<boolean>;
+}
+
+export interface DeployTargetResolution {
+  targetDir: string;
+  isAbsolute: boolean;
+  fileCount?: number;
+}
+
+/**
+ * Resolve a deploy target and apply the extra safety ceremony required for
+ * absolute paths. Relative paths deliberately take the established path with
+ * no additional filesystem access or prompts.
+ */
+export async function resolveDeployTarget(
+  fileOrFolder: string,
+  options: AbsoluteDeploySafetyOptions,
+  dependencies: AbsoluteDeploySafetyDependencies = {},
+): Promise<DeployTargetResolution> {
+  const cwd = (dependencies.cwd ?? Deno.cwd)();
+
+  if (!isAbsolute(fileOrFolder)) {
+    return {
+      targetDir: join(cwd, fileOrFolder),
+      isAbsolute: false,
+    };
+  }
+
+  const requestedTarget = resolve(fileOrFolder);
+  if (dirname(requestedTarget) === requestedTarget) {
+    throw new Error("Refusing to deploy the filesystem root directory.");
+  }
+
+  if (typeof options.config !== "string" || options.config.trim().length === 0) {
+    throw new Error(
+      "Absolute deploy paths require an explicit nsite config. Provide one with -c/--config <path>.",
+    );
+  }
+
+  const readConfig = dependencies.readConfig ?? readProjectFile;
+  const config = readConfig(options.config);
+  if (!config) {
+    throw new Error(
+      `No valid nsite config found at ${options.config}. Absolute deploy paths require an existing valid config.`,
+    );
+  }
+
+  const realPath = dependencies.realPath ?? Deno.realPath;
+  const targetDir = await realPath(requestedTarget);
+  if (dirname(targetDir) === targetDir) {
+    throw new Error("Refusing to deploy the filesystem root directory.");
+  }
+
+  const scanFiles = dependencies.scanFiles ?? getLocalFiles;
+  const { includedFiles } = await scanFiles(targetDir);
+  const fileCount = includedFiles.length;
+  const fileLabel = fileCount === 1 ? "file" : "files";
+  const warning =
+    `Absolute deploy target: ${targetDir}\n${fileCount} ${fileLabel} will be considered for public deployment. This may replace the site's published file manifest.`;
+
+  if (options.nonInteractive) {
+    throw new Error(
+      `${warning}\nAbsolute deploy paths require interactive confirmation; remove -i/--non-interactive to continue.`,
+    );
+  }
+
+  const confirm = dependencies.confirm ?? ((message: string) =>
+    Confirm.prompt({
+      message,
+      default: false,
+    }));
+  if (!await confirm(warning)) {
+    throw new Error("Absolute path deploy cancelled.");
+  }
+
+  return { targetDir, isAbsolute: true, fileCount };
 }
 
 export interface FilePreparationResult {
@@ -307,7 +395,7 @@ export function registerDeployCommand(): void {
  * - Publishing metadata
  * - Displaying results
  *
- * @param fileOrFolder - Path to the file or folder to deploy, relative to current working directory
+ * @param fileOrFolder - Absolute or current-working-directory-relative path to deploy
  * @param options - Deploy command options
  */
 export async function deployCommand(
@@ -323,6 +411,8 @@ export async function deployCommand(
   const messageCollector = new MessageCollector(displayManager.isInteractive());
 
   try {
+    const target = await resolveDeployTarget(fileOrFolder, options);
+
     // Prompt for the secret at runtime if requested, before resolving auth context
     const promptConfigPath = typeof options.config === "string" ? options.config : undefined;
     const configuredBunkerPubkey = options.config === false
@@ -330,8 +420,7 @@ export async function deployCommand(
       : readProjectFile(promptConfigPath)?.bunkerPubkey;
     await resolvePromptSec(options, configuredBunkerPubkey);
 
-    const currentWorkingDir = Deno.cwd();
-    const targetDir = join(currentWorkingDir, fileOrFolder);
+    const targetDir = target.targetDir;
     const context = await resolveContext(options);
     const configPath = typeof options.config === "string" ? options.config : undefined;
 

--- a/tests/unit/deploy_absolute_path_test.ts
+++ b/tests/unit/deploy_absolute_path_test.ts
@@ -1,0 +1,184 @@
+// deno-lint-ignore-file require-await
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import { resolveDeployTarget } from "../../src/commands/deploy.ts";
+
+const validConfig = {
+  relays: ["wss://relay.example.com"],
+  servers: ["https://blossom.example.com"],
+};
+
+Deno.test("resolveDeployTarget preserves relative-path behavior", async () => {
+  let dependencyCalled = false;
+  const result = await resolveDeployTarget("dist", {
+    nonInteractive: true,
+  }, {
+    cwd: () => "/project",
+    realPath: async (path) => {
+      dependencyCalled = true;
+      return path;
+    },
+    confirm: async () => {
+      dependencyCalled = true;
+      return false;
+    },
+  });
+
+  assertEquals(result, {
+    targetDir: join("/project", "dist"),
+    isAbsolute: false,
+  });
+  assertEquals(dependencyCalled, false);
+});
+
+Deno.test("resolveDeployTarget rejects the filesystem root before config lookup", async () => {
+  let configRead = false;
+
+  await assertRejects(
+    () =>
+      resolveDeployTarget("/", { nonInteractive: false }, {
+        readConfig: () => {
+          configRead = true;
+          return validConfig;
+        },
+      }),
+    Error,
+    "Refusing to deploy the filesystem root directory",
+  );
+  assertEquals(configRead, false);
+});
+
+Deno.test("resolveDeployTarget rejects a symlink resolving to the filesystem root", async () => {
+  await assertRejects(
+    () =>
+      resolveDeployTarget("/safe-looking-link", {
+        config: "/project/.nsite/config.json",
+        nonInteractive: false,
+      }, {
+        readConfig: () => validConfig,
+        realPath: async () => "/",
+      }),
+    Error,
+    "Refusing to deploy the filesystem root directory",
+  );
+});
+
+Deno.test("resolveDeployTarget requires an explicit config for absolute paths", async () => {
+  for (const config of [undefined, false, ""] as const) {
+    await assertRejects(
+      () =>
+        resolveDeployTarget("/tmp/site", { config, nonInteractive: false }, {
+          realPath: async (path) => path,
+        }),
+      Error,
+      "require an explicit nsite config",
+    );
+  }
+});
+
+Deno.test("resolveDeployTarget requires the explicit config to exist", async () => {
+  await assertRejects(
+    () =>
+      resolveDeployTarget("/tmp/site", {
+        config: "/tmp/missing-config.json",
+        nonInteractive: false,
+      }, {
+        readConfig: () => null,
+      }),
+    Error,
+    "No valid nsite config found",
+  );
+});
+
+Deno.test("resolveDeployTarget reports file count and requires default-safe confirmation", async () => {
+  let promptMessage = "";
+  const result = await resolveDeployTarget("/tmp/site", {
+    config: "/project/.nsite/config.json",
+    nonInteractive: false,
+  }, {
+    readConfig: () => validConfig,
+    realPath: async () => "/private/tmp/site",
+    scanFiles: async () => ({
+      includedFiles: [
+        { path: "/index.html", size: 1, sha256: "a" },
+        { path: "/app.js", size: 1, sha256: "b" },
+      ],
+    }),
+    confirm: async (message) => {
+      promptMessage = message;
+      return true;
+    },
+  });
+
+  assertEquals(result, {
+    targetDir: "/private/tmp/site",
+    isAbsolute: true,
+    fileCount: 2,
+  });
+  assertStringIncludes(promptMessage, "Absolute deploy target: /private/tmp/site");
+  assertStringIncludes(promptMessage, "2 files will be considered for public deployment");
+  assertStringIncludes(promptMessage, "replace the site's published file manifest");
+});
+
+Deno.test("resolveDeployTarget cancels when confirmation is declined", async () => {
+  await assertRejects(
+    () =>
+      resolveDeployTarget("/tmp/site", {
+        config: "/project/.nsite/config.json",
+        nonInteractive: false,
+      }, {
+        readConfig: () => validConfig,
+        realPath: async (path) => path,
+        scanFiles: async () => ({ includedFiles: [] }),
+        confirm: async () => false,
+      }),
+    Error,
+    "Absolute path deploy cancelled",
+  );
+});
+
+Deno.test("resolveDeployTarget does not bypass confirmation in non-interactive mode", async () => {
+  let prompted = false;
+  await assertRejects(
+    () =>
+      resolveDeployTarget("/tmp/site", {
+        config: "/project/.nsite/config.json",
+        nonInteractive: true,
+      }, {
+        readConfig: () => validConfig,
+        realPath: async (path) => path,
+        scanFiles: async () => ({ includedFiles: [{ path: "/index.html", sha256: "a" }] }),
+        confirm: async () => {
+          prompted = true;
+          return true;
+        },
+      }),
+    Error,
+    "1 file will be considered for public deployment",
+  );
+  assertEquals(prompted, false);
+});
+
+Deno.test("resolveDeployTarget uses schema validation for the explicit config", async () => {
+  const tempDir = await Deno.makeTempDir();
+  try {
+    const siteDir = join(tempDir, "site");
+    const configPath = join(tempDir, "config.json");
+    await Deno.mkdir(siteDir);
+    await Deno.writeTextFile(configPath, "{}");
+
+    await assertRejects(
+      () =>
+        resolveDeployTarget(siteDir, {
+          config: configPath,
+          nonInteractive: false,
+        }, {
+          confirm: async () => true,
+        }),
+      Error,
+      "Invalid configuration format",
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- resolve absolute deploy targets correctly while leaving relative target resolution unchanged
- require an explicit, existing, schema-valid `-c/--config` before any auth or network work
- reject filesystem roots, including normalized aliases and symlinks resolving to a root
- scan the target first and show its resolved path and deployable file count in a default-No confirmation
- reject non-interactive absolute deploys so the safety confirmation cannot be bypassed

## Safety notes

The preflight happens before secret prompting, signer initialization, relay discovery, uploads, or publishing. This protects against accidentally publishing an unrelated absolute directory. Symlink resolution prevents a seemingly safe path from resolving to `/`. Relative paths take the existing branch with no new filesystem calls or ceremony.

## Tests

- `deno check src/commands/deploy.ts tests/unit/deploy_absolute_path_test.ts`
- `deno lint src/commands/deploy.ts tests/unit/deploy_absolute_path_test.ts`
- `deno test --allow-all --no-check tests/unit/deploy_absolute_path_test.ts tests/unit/upload_command_test.ts` (14 passed, 18 steps)
- `deno publish --dry-run`
- full suite: 224 passed; 4 failing steps are pre-existing and reproduce on untouched `origin/main` (macOS temp-path assumptions in `dry-run/writer_test.ts`, existing ignore-pattern expectations in `files_test.ts`)

Repository-wide `deno fmt --check` and `deno lint` also have pre-existing failures on untouched main; both changed files pass their scoped checks.