### PR TITLE
Add Nix support for macOS and ARM

### DIFF
--- a/.github/workflows/doc-drift.yml
+++ b/.github/workflows/doc-drift.yml
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
       - name: Set up pnpm
@@ -27,7 +27,7 @@ jobs:
             npm install -g pnpm@11.3.0
           fi
       - name: Set up pnpm cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "pnpm"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,58 @@
+name: Nix
+
+on:
+  push:
+    paths:
+      - ".github/workflows/nix.yml"
+      - "flake.lock"
+      - "flake.nix"
+      - "nix/**"
+      - "deno.json"
+      - "deno.lock"
+      - "src/**"
+  pull_request:
+    paths:
+      - ".github/workflows/nix.yml"
+      - "flake.lock"
+      - "flake.nix"
+      - "nix/**"
+      - "deno.json"
+      - "deno.lock"
+      - "src/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check (${{ matrix.system }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: ubuntu-latest
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - system: x86_64-darwin
+            runner: macos-15-intel
+          - system: aarch64-darwin
+            runner: macos-15
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Check flake
+        run: nix flake check --print-build-logs
+
+      - name: Build package
+        run: nix build ".#packages.${{ matrix.system }}.default" --print-build-logs
+
+      - name: Smoke test packaged CLI
+        run: nix run ".#packages.${{ matrix.system }}.default" -- --version

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Nix
         uses: cachix/install-nix-action@v31

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -128,7 +128,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout nsyte repo (for PKGBUILD template)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up SSH agent with AUR key
         uses: webfactory/ssh-agent@v0.10.0
@@ -216,7 +216,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout nsyte repo (for formula template)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up SSH agent with Homebrew tap deploy key
         uses: webfactory/ssh-agent@v0.10.0
@@ -275,7 +275,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout nsyte repo (for manifest template)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up SSH agent with Scoop bucket deploy key
         uses: webfactory/ssh-agent@v0.10.0
@@ -332,7 +332,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout nsyte repo (for ManifestVersion sanity check)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Verify ManifestVersion in templates (informational, resolves WR-02)
         shell: pwsh
@@ -398,7 +398,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout release source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name || github.event.inputs.tag }}
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -379,10 +379,22 @@ jobs:
           Write-Host "Winget manifest PR submitted successfully."
 
   publish-nix:
-    name: Verify Nix flake
+    name: Verify Nix flake (${{ matrix.system }})
     needs: [setup]
     if: needs.setup.result == 'success' && (github.event_name == 'release' || github.event.inputs.manager == 'all' || github.event.inputs.manager == 'nix')
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: ubuntu-latest
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - system: x86_64-darwin
+            runner: macos-15-intel
+          - system: aarch64-darwin
+            runner: macos-15
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     steps:
       - name: Checkout release source
@@ -394,12 +406,14 @@ jobs:
         uses: cachix/install-nix-action@v31
 
       - name: Build and check flake
-        run: nix flake check --print-build-logs
+        run: |
+          nix flake check --print-build-logs
+          nix build ".#packages.${{ matrix.system }}.default" --print-build-logs
 
       - name: Smoke test packaged CLI
         env:
           VERSION: ${{ needs.setup.outputs.version }}
         run: |
-          output=$(nix run .# -- --version)
+          output=$(nix run ".#packages.${{ matrix.system }}.default" -- --version)
           echo "$output"
           grep -F "$VERSION" <<< "$output"

--- a/.github/workflows/release-simple.yml
+++ b/.github/workflows/release-simple.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -92,7 +92,7 @@ jobs:
           ls -la
 
       - name: Create simple release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.TAG }}
           name: nsyte ${{ env.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -75,7 +75,7 @@ jobs:
       - name: Compress with UPX
         id: compress_linux
         continue-on-error: true
-        uses: svenstaro/upx-action@v2
+        uses: svenstaro/upx-action@v3
         with:
           files: dist/nsyte-linux-compressed
           args: --best --lzma
@@ -99,7 +99,7 @@ jobs:
           ls -lh dist/nsyte-linux*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-binaries
           path: |
@@ -112,10 +112,10 @@ jobs:
     runs-on: macos-15-intel
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -170,7 +170,7 @@ jobs:
           ls -lh dist/nsyte-macos-x64*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-intel-binaries
           path: |
@@ -183,10 +183,10 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -244,7 +244,7 @@ jobs:
           ls -lh dist/nsyte-macos-arm64*
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-arm-binaries
           path: |
@@ -257,10 +257,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -304,7 +304,7 @@ jobs:
         shell: pwsh
 
       - name: Compress with UPX
-        uses: svenstaro/upx-action@v2
+        uses: svenstaro/upx-action@v3
         with:
           files: dist/nsyte-windows-compressed.exe
           args: --best --lzma
@@ -324,7 +324,7 @@ jobs:
         shell: pwsh
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-binaries
           path: |
@@ -340,10 +340,10 @@ jobs:
       id-token: write # Required for OIDC authentication with JSR
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -397,7 +397,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Get version
         id: get_version
@@ -438,7 +438,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 
@@ -473,7 +473,7 @@ jobs:
           EOF
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event_name == 'workflow_dispatch' && format('v{0}', env.VERSION) || github.ref_name }}
           name: nsyte v${{ env.VERSION }}

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload badge artifacts
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-badges
           path: |
@@ -63,10 +63,10 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download badge artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: coverage-badges
           path: static/

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -51,10 +51,10 @@ jobs:
   #   runs-on: macos-13
   #   steps:
   #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  #       uses: actions/checkout@v7
 
   #     - name: Set up Deno
-  #       uses: denoland/setup-deno@v1
+  #       uses: denoland/setup-deno@v2
   #       with:
   #         deno-version: v2.x
 
@@ -93,10 +93,10 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -137,10 +137,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
 
@@ -170,7 +170,7 @@ jobs:
         shell: pwsh
 
       - name: Test UPX
-        uses: svenstaro/upx-action@v2
+        uses: svenstaro/upx-action@v3
         with:
           files: dist/nsyte-windows-test.exe
           args: --best --lzma

--- a/flake.lock
+++ b/flake.lock
@@ -36,10 +36,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-darwin": {
+      "locked": {
+        "lastModified": 1787940818,
+        "narHash": "sha256-vFzVv78WlyEbTyV5BbrnicnV159wC0YPOcBe3QagyBI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f6107e546a5012172d93e79f1f7950da02ad798f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "deno2nix": "deno2nix",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-darwin": "nixpkgs-darwin"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-darwin.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     deno2nix.url = "github:hzrd149/deno2nix";
     deno2nix.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -11,11 +12,15 @@
     {
       self,
       nixpkgs,
+      nixpkgs-darwin,
       deno2nix,
     }:
     let
       systems = [
         "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
       ];
 
       forAllSystems =
@@ -23,7 +28,7 @@
         nixpkgs.lib.genAttrs systems (
           system:
           f system (
-            import nixpkgs {
+            import (if system == "x86_64-darwin" then nixpkgs-darwin else nixpkgs) {
               inherit system;
               overlays = [ deno2nix.overlays.default ];
             }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,6 +26,8 @@ let
     runtimeInputs = [
       pkgs.git
       pkgs.which
+    ]
+    ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
       pkgs.libsecret
       pkgs.xdg-utils
     ];


### PR DESCRIPTION
## Summary
- add Nix flake outputs for ARM64 Linux and Intel/Apple Silicon macOS
- keep Linux-only runtime helpers off Darwin and pin Intel macOS to the final supported Nixpkgs Darwin branch
- validate all four platforms with native GitHub-hosted runners during CI and package publishing
- update workflow actions to Node 24-compatible releases

## Validation
- `nix flake show --all-systems`
- `nix flake check --print-build-logs`
- `nix build .#packages.x86_64-linux.default --print-build-logs`
- four-platform Nix CI matrix passed: https://github.com/sandwichfarm/nsyte/actions/runs/33260750638