### PR TITLE
Include site addresses in deletion requests

### DIFF
--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -20,6 +20,7 @@ import nsyte from "./root.ts";
 
 const log = createLogger("delete");
 
+import type { NostrEvent } from "applesauce-core/helpers";
 import type { ISigner } from "applesauce-signers";
 import { handleError } from "../lib/error-utils.ts";
 
@@ -44,12 +45,12 @@ function collectBlobHashes(pathTags: string[][]): Set<string> {
 
 async function handleDeleteDryRun(
   siteType: string,
-  manifestId: string,
+  manifest: NostrEvent,
   pathTags: string[][],
   options: DeleteDryRunOptions,
   servers: string[],
 ): Promise<void> {
-  const deleteTemplate = await createDeleteEventTemplate([manifestId], options.createdAt);
+  const deleteTemplate = await createDeleteEventTemplate([manifest], options.createdAt);
 
   await handleDryRunOutput(
     [{
@@ -274,7 +275,7 @@ export function registerDeleteCommand() {
             : (config.servers || []);
           await handleDeleteDryRun(
             `named site "${options.name}"`,
-            manifest.id,
+            manifest,
             pathTags,
             options,
             servers,
@@ -300,7 +301,7 @@ export function registerDeleteCommand() {
 
         // Create and publish delete event
         console.log(colors.cyan("\nCreating delete event..."));
-        const deleteEvent = await createDeleteEvent(signer, [manifest.id]);
+        const deleteEvent = await createDeleteEvent(signer, [manifest]);
 
         console.log(colors.cyan("Publishing delete event to relays..."));
         const success = await publishEventsToRelays(trustedManifest.relays, [deleteEvent]);
@@ -489,7 +490,7 @@ export function registerDeleteCommand() {
       }
 
       if (options.dryRun) {
-        await handleDeleteDryRun("root site", manifest.id, pathTags, options, servers);
+        await handleDeleteDryRun("root site", manifest, pathTags, options, servers);
         if ("close" in signer && typeof signer.close === "function") {
           await signer.close();
         }
@@ -511,7 +512,7 @@ export function registerDeleteCommand() {
 
       // Create and publish delete event
       console.log(colors.cyan("\nCreating delete event..."));
-      const deleteEvent = await createDeleteEvent(signer, [manifest.id]);
+      const deleteEvent = await createDeleteEvent(signer, [manifest]);
 
       console.log(colors.cyan("Publishing delete event to relays..."));
       const success = await publishEventsToRelays(trustedManifest.relays, [deleteEvent]);

--- a/src/commands/undeploy.ts
+++ b/src/commands/undeploy.ts
@@ -231,7 +231,7 @@ export function registerUndeployCommand() {
       if (options.dryRun) {
         const dryRunOptions = options as UndeployDryRunOptions;
         const deleteTemplate = await createDeleteEventTemplate(
-          [manifest.id],
+          [manifest],
           dryRunOptions.createdAt,
         );
         await handleDryRunOutput(
@@ -346,7 +346,7 @@ export function registerUndeployCommand() {
 
       // Publish NIP-09 delete event for the manifest
       console.log(colors.cyan("\nCreating delete event for site manifest..."));
-      const deleteEvent = await createDeleteEvent(signer, [manifest.id]);
+      const deleteEvent = await createDeleteEvent(signer, [manifest]);
 
       console.log(colors.cyan("Publishing delete event to relays..."));
       const success = await publishEventsToRelays(trustedManifest.relays, [deleteEvent]);

--- a/src/lib/nostr.ts
+++ b/src/lib/nostr.ts
@@ -570,15 +570,15 @@ export async function createSiteManifestEvent(
   return await signer.signEvent(template);
 }
 
-/** Create a delete event (NIP-09) */
+/** Create a NIP-09 deletion request. Pass full events to also delete replaceable history. */
 export async function createDeleteEventTemplate(
-  eventIds: string[],
+  events: (string | NostrEvent)[],
   createdAt?: number,
 ): Promise<EventTemplate> {
   const draft = await buildEvent(
     { kind: kinds.EventDeletion },
     { client: { name: "nsyte" } },
-    setDeleteEvents(eventIds),
+    setDeleteEvents(events),
   );
 
   if (createdAt !== undefined) {
@@ -590,9 +590,9 @@ export async function createDeleteEventTemplate(
 
 export async function createDeleteEvent(
   signer: ISigner,
-  eventIds: string[],
+  events: (string | NostrEvent)[],
 ): Promise<NostrEvent> {
-  const draft = await createDeleteEventTemplate(eventIds);
+  const draft = await createDeleteEventTemplate(events);
   return await signer.signEvent(draft);
 }
 

--- a/tests/unit/delete_event_test.ts
+++ b/tests/unit/delete_event_test.ts
@@ -1,0 +1,34 @@
+import { assertEquals } from "@std/assert";
+import type { NostrEvent } from "applesauce-core/helpers";
+import { SimpleSigner } from "applesauce-signers";
+import { createDeleteEvent, createDeleteEventTemplate } from "../../src/lib/nostr.ts";
+
+for (const [kind, identifier] of [[15128, ""], [35128, "blog"]] as const) {
+  Deno.test(`deletion includes event ID and address for kind ${kind}`, async () => {
+    const signer = new SimpleSigner(new Uint8Array(32).fill(1));
+    const manifest: NostrEvent = await signer.signEvent({
+      kind,
+      created_at: 100,
+      content: "",
+      tags: identifier ? [["d", identifier]] : [],
+    });
+    const template = await createDeleteEventTemplate([manifest], 123);
+    const signed = await createDeleteEvent(signer, [manifest]);
+    assertEquals(template.created_at, 123);
+    for (const event of [template, signed]) {
+      assertEquals(event.kind, 5);
+      assertEquals(event.tags.filter((tag) => tag[0] === "e").map((tag) => tag[1]), [manifest.id]);
+      assertEquals(event.tags.filter((tag) => tag[0] === "a").map((tag) => tag[1]), [
+        `${kind}:${manifest.pubkey}:${identifier}`,
+      ]);
+      assertEquals(event.tags.filter((tag) => tag[0] === "k").map((tag) => tag[1]), [String(kind)]);
+    }
+  });
+}
+
+Deno.test("ID-only deletion remains supported without inventing an address", async () => {
+  const id = "a".repeat(64);
+  const event = await createDeleteEventTemplate([id]);
+  assertEquals(event.tags.filter((tag) => tag[0] === "e").map((tag) => tag[1]), [id]);
+  assertEquals(event.tags.filter((tag) => tag[0] === "a"), []);
+});


### PR DESCRIPTION
`nsyte delete` passed only the latest manifest ID to the NIP-09 builder, so relays retaining history could leave older site versions available. Pass the full root or named-site manifest to the existing Applesauce builder so deletion requests include both `e` and `a` tags, plus the recommended `k` tag. Apply the same behavior to dry runs and `undeploy`, while retaining ID-only support for existing callers.

resolves #159

Validation:
- Full test suite: 222 passed (1298 steps), 0 failed, 9 ignored.
- New regression tests cover root and named manifests in unsigned and signed deletion events, custom preview timestamps, and ID-only compatibility.
- `deno check src/cli.ts tests/unit/delete_event_test.ts` passes; the new test fails type-checking against the original API.
- Changed-file lint, formatting, and `git diff --check` pass.
- Repository-wide lint (631 problems) and formatting (32 files) fail identically on the base branch.

No deletion requests were sent to public relays; relay enforcement remains implementation-dependent.
