### PR TITLE
Let snapshots set their own title and description

### DIFF
--- a/docs/usage/commands/snapshot.md
+++ b/docs/usage/commands/snapshot.md
@@ -27,6 +27,12 @@ nsyte snapshot [options]
   `--sec` (keeps it out of shell history)
 - `-d, --name <name>` — The site identifier for named sites (kind 35128). If not
   provided, snapshots the root site (kind 15128)
+- `--title <title>` — Title for this snapshot. Defaults to the source manifest's
+  title
+- `--no-title` — Omit the title inherited from the source manifest
+- `--description <description>` — Description for this snapshot. Defaults to the
+  source manifest's description
+- `--no-description` — Omit the description inherited from the source manifest
 - `--dry-run` — Preview the snapshot event without signing or publishing it
 - `--dry-run-output <dir>` — Directory to write dry-run event JSON files
 - `--dry-run-show-kinds <kinds>` — Also print events of these kinds to stdout
@@ -57,6 +63,24 @@ Publish a snapshot for a named site, including fallback relays:
 ```bash
 nsyte snapshot -d docs --use-fallback-relays
 ```
+
+Label a snapshot with a release tag, leaving the live site untouched:
+
+```bash
+nsyte snapshot --title "v1.2.3" --description "Release v1.2.3"
+```
+
+## Snapshot Labels
+
+A snapshot inherits its descriptive tags — `title`, `description`, `source`,
+`app`, `server`, `relay` — from the manifest it is taken from. `--title` and
+`--description` set those tags on this snapshot only; the live manifest is never
+rewritten, so there is no need to retitle a site, redeploy, snapshot, and put the
+title back just to label a release. `--no-title` and `--no-description` drop the
+inherited tag instead of replacing it.
+
+The verifiable parts of a snapshot — the aggregate hash and the file set — always
+come from the source manifest and cannot be overridden.
 
 ## See Also
 

--- a/src/commands/snapshot.ts
+++ b/src/commands/snapshot.ts
@@ -27,6 +27,10 @@ interface SnapshotCommandOptions {
   sec?: string;
   promptSec?: boolean;
   name?: string;
+  /** String sets the tag, `false` (via `--no-title`) omits it, undefined inherits. */
+  title?: string | false;
+  /** String sets the tag, `false` (via `--no-description`) omits it, undefined inherits. */
+  description?: string | false;
   dryRun?: boolean;
   dryRunOutput?: string;
   dryRunShowKinds?: string;
@@ -37,6 +41,19 @@ interface SnapshotCommandOptions {
 
 export function formatSnapshotCreatedAt(createdAt: number): string {
   return `${createdAt} (${formatTimestamp(createdAt)})`;
+}
+
+function findTagValue(template: { tags: string[][] }, name: string): string | undefined {
+  return template.tags.find((tag) => tag[0] === name)?.[1];
+}
+
+/**
+ * Maps a CLI descriptive-tag flag onto a snapshot override: `false` (from
+ * `--no-title`/`--no-description`) becomes the empty string, which drops the tag.
+ */
+export function resolveTagOverride(value: string | false | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return value === false ? "" : value;
 }
 
 export function registerSnapshotCommand(): void {
@@ -56,6 +73,20 @@ export function registerSnapshotCommand(): void {
       "-d, --name <name:string>",
       "The site identifier for named sites (kind 35128). If not provided, snapshots the root site (kind 15128).",
     )
+    .option(
+      "--title <title:string>",
+      "Title for this snapshot. Defaults to the source manifest's title.",
+    )
+    .option("--no-title", "Omit the title inherited from the source manifest.", {
+      default: undefined,
+    })
+    .option(
+      "--description <description:string>",
+      "Description for this snapshot. Defaults to the source manifest's description.",
+    )
+    .option("--no-description", "Omit the description inherited from the source manifest.", {
+      default: undefined,
+    })
     .option("--dry-run", "Preview the snapshot event without signing or publishing it.")
     .option("--dry-run-output <dir:string>", "Directory to write dry-run event JSON files.")
     .option(
@@ -137,7 +168,10 @@ export async function snapshotCommand(options: SnapshotCommandOptions): Promise<
 
   const sourceManifest = trustedManifest.event;
   const aggregateTag = await getOrComputeManifestAggregateTag(sourceManifest);
-  const snapshotTemplate = await createSnapshotTemplate(sourceManifest, options.createdAt);
+  const snapshotTemplate = await createSnapshotTemplate(sourceManifest, options.createdAt, {
+    title: resolveTagOverride(options.title),
+    description: resolveTagOverride(options.description),
+  });
 
   console.log(
     colors.gray(
@@ -149,6 +183,17 @@ export async function snapshotCommand(options: SnapshotCommandOptions): Promise<
   console.log(
     colors.cyan(`Snapshot created_at: ${formatSnapshotCreatedAt(snapshotTemplate.created_at)}`),
   );
+
+  const snapshotTitle = findTagValue(snapshotTemplate, "title");
+  if (snapshotTitle) {
+    console.log(colors.cyan(`Snapshot title: ${snapshotTitle}`));
+  }
+
+  const snapshotDescription = findTagValue(snapshotTemplate, "description");
+  if (snapshotDescription) {
+    console.log(colors.cyan(`Snapshot description: ${snapshotDescription}`));
+  }
+
   console.log("");
 
   if (options.dryRun) {

--- a/src/lib/manifest.ts
+++ b/src/lib/manifest.ts
@@ -208,10 +208,27 @@ export async function getOrComputeManifestAggregateTag(
   return ["x", await computeManifestAggregateHash(manifest), "aggregate"];
 }
 
-/** Builds a snapshot event template from an existing root or named site manifest */
+/**
+ * Caller-supplied descriptive tags for a snapshot, replacing the values inherited
+ * from the source manifest. An empty string drops the inherited tag entirely.
+ * Verifiable data (the aggregate hash and the file set) is never overridable.
+ */
+export interface SnapshotTagOverrides {
+  title?: string;
+  description?: string;
+}
+
+const SNAPSHOT_OVERRIDABLE_TAGS = ["title", "description"] as const;
+
+/**
+ * Builds a snapshot event template from an existing root or named site manifest.
+ * Descriptive tags are copied from the source manifest unless `overrides` supplies
+ * its own values.
+ */
 export async function createSnapshotTemplate(
   sourceManifest: NostrEvent,
   createdAt?: number,
+  overrides: SnapshotTagOverrides = {},
 ): Promise<EventTemplate> {
   if (
     sourceManifest.kind !== NSITE_ROOT_SITE_KIND && sourceManifest.kind !== NSITE_NAME_SITE_KIND
@@ -227,6 +244,15 @@ export async function createSnapshotTemplate(
     tags.push([...originTag]);
   }
 
+  const overridden = new Map<string, string>();
+  for (const name of SNAPSHOT_OVERRIDABLE_TAGS) {
+    const value = overrides[name];
+    if (value !== undefined) {
+      overridden.set(name, value);
+    }
+  }
+  const applied = new Set<string>();
+
   for (const tag of sourceManifest.tags) {
     if (!SNAPSHOT_COPYABLE_TAGS.has(tag[0]) || tag[0] === "A") {
       continue;
@@ -236,7 +262,23 @@ export async function createSnapshotTemplate(
       continue;
     }
 
+    const override = overridden.get(tag[0]);
+    if (override !== undefined) {
+      // Replace the inherited tag in place, at most once.
+      if (applied.has(tag[0])) continue;
+      applied.add(tag[0]);
+      if (override !== "") {
+        tags.push([tag[0], override]);
+      }
+      continue;
+    }
+
     tags.push([...tag]);
+  }
+
+  for (const [name, value] of overridden) {
+    if (applied.has(name) || value === "") continue;
+    tags.push([name, value]);
   }
 
   tags.push(await getOrComputeManifestAggregateTag(sourceManifest));

--- a/tests/unit/manifest_snapshot_test.ts
+++ b/tests/unit/manifest_snapshot_test.ts
@@ -134,6 +134,107 @@ describe("manifest snapshot helpers", () => {
     assertEquals(snapshot.tags.filter((tag) => tag[0] === "x").length, 1);
   });
 
+  it("replaces inherited title and description with caller overrides", async () => {
+    const manifest = createManifest({
+      tags: [
+        ["path", "/index.html", "a".repeat(64)],
+        ["title", "My Site"],
+        ["description", "the live site"],
+      ],
+    });
+
+    const snapshot = await createSnapshotTemplate(manifest, undefined, {
+      title: "v1.2.3",
+      description: "release snapshot",
+    });
+
+    assertEquals(snapshot.tags.filter((tag) => tag[0] === "title"), [["title", "v1.2.3"]]);
+    assertEquals(
+      snapshot.tags.filter((tag) => tag[0] === "description"),
+      [["description", "release snapshot"]],
+    );
+  });
+
+  it("adds an overridden title when the source manifest has none", async () => {
+    const manifest = createManifest({
+      tags: [["path", "/index.html", "a".repeat(64)]],
+    });
+
+    const snapshot = await createSnapshotTemplate(manifest, undefined, { title: "v1.2.3" });
+
+    assertEquals(snapshot.tags.filter((tag) => tag[0] === "title"), [["title", "v1.2.3"]]);
+    assertEquals(snapshot.tags.some((tag) => tag[0] === "description"), false);
+  });
+
+  it("drops an inherited tag when the override is an empty string", async () => {
+    const manifest = createManifest({
+      tags: [
+        ["path", "/index.html", "a".repeat(64)],
+        ["title", "My Site"],
+        ["description", "the live site"],
+      ],
+    });
+
+    const snapshot = await createSnapshotTemplate(manifest, undefined, { title: "" });
+
+    assertEquals(snapshot.tags.some((tag) => tag[0] === "title"), false);
+    assertEquals(
+      snapshot.tags.filter((tag) => tag[0] === "description"),
+      [["description", "the live site"]],
+    );
+  });
+
+  it("inherits descriptive tags when no override is given", async () => {
+    const manifest = createManifest({
+      tags: [
+        ["path", "/index.html", "a".repeat(64)],
+        ["title", "My Site"],
+        ["description", "the live site"],
+      ],
+    });
+
+    const snapshot = await createSnapshotTemplate(manifest, undefined, {});
+
+    assertEquals(snapshot.tags.filter((tag) => tag[0] === "title"), [["title", "My Site"]]);
+    assertEquals(
+      snapshot.tags.filter((tag) => tag[0] === "description"),
+      [["description", "the live site"]],
+    );
+  });
+
+  it("keeps verifiable tags untouched when descriptive tags are overridden", async () => {
+    const manifest = createManifest({
+      tags: [
+        ["path", "/index.html", "a".repeat(64)],
+        ["path", "/post.html", "b".repeat(64)],
+        ["x", "1".repeat(64), "aggregate"],
+        ["title", "My Site"],
+      ],
+    });
+
+    const snapshot = await createSnapshotTemplate(manifest, undefined, { title: "v1.2.3" });
+
+    assertEquals(snapshot.tags.filter((tag) => tag[0] === "path").length, 2);
+    assertEquals(
+      snapshot.tags.filter((tag) => tag[0] === "x"),
+      [["x", "1".repeat(64), "aggregate"]],
+    );
+  });
+
+  it("collapses duplicate inherited tags into a single override", async () => {
+    const manifest = createManifest({
+      tags: [
+        ["path", "/index.html", "a".repeat(64)],
+        ["title", "My Site"],
+        ["title", "Stale Title"],
+      ],
+    });
+
+    const snapshot = await createSnapshotTemplate(manifest, undefined, { title: "v1.2.3" });
+
+    assertEquals(snapshot.tags.filter((tag) => tag[0] === "title"), [["title", "v1.2.3"]]);
+  });
+
   it("creates a root-site snapshot and computes aggregate x when absent", async () => {
     const manifest = createManifest({
       kind: 15128,

--- a/tests/unit/snapshot_command_test.ts
+++ b/tests/unit/snapshot_command_test.ts
@@ -4,7 +4,11 @@ import "../test-setup-global.ts";
 import { assertEquals, assertExists } from "@std/assert";
 import { describe, it } from "@std/testing/bdd";
 import nsyte from "../../src/commands/root.ts";
-import { formatSnapshotCreatedAt, registerSnapshotCommand } from "../../src/commands/snapshot.ts";
+import {
+  formatSnapshotCreatedAt,
+  registerSnapshotCommand,
+  resolveTagOverride,
+} from "../../src/commands/snapshot.ts";
 
 describe("snapshot command", () => {
   it("registers the snapshot command", () => {
@@ -20,9 +24,19 @@ describe("snapshot command", () => {
     assertExists(snapshotCommand.getOption("no-config"));
     assertExists(snapshotCommand.getOption("name"));
     assertExists(snapshotCommand.getOption("relays"));
+    assertExists(snapshotCommand.getOption("title"));
+    assertExists(snapshotCommand.getOption("no-title"));
+    assertExists(snapshotCommand.getOption("description"));
+    assertExists(snapshotCommand.getOption("no-description"));
     assertExists(snapshotCommand.getOption("dry-run"));
     assertExists(snapshotCommand.getOption("dry-run-output"));
     assertExists(snapshotCommand.getOption("dry-run-show-kinds"));
+  });
+
+  it("maps descriptive tag flags onto snapshot overrides", () => {
+    assertEquals(resolveTagOverride(undefined), undefined);
+    assertEquals(resolveTagOverride("v1.2.3"), "v1.2.3");
+    assertEquals(resolveTagOverride(false), "");
   });
 
   it("formats snapshot created_at as unix and human-readable text", () => {


### PR DESCRIPTION
Fixes #155.

## Problem

Every descriptive tag on a snapshot event is inherited from the live manifest it was taken from, so labelling a snapshot means retitling the live site, deploying, snapshotting, and putting the title back. As #155 describes, that can strand the live site under a version title if the run dies halfway, publishes two manifests whose only purpose is to carry a label for a moment, makes `--sync` load-bearing, and races anything else deploying concurrently — into an event that by design is never replaced.

## Change

`nsyte snapshot` takes `--title` and `--description`, which set those tags on the snapshot only. The live manifest is never touched:

```sh
nsyte snapshot --title "v1.2.3" --description "Release v1.2.3"
```

Absent the flags, behaviour is unchanged: tags are inherited from the source manifest. `--no-title` and `--no-description` drop an inherited tag rather than replacing it — cliffy rejects `--title ""` as a missing value, so a negation flag is the only way to express "no title" on the CLI.

The verifiable parts of the snapshot — the aggregate hash and the file set — still come from the source event only and remain non-overridable, per the issue's own reasoning.

Under the hood `createSnapshotTemplate` takes an optional `SnapshotTagOverrides`, where an empty string means "omit". Overrides replace the inherited tag in place, so tag order is preserved and duplicates collapse to one.

The effective title and description are now printed alongside the aggregate hash and `created_at`, so a labelled snapshot can be confirmed without `--dry-run`.

## Tests

Seven new cases in `tests/unit/manifest_snapshot_test.ts` and `tests/unit/snapshot_command_test.ts` cover replacing, adding, dropping and inheriting the tags, duplicate collapsing, verifiable tags staying untouched, and the flag-to-override mapping. Full suite: 219 passed, 0 failed. `deno fmt --check` and `deno lint` are clean on the touched files.

Note on the docs diff: `docs/usage/commands/snapshot.md` is wrapped at ~72 columns like its siblings and isn't `deno fmt`-formatted, so I matched the existing wrapping rather than let `deno fmt` reflow the whole file.