### PR TITLE
Avoid Git permission prompt after deploy

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -96,6 +96,13 @@ export async function detectSourceUrl(configSource?: string): Promise<string | u
   if (configSource) return configSource;
 
   try {
+    // Source detection is optional, so do not trigger an interactive permission
+    // prompt when nsyte was started without --allow-run=git. In particular, this
+    // runs after deploy progress output and Deno's prompt can leave the terminal
+    // in raw mode if the process is interrupted.
+    const runPermission = await Deno.permissions.query({ name: "run", command: "git" });
+    if (runPermission.state !== "granted") return undefined;
+
     const command = new Deno.Command("git", {
       args: ["remote", "get-url", "origin"],
       stdout: "piped",

--- a/tests/unit/utils_expanded_test.ts
+++ b/tests/unit/utils_expanded_test.ts
@@ -156,6 +156,28 @@ describe("detectSourceUrl", () => {
     assertEquals(result, "https://example.com");
   });
 
+  it("skips git without prompting when run permission is not granted", async () => {
+    const permissionStub = stub(
+      Deno.permissions,
+      "query",
+      () => Promise.resolve({ state: "prompt" } as PermissionStatus),
+    );
+    let commandCreated = false;
+    const commandStub = stub(Deno, "Command", () => {
+      commandCreated = true;
+      throw new Error("git should not run");
+    });
+
+    try {
+      const result = await detectSourceUrl();
+      assertEquals(result, undefined);
+      assertEquals(commandCreated, false);
+    } finally {
+      permissionStub.restore();
+      commandStub.restore();
+    }
+  });
+
   it("returns undefined when git command fails", async () => {
     const commandStub = stub(Deno, "Command", () => ({
       output: () => Promise.resolve({ success: false, stdout: new Uint8Array() }),


### PR DESCRIPTION
## Summary

- query the existing `run` permission before optional Git source detection
- skip source auto-detection when `git` execution was not pre-authorized
- add a regression test proving no Git command is created for a prompt permission state

## Why

Source URL auto-detection runs after upload while publishing the site manifest. When nsyte is launched without `--allow-run`, Deno opens an interactive permission prompt for `git`; interrupting there can leave the terminal in raw mode and unusable. Since source detection is optional, it should never request new privileges during deploy.

## Verification

- `deno test --allow-all --no-check tests/unit/utils_expanded_test.ts`
- `deno lint src/lib/utils.ts tests/unit/utils_expanded_test.ts`
- `deno check src/cli.ts`
- real PTY run with `--allow-read=. --allow-env` and no `--allow-run` exits without a prompt

Full `deno task test:unit`: 186 passed, 3 failed (4 steps), 9 ignored. The failures are existing environment-sensitive assertions: two hard-code `/tmp` on macOS, and two file-ignore assertions fail when the full suite runs together.