### PR TITLE
Update nostr-tools so NIP-44 accepts payloads over 64 KiB

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -49,7 +49,8 @@
     "npm:applesauce-core@^5.2.0": "5.2.0",
     "npm:applesauce-loaders@^5.1.0": "5.1.0",
     "npm:applesauce-relay@^5.2.0": "5.2.0",
-    "npm:applesauce-signers@^5.2.0": "5.2.0_@capacitor+core@7.6.1",
+    "npm:applesauce-signers@^5.2.0": "5.2.0",
+    "npm:nostr-tools@*": "2.24.1",
     "npm:rxjs@^7.8.2": "7.8.2"
   },
   "jsr": {
@@ -222,20 +223,8 @@
         "tslib"
       ]
     },
-    "@noble/ciphers@0.5.3": {
-      "integrity": "sha512-B0+6IIHiqEs3BPMT0hcRmHvEj2QHOLu+uwt+tqDDeVd0oyVzh7BPrDcPjRnV1PV/5LaknXJJQvOuRGR0zQJz+w=="
-    },
-    "@noble/curves@1.1.0": {
-      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
-      "dependencies": [
-        "@noble/hashes@1.3.1"
-      ]
-    },
-    "@noble/curves@1.2.0": {
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dependencies": [
-        "@noble/hashes@1.3.2"
-      ]
+    "@noble/ciphers@2.1.1": {
+      "integrity": "sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw=="
     },
     "@noble/curves@1.9.7": {
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
@@ -243,14 +232,17 @@
         "@noble/hashes@1.8.0"
       ]
     },
-    "@noble/hashes@1.3.1": {
-      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA=="
-    },
-    "@noble/hashes@1.3.2": {
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+    "@noble/curves@2.0.1": {
+      "integrity": "sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==",
+      "dependencies": [
+        "@noble/hashes@2.0.1"
+      ]
     },
     "@noble/hashes@1.8.0": {
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="
+    },
+    "@noble/hashes@2.0.1": {
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="
     },
     "@noble/secp256k1@1.7.2": {
       "integrity": "sha512-/qzwYl5eFLH8OWIecQWM31qld2g1NfjgylK+TNhqtaUKP37Nm+Y+z30Fjhw0Ct8p9yCQEm2N3W/AckdIb3SMcQ=="
@@ -261,13 +253,8 @@
     "@scure/base@1.2.6": {
       "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="
     },
-    "@scure/bip32@1.3.1": {
-      "integrity": "sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==",
-      "dependencies": [
-        "@noble/curves@1.1.0",
-        "@noble/hashes@1.3.2",
-        "@scure/base@1.1.1"
-      ]
+    "@scure/base@2.0.0": {
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w=="
     },
     "@scure/bip32@1.7.0": {
       "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
@@ -277,11 +264,12 @@
         "@scure/base@1.2.6"
       ]
     },
-    "@scure/bip39@1.2.1": {
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+    "@scure/bip32@2.0.1": {
+      "integrity": "sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==",
       "dependencies": [
-        "@noble/hashes@1.3.2",
-        "@scure/base@1.1.1"
+        "@noble/curves@2.0.1",
+        "@noble/hashes@2.0.1",
+        "@scure/base@2.0.0"
       ]
     },
     "@scure/bip39@1.6.0": {
@@ -289,6 +277,13 @@
       "dependencies": [
         "@noble/hashes@1.8.0",
         "@scure/base@1.2.6"
+      ]
+    },
+    "@scure/bip39@2.0.1": {
+      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "dependencies": [
+        "@noble/hashes@2.0.1",
+        "@scure/base@2.0.0"
       ]
     },
     "ajv-formats@3.0.1_ajv@8.17.1": {
@@ -348,7 +343,7 @@
         "rxjs"
       ]
     },
-    "applesauce-signers@5.2.0_@capacitor+core@7.6.1": {
+    "applesauce-signers@5.2.0": {
       "integrity": "sha512-7tN7lNK2XERdrRchG5z4rdpMqOacFdv7rRhiS+DLTdlbqeSf0wD6Kj8M3vSqq5f2pVS2cl5Z4E/m5RpWC4PSxg==",
       "dependencies": [
         "@noble/secp256k1",
@@ -398,15 +393,15 @@
         "@capacitor/core"
       ]
     },
-    "nostr-tools@2.19.4": {
-      "integrity": "sha512-qVLfoTpZegNYRJo5j+Oi6RPu0AwLP6jcvzcB3ySMnIT5DrAGNXfs5HNBspB/2HiGfH3GY+v6yXkTtcKSBQZwSg==",
+    "nostr-tools@2.24.1": {
+      "integrity": "sha512-KdrKjC74n/rr6J3eCSfZj8dcbZFvolHYe4S22SefNZ5YWbhHiB0KL/mmJjEZ0u6B9mZK0YcQtl+WQ46KzwapeQ==",
       "dependencies": [
         "@noble/ciphers",
-        "@noble/curves@1.2.0",
-        "@noble/hashes@1.3.1",
-        "@scure/base@1.1.1",
-        "@scure/bip32@1.3.1",
-        "@scure/bip39@1.2.1",
+        "@noble/curves@2.0.1",
+        "@noble/hashes@2.0.1",
+        "@scure/base@2.0.0",
+        "@scure/bip32@2.0.1",
+        "@scure/bip39@2.0.1",
         "nostr-wasm"
       ]
     },

--- a/tests/unit/nip44_large_payload_test.ts
+++ b/tests/unit/nip44_large_payload_test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "@std/assert";
+import * as nip44 from "npm:nostr-tools/nip44";
+import { generateSecretKey, getPublicKey } from "npm:nostr-tools/pure";
+
+/**
+ * NIP-46 wraps every request to a remote signer in a NIP-44 payload, so the
+ * largest event nsyte can have a bunker sign is bounded by NIP-44's plaintext
+ * limit. NIP-44 v2 raised that to 2^32-1 bytes with a 6-byte extended length
+ * prefix (`[0x00, 0x00][u32]`) for anything >= 65536; before that it was
+ * capped at 65535.
+ *
+ * A site manifest (kind 35128) carries one `path` tag per file, so a site of a
+ * few hundred files clears 64 KiB easily -- a 1117-file site produces a
+ * ~141 KB event. Against an implementation that still enforces the old cap,
+ * every such deploy fails at the last step with "invalid plaintext size: must
+ * be between 1 and 65535 bytes", after the upload has already happened.
+ *
+ * This guards the resolved nostr-tools version rather than code in this repo:
+ * a lockfile that drifts back to a pre-extended-prefix release reintroduces
+ * the failure silently.
+ */
+Deno.test("NIP-44 round-trips payloads larger than the old 65535-byte cap", () => {
+  const conversationKey = nip44.getConversationKey(
+    generateSecretKey(),
+    getPublicKey(generateSecretKey()),
+  );
+
+  // 65535 is the last size the 2-byte u16 prefix covers; 65536 is the first
+  // that needs the extended prefix, and is where the old implementation threw.
+  // 141397 is the size of a real 1117-file manifest.
+  for (const size of [65535, 65536, 141397]) {
+    const plaintext = "a".repeat(size);
+    const decrypted = nip44.decrypt(nip44.encrypt(plaintext, conversationKey), conversationKey);
+    assertEquals(decrypted.length, size, `NIP-44 failed to round-trip ${size} bytes`);
+    assertEquals(decrypted, plaintext);
+  }
+});

--- a/tests/unit/timestamp_exclusion_test.ts
+++ b/tests/unit/timestamp_exclusion_test.ts
@@ -1,7 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { beforeAll, describe, it } from "@std/testing/bdd";
 import { SimpleSigner } from "applesauce-signers";
-import { encodeHex } from "@std/encoding/hex";
 import { createDeleteEvent } from "../../src/lib/nostr.ts";
 
 let signer: SimpleSigner;
@@ -9,7 +8,7 @@ let signer: SimpleSigner;
 beforeAll(async () => {
   const privKeyBytes = new Uint8Array(32);
   crypto.getRandomValues(privKeyBytes);
-  signer = new SimpleSigner(encodeHex(privKeyBytes));
+  signer = new SimpleSigner(privKeyBytes);
   await signer.getPublicKey();
 });
 

--- a/tests/unit/timestamp_propagation_test.ts
+++ b/tests/unit/timestamp_propagation_test.ts
@@ -1,7 +1,6 @@
 import { assertEquals } from "@std/assert";
 import { beforeAll, describe, it } from "@std/testing/bdd";
 import { SimpleSigner } from "applesauce-signers";
-import { encodeHex } from "@std/encoding/hex";
 import {
   createAppHandlerEvent,
   createAppRecommendationEvent,
@@ -21,7 +20,7 @@ let pubkey: string;
 beforeAll(async () => {
   const privKeyBytes = new Uint8Array(32);
   crypto.getRandomValues(privKeyBytes);
-  signer = new SimpleSigner(encodeHex(privKeyBytes));
+  signer = new SimpleSigner(privKeyBytes);
   pubkey = await signer.getPublicKey();
 });
 


### PR DESCRIPTION
## The problem

Deploying a site with more than a few hundred files fails at the very last step, after every blob has already been uploaded:

```
Creating site manifest event with:
  Files: 1117
  Relays: 3
  Servers: 3
✗ Failed to create/publish manifest: invalid plaintext size: must be between 1 and 65535 bytes
[ERROR] deploy: Error creating/publishing site manifest: invalid plaintext size: must be between 1 and 65535 bytes
```

NIP-46 wraps every request to a remote signer in a NIP-44 payload, so the largest event a bunker can sign is bounded by NIP-44's plaintext limit. A site manifest carries one `path` tag per file, so a 1117-file site produces a ~141 KB event — well past the old ceiling.

NIP-44 v2 [no longer has that ceiling](https://github.com/nostr-protocol/nips/blob/master/44.md): `max_plaintext_size` is `4294967295`, with a 6-byte extended length prefix (`[0x00, 0x00][u32]`) for anything `>= 65536`. `nostr-tools` implements this from **2.23.8**, but `deno.lock` pinned **2.19.4**, which still hard-caps at 65535:

```js
// nostr-tools 2.19.4
var maxPlaintextSize = 65535;

// nostr-tools 2.24.1
var maxPlaintextSize = 4294967295;
var extendedPrefixThreshold = 65536;
```

`applesauce-signers` already allows it (`nostr-tools: ^2.10.4`) — only the lockfile held it back.

Deploys signed with a local key were never affected, since nothing is encrypted in that path. That asymmetry is what makes this look like a size limit on manifests rather than a signer issue.

## The change

- `deno.lock`: resolve `nostr-tools` to 2.24.1.
- New test `tests/unit/nip44_large_payload_test.ts`, round-tripping 65535 / 65536 / 141397 bytes. It fails on the old lock with the exact error above and passes on the new one.
- `nostr-tools` 2.24.1 pulls `@noble/curves` 2.x, which no longer accepts a hex string where a `Uint8Array` is expected. Two tests constructed `SimpleSigner` that way and now pass the raw key bytes; `src/` already passed bytes (`hexToBytes(info.local_key)`), so no runtime code changed.

## Verification

```
deno test --allow-all --no-check tests/unit/
ok | 190 passed (1248 steps) | 0 failed | 9 ignored
```

Before this change the same suite was `188 passed | 2 failed`.

Direct comparison of the two versions:

```
nostr-tools 2.19.4                     nostr-tools 2.24.1
  65535  bytes -> ok                     65535  bytes -> ok
  65536  bytes -> FAILED                 65536  bytes -> ok
  141397 bytes -> FAILED                 141397 bytes -> ok
```

One caveat worth naming: this fixes nsyte's side of the exchange. A remote signer whose own NIP-44 implementation predates the extended prefix will still reject a payload above 64 KiB, so a large-site bunker deploy also needs an up-to-date signer.
