### PR TITLE
Prepare patch release 0.28.1

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsyte/cli",
-  "version": "0.27.2",
+  "version": "0.28.1",
   "description": "nsyte - publish your site to nostr and blossom servers",
   "license": "MIT",
   "exports": "./src/cli.ts",


### PR DESCRIPTION
Prepare patch release 0.28.1 after #160 so the tagged source, binaries, and package metadata agree.

Validation: version and deletion regression tests passed (4 tests); `deno publish --dry-run --allow-dirty`, formatting, and diff checks passed.
