### PR TITLE
Keep AUR checkouts writable after metadata generation

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -170,14 +170,14 @@ jobs:
             fi
 
             docker run --rm \
+              -e HOST_UID="$(id -u)" \
               -v "${repo}:/pkg" \
               archlinux:base-devel \
               bash -c '
                 set -euo pipefail
-                useradd -m builder
-                chown -R builder /pkg
+                useradd -m -u "$HOST_UID" builder
                 cd /pkg
-                runuser -u builder -- makepkg --printsrcinfo > .SRCINFO
+                runuser -u builder -- bash -c "makepkg --printsrcinfo > .SRCINFO"
               '
 
             test -s "${repo}/.SRCINFO" || {


### PR DESCRIPTION
AUR publication authenticated successfully but failed writing `.git/config`: the metadata-generation container recursively changed checkout ownership to its builder UID.

Use the runner UID for the container builder and write `.SRCINFO` as that user. This preserves checkout ownership for the following Git commit/push step.

Validation: executed the actual workflow Docker block against a disposable Git checkout; `.SRCINFO` generation, ownership checks, `git config`, and staging passed. YAML formatting and diff checks passed.
