### PR TITLE
Add AI slop score workflow and README badge

### DIFF
--- a/.github/workflows/aislop-badge.yml
+++ b/.github/workflows/aislop-badge.yml
@@ -1,0 +1,45 @@
+name: AI Slop Badge
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - ".github/badges/aislop-score.json"
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Read-only by default; write only granted to the scan job so it can commit the badge on main
+permissions:
+  contents: read
+
+concurrency:
+  group: aislop-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  aislop:
+    name: Scan for AI slop
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run aislop and generate badge
+        id: badge
+        uses: sandwichfarm/aislop-badge@v1
+        with:
+          aislop-version: "0.12.0"
+          badge-file: .github/badges/aislop-score.json
+          # aislop exits 1 whenever it reports findings; the badge is the signal, not a red job
+          fail-on-error: false
+          # Only commit the badge from pushes to main, never from PR contexts
+          commit-badge: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+          commit-message: "ci: update AI slop badge [skip ci]"

--- a/.github/workflows/aislop-badge.yml
+++ b/.github/workflows/aislop-badge.yml
@@ -9,7 +9,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Read-only by default; write only granted to the scan job so it can commit the badge on main
+# Read-only by default; write only granted to the badge-commit job
 permissions:
   contents: read
 
@@ -21,8 +21,6 @@ jobs:
   aislop:
     name: Scan for AI slop
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -34,12 +32,54 @@ jobs:
 
       - name: Run aislop and generate badge
         id: badge
-        uses: sandwichfarm/aislop-badge@v1
+        uses: sandwichfarm/aislop-badge@21d563e881c80835c1b307a7d598ceca43422193 # v1.1.0
         with:
           aislop-version: "0.12.0"
           badge-file: .github/badges/aislop-score.json
           # aislop exits 1 whenever it reports findings; the badge is the signal, not a red job
           fail-on-error: false
-          # Only commit the badge from pushes to main, never from PR contexts
-          commit-badge: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
-          commit-message: "ci: update AI slop badge [skip ci]"
+          # Never commit from this job; the commit-badge job below handles main
+          commit-badge: false
+
+      - name: Upload badge artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v7
+        with:
+          name: aislop-badge
+          path: .github/badges/aislop-score.json
+
+  commit-badge:
+    name: Commit Updated Badge
+    needs: aislop
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Download badge artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: aislop-badge
+          path: .github/badges/
+
+      - name: Commit updated badge
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/aislop-score.json
+          git diff --staged --quiet || git commit -m "ci: update AI slop badge [skip ci]"
+          git pull --rebase
+          push_stderr="$(mktemp)"
+          if ! git push 2>"$push_stderr"; then
+            if grep -qiE 'GH006|GH013|protected branch|repository rule violations' "$push_stderr"; then
+              echo "Push blocked by branch protection (badge not updated)"
+            else
+              cat "$push_stderr" >&2
+              rm -f "$push_stderr"
+              exit 1
+            fi
+          fi
+          rm -f "$push_stderr"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Doc Drift Gate](https://github.com/sandwichfarm/nsyte/actions/workflows/doc-drift.yml/badge.svg)](https://github.com/sandwichfarm/nsyte/actions/workflows/doc-drift.yml)
 [![Deploy Docs](https://github.com/sandwichfarm/nsyte/actions/workflows/docs.yml/badge.svg)](https://github.com/sandwichfarm/nsyte/actions/workflows/docs.yml)
 [![Tests & Coverage](https://github.com/sandwichfarm/nsyte/actions/workflows/test-coverage.yml/badge.svg)](https://github.com/sandwichfarm/nsyte/actions/workflows/test-coverage.yml)
+[![AI Slop Score](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsandwichfarm%2Fnsyte%2Fmain%2F.github%2Fbadges%2Faislop-score.json)](https://github.com/sandwichfarm/nsyte/actions/workflows/aislop-badge.yml)
 
 ![Coverage](./static/coverage-badge.svg)
 ![Line Coverage](./static/coverage-lines-badge.svg)


### PR DESCRIPTION
## Summary

Adds [sandwichfarm/aislop-badge](https://github.com/sandwichfarm/aislop-badge) as a workflow and puts the resulting score badge in the README next to the other status badges.

- `.github/workflows/aislop-badge.yml` — runs on pushes to `main`, PRs, and manual dispatch. Scans the whole checkout, pins `aislop` 0.12.0 for a deterministic score, and commits `.github/badges/aislop-score.json` only from pushes to `main` (PR contexts stay read-only). Job-level `contents: write`; workflow default stays `read`.
- `fail-on-error: false` — `aislop` exits 1 whenever it has findings, which would make the job permanently red; the badge is the signal. `minimum-score` is left at 0 (no gate) — easy to add later.
- README badge: Shields endpoint pointing at the raw JSON on `main`.

Heads-up: a local run of `aislop@0.12.0 scan .` scores the repo **14/100 (Critical)** — 1051 ai-slop findings, 74 code-quality, 2 security. The badge will be red until that improves. It renders as "invalid" until the first `main` run commits the JSON.

## Test plan
- [x] `npx aislop@0.12.0 scan --json .` runs locally (exit 1 = findings, JSON produced)
- [ ] After merge: first `main` run commits `.github/badges/aislop-score.json` and the README badge resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWKUp1KHCw1zCKi65g5uVx