### PR TITLE
Package Nix flake with deno2nix

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -44,9 +44,6 @@ jobs:
       sha256_macos_x64: ${{ steps.checksums.outputs.sha256_macos_x64 }}
       sha256_windows: ${{ steps.checksums.outputs.sha256_windows }}
       sha256_source: ${{ steps.checksums.outputs.sha256_source }}
-      sri_linux_x64: ${{ steps.checksums.outputs.sri_linux_x64 }}
-      sri_macos_arm64: ${{ steps.checksums.outputs.sri_macos_arm64 }}
-      sri_macos_x64: ${{ steps.checksums.outputs.sri_macos_x64 }}
     steps:
       - name: Extract version and tag
         id: extract
@@ -66,9 +63,6 @@ jobs:
           VERSION: ${{ steps.extract.outputs.version }}
           REPO: ${{ github.repository }}
         run: |
-          TAG="${TAG}"
-          VERSION="${VERSION}"
-          REPO="${REPO}"
           EXPECTED="nsyte-linux-${VERSION} nsyte-macos-arm64-${VERSION} nsyte-macos-x64-${VERSION} nsyte-windows-${VERSION}.exe"
           TIMEOUT=300
           INTERVAL=15
@@ -112,10 +106,6 @@ jobs:
           curl -fsSL -o nsyte-macos-x64   "${BASE}/nsyte-macos-x64-${VERSION}"
           curl -fsSL -o nsyte-windows.exe "${BASE}/nsyte-windows-${VERSION}.exe"
 
-          to_sri() {
-            printf '%s' "$1" | xxd -r -p | base64 -w0
-          }
-
           SHA256_SOURCE=$(sha256sum nsyte-source.tar.gz | awk '{print $1}')
           SHA256_LINUX_X64=$(sha256sum nsyte-linux | awk '{print $1}')
           SHA256_MACOS_ARM64=$(sha256sum nsyte-macos-arm64 | awk '{print $1}')
@@ -128,9 +118,6 @@ jobs:
             echo "sha256_macos_arm64=${SHA256_MACOS_ARM64}"
             echo "sha256_macos_x64=${SHA256_MACOS_X64}"
             echo "sha256_windows=${SHA256_WINDOWS}"
-            echo "sri_linux_x64=sha256-$(to_sri "${SHA256_LINUX_X64}")"
-            echo "sri_macos_arm64=sha256-$(to_sri "${SHA256_MACOS_ARM64}")"
-            echo "sri_macos_x64=sha256-$(to_sri "${SHA256_MACOS_X64}")"
           } >> "$GITHUB_OUTPUT"
 
   publish-aur:
@@ -392,47 +379,27 @@ jobs:
           Write-Host "Winget manifest PR submitted successfully."
 
   publish-nix:
-    name: Update Nix flake
+    name: Verify Nix flake
     needs: [setup]
     if: needs.setup.result == 'success' && (github.event_name == 'release' || github.event.inputs.manager == 'all' || github.event.inputs.manager == 'nix')
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
-      - name: Checkout default branch
+      - name: Checkout release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 
-      - name: Patch flake hashes
-        env:
-          VERSION: ${{ needs.setup.outputs.version }}
-          SRI_X86_64_LINUX: ${{ needs.setup.outputs.sri_linux_x64 }}
-          SRI_AARCH64_DARWIN: ${{ needs.setup.outputs.sri_macos_arm64 }}
-          SRI_X86_64_DARWIN: ${{ needs.setup.outputs.sri_macos_x64 }}
-        run: |
-          set -euo pipefail
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
 
-          sed -i -E "s|version = \"[^\"]+\";|version = \"${VERSION}\";|" flake.nix
-          sed -i -E '/"x86_64-linux" = \{/,/};/ s|hash = "sha256-[^"]+";|hash = "'"${SRI_X86_64_LINUX}"'";|' flake.nix
-          sed -i -E '/"x86_64-darwin" = \{/,/};/ s|hash = "sha256-[^"]+";|hash = "'"${SRI_X86_64_DARWIN}"'";|' flake.nix
-          sed -i -E '/"aarch64-darwin" = \{/,/};/ s|hash = "sha256-[^"]+";|hash = "'"${SRI_AARCH64_DARWIN}"'";|' flake.nix
+      - name: Build and check flake
+        run: nix flake check --print-build-logs
 
-          if grep -q "PLACEHOLDER_" flake.nix; then
-            echo "::error::flake.nix still contains PLACEHOLDER_ markers after substitution."
-            grep "PLACEHOLDER_" flake.nix
-            exit 1
-          fi
-
-      - name: Commit and push flake update
+      - name: Smoke test packaged CLI
         env:
           VERSION: ${{ needs.setup.outputs.version }}
         run: |
-          git config user.name "nsyte-bot"
-          git config user.email "nsyte-bot@users.noreply.github.com"
-          git add flake.nix
-          if git diff --cached --quiet; then
-            echo "flake.nix already up to date for v${VERSION}. Skipping push."
-            exit 0
-          fi
-          git commit -m "chore: update Nix flake to v${VERSION}"
-          git push
+          output=$(nix run .# -- --version)
+          echo "$output"
+          grep -F "$VERSION" <<< "$output"

--- a/docs/PACKAGE_MANAGERS.md
+++ b/docs/PACKAGE_MANAGERS.md
@@ -15,7 +15,7 @@ handoff.
 | AUR `nsite-git`                   | Prepared, blocked on first authenticated AUR push | Public AUR package page returns 404; local `packages/aur/nsite-git/PKGBUILD` generated `.SRCINFO` for `0.27.1` and passed `namcap`. |
 | Homebrew                          | Live tap created and seeded                       | `https://github.com/sandwichfarm/homebrew-nsyte` exists, has `Formula/nsyte.rb` for `0.27.1`, and has a write deploy key.           |
 | Scoop                             | Live bucket created and seeded                    | `https://github.com/sandwichfarm/scoop-nsyte` exists, has `bucket/nsyte.json` for `0.27.1`, and has a write deploy key.             |
-| Nix                               | Usable flake plus release update job              | `flake.nix` is pinned to `0.27.1` with real SRI hashes; `publish-nix` updates it on future releases.                                |
+| Nix                               | Reproducible source package plus CI verification  | `flake.nix` uses deno2nix to install locked dependencies and run the packaged source with the shared Nix `deno` package.            |
 | WinGet                            | Bootstrap PR opened; update job prepared          | `microsoft/winget-pkgs#386658` adds `sandwichfarm.nsyte` `0.27.1`; future releases need `WINGET_FORK_TOKEN` after that PR merges.   |
 | Chocolatey, Snap, Flatpak, Debian | Local packaging templates refreshed               | `.packaging/*` is updated for `0.27.1`; registry publishing requires external accounts/tokens and package-specific review.          |
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "deno2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785930870,
+        "narHash": "sha256-HQ0FPHO24Un5Z3ZXxCUE0t6SLNUU3VyE56jodiv4Uks=",
+        "owner": "hzrd149",
+        "repo": "deno2nix",
+        "rev": "4c06da532c2ff10b5b2ebb3a77e709ae40540261",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hzrd149",
+        "repo": "deno2nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "deno2nix": "deno2nix",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,77 +1,83 @@
 {
   description = "nsyte - publish your site to nostr and blossom servers";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    deno2nix.url = "github:hzrd149/deno2nix";
+    deno2nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      deno2nix,
+    }:
     let
-      version = "0.27.2";
+      systems = [
+        "x86_64-linux"
+      ];
 
-      # Per-system source URLs and SRI hashes.
-      # Phase 26 CI patches these placeholders on release via sed.
-      sources = {
-        "x86_64-linux" = {
-          url = "https://github.com/sandwichfarm/nsyte/releases/download/v${version}/nsyte-linux-${version}";
-          hash = "sha256-HG/fmabpMejBYKcJP19nn4PsMCGhwBvMbz6tUZtTl+0=";
-        };
-        # "aarch64-linux" pending release.yml aarch64 Linux build step - add back when binary is published
-        "x86_64-darwin" = {
-          url = "https://github.com/sandwichfarm/nsyte/releases/download/v${version}/nsyte-macos-x64-${version}";
-          hash = "sha256-t3gtJYwEeDecZgTsNzqDop3ErMNt1otgPJW387mXOHI=";
-        };
-        "aarch64-darwin" = {
-          url = "https://github.com/sandwichfarm/nsyte/releases/download/v${version}/nsyte-macos-arm64-${version}";
-          hash = "sha256-A9GRmkhcIUzj5SimbsO5Olq0fW50O5o7ERWw/6KndBs=";
-        };
+      forAllSystems =
+        f:
+        nixpkgs.lib.genAttrs systems (
+          system:
+          f system (
+            import nixpkgs {
+              inherit system;
+              overlays = [ deno2nix.overlays.default ];
+            }
+          )
+        );
+
+      # Include only files needed by `deno run src/cli.ts`, so unrelated
+      # repository changes cannot affect the package derivation.
+      src = nixpkgs.lib.fileset.toSource {
+        root = ./.;
+        fileset = nixpkgs.lib.fileset.unions [
+          ./deno.json
+          ./deno.lock
+          ./src
+        ];
       };
-
-      supportedSystems = builtins.attrNames sources;
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     in
     {
-      packages = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          src = sources.${system};
-          isLinux = pkgs.stdenvNoCC.isLinux;
-        in
-        {
-          nsyte = pkgs.stdenvNoCC.mkDerivation {
-            pname = "nsyte";
-            inherit version;
+      packages = forAllSystems (
+        _system: pkgs:
+        import ./nix/package.nix {
+          inherit pkgs src;
+          version = (builtins.fromJSON (builtins.readFile ./deno.json)).version;
+        }
+      );
 
-            src = pkgs.fetchurl {
-              inherit (src) url hash;
-            };
-
-            # autoPatchelfHook patches the ELF interpreter path for NixOS.
-            # Only needed on Linux - Darwin uses Mach-O, no patching needed.
-            nativeBuildInputs = pkgs.lib.optionals isLinux [
-              pkgs.autoPatchelfHook
-            ];
-
-            # glibc is the only runtime dependency for a deno-compile binary.
-            buildInputs = pkgs.lib.optionals isLinux [
-              pkgs.glibc
-            ];
-
-            dontUnpack = true;
-            dontBuild = true;
-
-            installPhase = ''
-              install -m755 -D $src $out/bin/nsyte
-            '';
-
-            meta = with pkgs.lib; {
-              description = "Publish your site to nostr and blossom servers";
-              homepage = "https://github.com/sandwichfarm/nsyte";
-              license = licenses.mit;
-              platforms = supportedSystems;
-              mainProgram = "nsyte";
-            };
+      apps = forAllSystems (
+        system: _pkgs: {
+          default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/nsyte";
+            meta.description = "Run nsyte";
           };
+        }
+      );
 
-          default = self.packages.${system}.nsyte;
-        });
+      devShells = forAllSystems (
+        _system: pkgs: {
+          default = pkgs.mkShell {
+            packages = [ pkgs.deno ];
+
+            shellHook = ''
+              echo "nsyte dev shell"
+              echo "  deno task dev"
+              echo "  nix build .#nsyte"
+            '';
+          };
+        }
+      );
+
+      checks = forAllSystems (
+        system: _pkgs: {
+          package = self.packages.${system}.default;
+        }
+      );
     };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,44 @@
+{
+  pkgs,
+  src,
+  version,
+}:
+let
+  inherit (pkgs) lib;
+
+  nsyte = pkgs.buildDenoApplication {
+    pname = "nsyte";
+    inherit version src;
+
+    entrypoint = "src/cli.ts";
+    denoDepsHash = "sha256-lNkreZhZU+rH2QeXFE8ZfwlXRkykJwuqHzTnyfW43CU=";
+
+    runFlags = [
+      "--vendor=true"
+      "--allow-run"
+      "--allow-read"
+      "--allow-write"
+      "--allow-net"
+      "--allow-env"
+      "--allow-sys"
+    ];
+
+    runtimeInputs = [
+      pkgs.git
+      pkgs.which
+      pkgs.libsecret
+      pkgs.xdg-utils
+    ];
+
+    meta = {
+      description = "Publish your site to nostr and blossom servers";
+      homepage = "https://github.com/sandwichfarm/nsyte";
+      license = lib.licenses.mit;
+    };
+  };
+in
+{
+  default = nsyte;
+  inherit nsyte;
+  denoDeps = nsyte.denoDeps;
+}

--- a/packages/README.md
+++ b/packages/README.md
@@ -14,7 +14,8 @@ automation.
 - `homebrew/` - Homebrew tap formula template, published to `sandwichfarm/homebrew-nsyte`
 - `scoop/` - Scoop bucket manifest template, published to `sandwichfarm/scoop-nsyte`
 - `winget/` - Winget bootstrap manifests, used with `wingetcreate` after the first manual PR
-- `../flake.nix` - Nix flake template at repo root, updated by the Nix publish job
+- `../flake.nix` and `../nix/package.nix` - source-based Nix package using deno2nix, verified by the
+  Nix publish job
 
 ## Preserved templates
 


### PR DESCRIPTION
## Summary

- package nsyte source and locked dependencies with deno2nix instead of downloading compiled release binaries
- expose the application, reusable dependency derivation, app, development shell, and package check for x86_64 Linux
- replace release-time flake hash rewriting with source-package validation and update packaging documentation

## Verification

- `nix build path:.#nsyte`
- `nix build path:.#denoDeps --no-link`
- `nix build path:.#nsyte --override-input deno2nix path:../deno2nix --no-link`
- `nix flake check path:. --print-build-logs`
- `nix run .# -- --version`
- `deno fmt --check .github/workflows/publish-packages.yml docs/PACKAGE_MANAGERS.md packages/README.md`
- `nixfmt --check flake.nix nix/package.nix`
- `actionlint .github/workflows/publish-packages.yml`
- `deno task check-doc-drift`