### PR TITLE
Add nsyte-ci companion skill; expand snapshot coverage

### DIFF
--- a/scripts/check-doc-drift.ts
+++ b/scripts/check-doc-drift.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S deno run --allow-read
 // scripts/check-doc-drift.ts
 //
-// Drift gate for nsyte's source-vs-docs-vs-skill alignment. Performs four checks:
+// Drift gate for nsyte's source-vs-docs-vs-skill alignment. Performs five checks:
 //   1. Command-page coverage: every src/commands/<name>.ts (except root.ts)
 //      has a corresponding docs/usage/commands/<name>.md, accounting for
 //      naming-mismatch (list↔ls) and alias-doc handling (upload→deploy).
@@ -14,8 +14,10 @@
 //   4. Agent-skill drift: skills/nsyte/SKILL.md must mention every command
 //      (by name or alias), must not reference flags that no command declares,
 //      and skills/nsyte/assets/config.schema.json must be identical to
-//      src/schemas/config.schema.json. Every other skills/*/SKILL.md is a
-//      companion skill (e.g. nsyte-ci): it is only checked for phantom flags.
+//      src/schemas/config.schema.json.
+//   5. Companion-skill drift: every other skills/*/SKILL.md (e.g. nsyte-ci)
+//      must not reference flags that no command declares. Companions are not
+//      required to cover every command or bundle the schema.
 //
 // Exit codes:
 //   0   No drift detected (clean baseline)

--- a/scripts/check-doc-drift.ts
+++ b/scripts/check-doc-drift.ts
@@ -14,7 +14,8 @@
 //   4. Agent-skill drift: skills/nsyte/SKILL.md must mention every command
 //      (by name or alias), must not reference flags that no command declares,
 //      and skills/nsyte/assets/config.schema.json must be identical to
-//      src/schemas/config.schema.json.
+//      src/schemas/config.schema.json. Every other skills/*/SKILL.md is a
+//      companion skill (e.g. nsyte-ci): it is only checked for phantom flags.
 //
 // Exit codes:
 //   0   No drift detected (clean baseline)
@@ -91,6 +92,11 @@ interface DriftReport {
     phantom: string[];
   };
   skill_drift: SkillDrift;
+  companion_skills: CompanionSkillDrift[];
+}
+interface CompanionSkillDrift {
+  skill_path: string;
+  phantom_flags: string[];
 }
 interface SkillDrift {
   skill_path: string;
@@ -378,21 +384,7 @@ async function checkSkill(
   }
 
   // 2. Every `--flag` in the skill must be declared by some command (or be global/implicit).
-  const known = new Set<string>(source.global_flags);
-  for (const spec of Object.values(source.commands)) {
-    for (const raw of spec.flags) {
-      const lf = extractLongFlag(raw);
-      if (lf) known.add(lf);
-    }
-  }
-  const phantomFlags: string[] = [];
-  for (const f of extractAllFlags(text)) {
-    if (known.has(f) || SKILL_IMPLICIT_FLAGS.has(f)) continue;
-    // Cliffy auto-negation: --no-X is real if some command declares --X
-    if (f.startsWith("--no-") && known.has("--" + f.substring(5))) continue;
-    phantomFlags.push(f);
-  }
-  phantomFlags.sort();
+  const phantomFlags = skillPhantomFlags(source, text);
 
   // 3. The bundled schema must match the source schema (compared as parsed JSON).
   const canon = (v: unknown): string => JSON.stringify(sortKeys(v));
@@ -407,6 +399,50 @@ async function checkSkill(
     schema_in_sync: schemaInSync,
     schema_paths: { source: relPath(sourceSchemaPath), skill: relPath(skillSchemaPath) },
   };
+}
+
+/** Flags in a skill text that no command declares (nor global/implicit/auto-negated). */
+function skillPhantomFlags(source: SourceFlags, text: string): string[] {
+  const known = new Set<string>(source.global_flags);
+  for (const spec of Object.values(source.commands)) {
+    for (const raw of spec.flags) {
+      const lf = extractLongFlag(raw);
+      if (lf) known.add(lf);
+    }
+  }
+  const phantom: string[] = [];
+  for (const f of extractAllFlags(text)) {
+    if (known.has(f) || SKILL_IMPLICIT_FLAGS.has(f)) continue;
+    // Cliffy auto-negation: --no-X is real if some command declares --X
+    if (f.startsWith("--no-") && known.has("--" + f.substring(5))) continue;
+    phantom.push(f);
+  }
+  return phantom.sort();
+}
+
+/**
+ * Companion skills: every skills/<name>/SKILL.md sibling of the primary skill.
+ * They cover a slice of nsyte (e.g. CI), so only phantom flags are checked.
+ */
+async function checkCompanionSkills(
+  source: SourceFlags,
+  primarySkillDir: string,
+): Promise<CompanionSkillDrift[]> {
+  const parent = primarySkillDir.replace(/\/+$/, "").split("/").slice(0, -1).join("/") || ".";
+  const primaryName = primarySkillDir.replace(/\/+$/, "").split("/").pop();
+  const out: CompanionSkillDrift[] = [];
+  for await (const entry of Deno.readDir(parent)) {
+    if (!entry.isDirectory || entry.name === primaryName) continue;
+    const skillPath = `${parent}/${entry.name}/SKILL.md`;
+    let text: string;
+    try {
+      text = await Deno.readTextFile(skillPath);
+    } catch {
+      continue;
+    }
+    out.push({ skill_path: relPath(skillPath), phantom_flags: skillPhantomFlags(source, text) });
+  }
+  return out.sort((a, b) => a.skill_path.localeCompare(b.skill_path));
 }
 
 function sortKeys(v: unknown): unknown {
@@ -617,6 +653,24 @@ function printTextReport(report: DriftReport) {
   }
   console.log("");
 
+  // Section 5: Companion-skill drift (phantom flags only)
+  if (report.companion_skills.length > 0) {
+    const bad = report.companion_skills.filter((c) => c.phantom_flags.length > 0);
+    console.log(`## Companion-skill drift (${report.companion_skills.length} skill(s))`);
+    if (bad.length === 0) {
+      console.log("  OK — every companion skill references only real flags.");
+    } else {
+      for (const c of bad) {
+        console.log(
+          `  ${c.skill_path}: phantom flags (${c.phantom_flags.length}): ${
+            c.phantom_flags.join(", ")
+          }`,
+        );
+      }
+    }
+    console.log("");
+  }
+
   if (report.exit_code === 0) {
     console.log("No drift detected — source, docs, and skill aligned.");
   } else {
@@ -646,6 +700,7 @@ async function main(argv: string[]): Promise<number> {
   const flagRows = checkFlags(source, docs);
   const env = await checkEnvVars(args.srcTree, args.docsTree);
   const skill = await checkSkill(source, args.skillDir, args.sourceSchema);
+  const companions = await checkCompanionSkills(source, args.skillDir);
 
   const aligned = flagRows.filter((r) => r.aligned).length;
   const drift = flagRows.length - aligned;
@@ -653,8 +708,10 @@ async function main(argv: string[]): Promise<number> {
   const anyEnvDrift = env.phantom.length > 0;
   const anySkillDrift = skill.missing_commands.length > 0 || skill.phantom_flags.length > 0 ||
     !skill.schema_in_sync;
+  const anyCompanionDrift = companions.some((c) => c.phantom_flags.length > 0);
 
-  const exit_code: 0 | 1 = anyCoverageDrift || drift > 0 || anyEnvDrift || anySkillDrift ? 1 : 0;
+  const exit_code: 0 | 1 =
+    anyCoverageDrift || drift > 0 || anyEnvDrift || anySkillDrift || anyCompanionDrift ? 1 : 0;
 
   const report: DriftReport = {
     generated: new Date().toISOString(),
@@ -664,6 +721,7 @@ async function main(argv: string[]): Promise<number> {
     flag_drift: flagRows,
     env_var_drift: env,
     skill_drift: skill,
+    companion_skills: companions,
   };
 
   if (args.format === "json") {

--- a/skills/README.md
+++ b/skills/README.md
@@ -34,17 +34,18 @@ Browse the listing at <https://skills.sh/sandwichfarm/nsyte>.
 
 ### Manual install
 
-Copy `skills/nsyte/` into your agent's skills directory, for example:
+Copy each skill directory you want into your agent's skills directory. `nsyte-ci` is optional — take
+it only if the agent will work on pipelines:
 
 ```bash
 # Claude Code (project)
-mkdir -p .claude/skills && cp -r skills/nsyte .claude/skills/
+mkdir -p .claude/skills && cp -r skills/nsyte skills/nsyte-ci .claude/skills/
 
 # Claude Code (user-wide)
-mkdir -p ~/.claude/skills && cp -r skills/nsyte ~/.claude/skills/
+mkdir -p ~/.claude/skills && cp -r skills/nsyte skills/nsyte-ci ~/.claude/skills/
 
 # Agent-neutral location read by many agents
-mkdir -p .agents/skills && cp -r skills/nsyte .agents/skills/
+mkdir -p .agents/skills && cp -r skills/nsyte skills/nsyte-ci .agents/skills/
 ```
 
 ## Layout

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,9 +6,10 @@ This directory holds [Agent Skills](https://skills.sh) for AI coding agents (Cla
 Cursor, OpenCode, Copilot, Gemini CLI, and others). A skill is a `SKILL.md` file plus optional
 `references/` and `assets/` that teach an agent how to use nsyte correctly.
 
-| Skill                     | What it covers                                                                                                                                                                                        |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`nsyte`](nsyte/SKILL.md) | Installing nsyte, project setup, `.nsite/config.json`, auth (NIP-46 / nsec / nbunksec), deploying, inspecting and updating sites, dry runs, secrets scanning, delete/undeploy, CI/CD, troubleshooting |
+| Skill                           | What it covers                                                                                                                                                                                                                           |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`nsyte`](nsyte/SKILL.md)       | Installing nsyte, project setup, `.nsite/config.json`, auth (NIP-46 / nsec / nbunksec), deploying, inspecting and updating sites, snapshots, dry runs, secrets scanning, delete/undeploy, troubleshooting                                |
+| [`nsyte-ci`](nsyte-ci/SKILL.md) | Deploying from pipelines: `nsyte ci` credentials, the `sandwichfarm/nsite-action` GitHub Action (inputs, defaults, traps), pinned-binary pipelines for GitHub Actions / GitLab CI / other runners, release snapshots, CI troubleshooting |
 
 ## Install
 
@@ -21,7 +22,8 @@ npx skills add sandwichfarm/nsyte
 Options:
 
 ```bash
-npx skills add sandwichfarm/nsyte --skill nsyte          # pick the skill explicitly
+npx skills add sandwichfarm/nsyte --skill nsyte          # pick one skill explicitly
+npx skills add sandwichfarm/nsyte --skill nsyte-ci       # only the CI/CD skill
 npx skills add sandwichfarm/nsyte -a claude-code -a codex # target specific agents
 npx skills add sandwichfarm/nsyte -g                      # install for the user, not just this project
 npx skills add sandwichfarm/nsyte -y                      # skip prompts (CI / scripts)
@@ -49,12 +51,14 @@ mkdir -p .agents/skills && cp -r skills/nsyte .agents/skills/
 
 ```
 skills/
-└── nsyte/
-    ├── SKILL.md                  # the skill (YAML frontmatter + instructions)
-    ├── references/
-    │   └── nostr-concepts.md     # relays, pubkeys, nsec, Blossom, NIP-46, event kinds
-    └── assets/
-        └── config.schema.json    # copy of src/schemas/config.schema.json
+├── nsyte/
+│   ├── SKILL.md                  # the primary skill (YAML frontmatter + instructions)
+│   ├── references/
+│   │   └── nostr-concepts.md     # relays, pubkeys, nsec, Blossom, NIP-46, event kinds
+│   └── assets/
+│       └── config.schema.json    # copy of src/schemas/config.schema.json
+└── nsyte-ci/
+    └── SKILL.md                  # companion skill: CI/CD and nsite-action
 ```
 
 `SKILL.md` follows the [Agent Skills](https://agentskills.io) format: `name` and `description` are
@@ -67,10 +71,13 @@ The skill is checked by the doc-drift gate (`deno task check-doc-drift`, also ru
 
 - every command in `src/commands/` must be mentioned in `skills/nsyte/SKILL.md`;
 - every `--flag` the skill mentions must exist in source;
-- `skills/nsyte/assets/config.schema.json` must be identical to `src/schemas/config.schema.json`.
+- `skills/nsyte/assets/config.schema.json` must be identical to `src/schemas/config.schema.json`;
+- every other `skills/*/SKILL.md` (companion skills such as `nsyte-ci`) must only mention real
+  `--flags` — they are not required to cover every command.
 
-When you add or rename a command or flag, update `SKILL.md` in the same PR. When you change the
-config schema, copy it over:
+When you add or rename a command or flag, update `SKILL.md` in the same PR. When
+`sandwichfarm/nsite-action` gains or changes an input, update `nsyte-ci/SKILL.md` — nothing checks
+that automatically. When you change the config schema, copy it over:
 
 ```bash
 cp src/schemas/config.schema.json skills/nsyte/assets/config.schema.json

--- a/skills/nsyte-ci/SKILL.md
+++ b/skills/nsyte-ci/SKILL.md
@@ -42,8 +42,10 @@ Then:
 1. Store the printed value as a pipeline secret. Any name works; this skill uses `NBUNK_SECRET`.
 2. Prefer a **dedicated bunker connection for CI** so it can be revoked without touching the user's
    other clients. Revocation happens in the signer app, not in nsyte.
-3. Never use a raw private key (`nsec1…` / hex) in CI. `nsite-action` rejects it outright; the CLI
-   accepts it but it cannot be revoked if leaked.
+3. Never use a raw private key (`nsec1…` / hex) in CI. `nsite-action`'s `nbunksec` input rejects
+   anything that is not `nbunksec1…`, but its compatibility `sec` input and the CLI's `--sec` accept
+   raw keys — the guard is only as good as the input you choose. A raw key cannot be revoked if
+   leaked; an `nbunksec` can be, in the signer app.
 
 The agent must not run `nsyte ci` on the user's behalf and paste the output anywhere — it prints a
 credential. Tell the user to run it and store the value themselves.
@@ -229,12 +231,32 @@ job the user has explicitly asked to be destructive.
 ## Snapshots as release markers
 
 A snapshot (`nsyte snapshot`) publishes an immutable kind 5128 event that pins the **currently
-published** manifest's aggregate hash and file set. It reads that manifest from the relays, so it
-must run after a successful deploy has propagated — never before, and never on a build that did not
-deploy.
+published** manifest's aggregate hash and file set. It reads that manifest from the relays with a
+single query and no retry, and it takes the **newest manifest it finds**. `deploy` succeeds once one
+relay accepts the manifest, so a snapshot run immediately afterwards can either fail with
+`No manifest found` or — worse — silently pin the _previous_ deploy. Always confirm propagation
+first: `deploy` prints `Event ID: <id>` and `snapshot --dry-run` prints
+`Source manifest: <id> (<age>)`, so compare the two before publishing.
 
 ```bash
-nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET"
+set -o pipefail
+
+# Deploy and capture the manifest event id
+deploy_log="$(mktemp)"
+nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET" | tee "$deploy_log"
+manifest_id="$(sed -n 's/.*Event ID: \([0-9a-f]\{64\}\).*/\1/p' "$deploy_log" | tail -n1)"
+[ -n "$manifest_id" ] || { echo "deploy did not print a manifest Event ID"; exit 1; }
+
+# Wait (bounded) until the relays return that manifest as the newest one
+for attempt in 1 2 3 4 5 6; do
+  if nsyte snapshot --dry-run --sec "$NBUNK_SECRET" | grep -q "Source manifest: $manifest_id"; then
+    break
+  fi
+  [ "$attempt" -lt 6 ] || { echo "manifest $manifest_id not visible on relays after 6 tries"; exit 1; }
+  sleep 10
+done
+
+# Create the release marker
 nsyte snapshot --sec "$NBUNK_SECRET" --title "v${TAG}" --description "Release ${TAG}"
 ```
 
@@ -243,7 +265,8 @@ nsyte snapshot --sec "$NBUNK_SECRET" --title "v${TAG}" --description "Release ${
 - `-d <name>` snapshots a named site; without it, the root site.
 - The hash and file set always come from the manifest and cannot be overridden.
 - `snapshot` has no `--non-interactive` flag; with `--sec` it never prompts.
-- Preview with `--dry-run` in the same job first if the pipeline is new.
+- `--dry-run` is also the propagation check above; keep it in the job even once the pipeline is
+  stable.
 - nsyte has no command to list snapshots; they are visible to relay clients that query kind 5128 by
   author.
 - Not available through `nsite-action` — use a pinned-binary step.

--- a/skills/nsyte-ci/SKILL.md
+++ b/skills/nsyte-ci/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: nsyte-ci
+description: Deploy nsites (Nostr/Blossom static sites) from CI/CD pipelines. Covers generating an nbunksec CI credential with `nsyte ci`, the sandwichfarm/nsite-action GitHub Action (inputs, defaults, traps), building a pinned-binary pipeline for GitHub Actions, GitLab CI, or any other runner, post-deploy snapshots for release tagging, secret handling, and CI troubleshooting. Use when the user wants to deploy an nsite from GitHub Actions, GitLab CI, or another pipeline, mentions nsite-action, nbunksec, or automating nsyte deploys.
+license: MIT
+metadata:
+  author: sandwichfarm
+  repository: https://github.com/sandwichfarm/nsyte
+  homepage: https://nsyte.run
+  docs: https://nsyte.run/docs/guides/ci-cd
+  action: https://github.com/sandwichfarm/nsite-action
+---
+
+# nsyte in CI/CD
+
+This skill covers automating nsite deploys. For the CLI itself (install, config, auth, deploy flags,
+inspecting sites, troubleshooting) use the companion `nsyte` skill — the rules there (never print
+secrets, prefer `--dry-run`, confirm destructive commands) apply here too.
+
+Two paths:
+
+| Runner                   | Use                                                                             |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| GitHub Actions           | [`sandwichfarm/nsite-action`](#github-actions-nsite-action) (deploy only)       |
+| Anything else / advanced | [Pinned nsyte binary](#any-ci-pinned-binary) + `nsyte deploy --non-interactive` |
+
+Both need the same credential, generated once on a dev machine.
+
+---
+
+## Step 1: Generate a CI credential
+
+`nsyte ci` connects to the user's NIP-46 bunker (signer app such as Amber or nsec.app) and prints an
+`nbunksec1…` string **once**. It is never written to disk.
+
+```bash
+nsyte ci                      # interactive: scan QR / paste bunker URL at the prompt
+nsyte ci '<bunker-url>'       # non-interactive, URL from the signer app
+```
+
+Then:
+
+1. Store the printed value as a pipeline secret. Any name works; this skill uses `NBUNK_SECRET`.
+2. Prefer a **dedicated bunker connection for CI** so it can be revoked without touching the user's
+   other clients. Revocation happens in the signer app, not in nsyte.
+3. Never use a raw private key (`nsec1…` / hex) in CI. `nsite-action` rejects it outright; the CLI
+   accepts it but it cannot be revoked if leaked.
+
+The agent must not run `nsyte ci` on the user's behalf and paste the output anywhere — it prints a
+credential. Tell the user to run it and store the value themselves.
+
+The signer app must be **online and reachable** on the relay in the bunker URL whenever the pipeline
+signs. A CI run that hangs at "waiting for bunker" means the signer is offline.
+
+---
+
+## GitHub Actions: nsite-action
+
+`sandwichfarm/nsite-action` downloads a pinned nsyte release binary for the runner OS, builds an
+effective config, validates it, and runs `nsyte deploy <directory> -i --sec <credential>` with
+secrets masked in logs. Latest release: `v0.7.0`.
+
+### Minimal workflow
+
+```yaml
+name: Deploy nsite
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci && npm run build
+      - name: Deploy to Nostr/Blossom
+        uses: sandwichfarm/nsite-action@v0.7.0
+        with:
+          nbunksec: ${{ secrets.NBUNK_SECRET }}
+          directory: ./dist
+          version: v0.28.1
+          skip_secrets_scan: "false"
+          config_path: .nsite/config.json
+```
+
+With a committed `.nsite/config.json` (it holds no secrets) this is the whole deploy. Without one,
+pass `relays` and `servers` inline (newline-separated):
+
+```yaml
+with:
+  nbunksec: ${{ secrets.NBUNK_SECRET }}
+  directory: ./dist
+  version: v0.28.1
+  skip_secrets_scan: "false"
+  title: My Site
+  relays: |
+    wss://relay.nsite.lol
+  servers: |
+    https://cdn.hzrd149.com
+    https://cdn.sovbit.host
+```
+
+### Inputs
+
+| Input                                                          | Default      | Notes                                                                                                                             |
+| -------------------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `nbunksec`                                                     | —            | The `nbunksec1…` from `nsyte ci`. Must start with `nbunksec1`; `sec1…` values are rejected.                                       |
+| `sec`                                                          | —            | Compatibility input passed straight to `--sec`. Prefer `nbunksec`.                                                                |
+| `directory`                                                    | —            | **Required.** Build output to upload.                                                                                             |
+| `version`                                                      | `latest`     | nsyte release tag (`v0.28.1`). **Always pin** — `latest` makes deploys non-reproducible.                                          |
+| `config_path`                                                  | `''`         | Path to a config JSON, relative to the repo root, no `..`. Validated with `nsyte validate --file` before deploy.                  |
+| `relays`, `servers`                                            | `''`         | Newline-separated. When set they **replace** the config's arrays, not merge.                                                      |
+| `name`                                                         | `''`         | Deploy a named site (`--name`, kind 35128). Empty = root site.                                                                    |
+| `title`, `description`                                         | `''`         | NIP-5A metadata written into an effective config (overrides the committed config's values).                                       |
+| `fallback`                                                     | `''`         | SPA fallback path, e.g. `/index.html` (`--fallback`).                                                                             |
+| `skip_secrets_scan`                                            | `true`       | **Default skips the scan.** Set `"false"` so `deploy` scans for leaked credentials first. Optional `scan_level`: low/medium/high. |
+| `force`, `sync`, `verbose`, `concurrency`                      | see docs     | Map to `--force`, `--sync`, `--verbose`, `--concurrency`.                                                                         |
+| `created_at`                                                   | `''`         | Override event timestamp (epoch seconds or ISO 8601) via global `--created-at`. Needs nsyte ≥ v0.26.0.                            |
+| `publish_relay_list`, `publish_server_list`, `publish_profile` | `false`      | Root sites only. Map to `--publish-relay-list`, `--publish-server-list`, `--publish-profile`.                                     |
+| `publish_app_handler`, `handler_kinds`                         | `false`/`''` | NIP-89 handler (`--publish-app-handler`, `--handler-kinds`).                                                                      |
+| `use_fallback_relays`, `use_fallback_servers`                  | `false`      | Add nsyte's built-in defaults (`--use-fallback-relays`, `--use-fallback-servers`).                                                |
+| `purge`                                                        | `false`      | **Deprecated, no-op.** Use `nsyte delete` / `nsyte undeploy` from the CLI instead.                                                |
+
+Outputs: `status` (`success` / `failure`) and `nsyte_version_used`.
+
+### Traps
+
+- **`skip_secrets_scan` defaults to `true`** — the opposite of the CLI. Set it to `"false"` unless
+  the user has confirmed the scan produces false positives on their build.
+- **`version` defaults to `latest`.** Pin it.
+- **The action only runs `deploy`.** `snapshot`, `announce`, `delete`, `undeploy`, `status` are not
+  available through it. For those, add a [pinned-binary step](#any-ci-pinned-binary) after the
+  action; the binary the action downloaded is an implementation detail, do not rely on its path.
+- **No `--dry-run` through the action.** To preview what a workflow would publish, run
+  `nsyte deploy ./dist --dry-run` locally or in a pinned-binary step.
+- **`relays`/`servers` inputs replace, not extend,** the committed config. To add the defaults on
+  top, use `use_fallback_relays` / `use_fallback_servers`.
+- **`purge` does nothing.** There is no deploy-time purge; removal is a separate CLI command that
+  should never run unattended without explicit user intent.
+- **Linux, macOS, and Windows runners are supported**; the action installs `jq` if missing (via
+  apt/brew/choco), which needs `sudo` on Linux runners.
+
+---
+
+## Any CI: pinned binary
+
+Use this for GitLab CI, Woodpecker, Drone, Jenkins, a plain shell script, or on GitHub when you need
+commands other than `deploy`. Download the release asset for the runner, verify it runs, then call
+nsyte directly. Asset names: `nsyte-linux-<ver>`, `nsyte-macos-arm64-<ver>`,
+`nsyte-macos-x64-<ver>`, `nsyte-windows-<ver>.exe`.
+
+### Pipeline steps
+
+```bash
+# 1. Install a pinned release
+NSYTE_VERSION=0.28.1
+curl -fsSLo /usr/local/bin/nsyte \
+  "https://github.com/sandwichfarm/nsyte/releases/download/v${NSYTE_VERSION}/nsyte-linux-${NSYTE_VERSION}"
+chmod +x /usr/local/bin/nsyte
+nsyte --version
+
+# 2. Gate: fail on leaked secrets and bad config before touching the network
+nsyte scan ./dist --scan-level high --quiet
+nsyte validate
+
+# 3. Deploy
+nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET"
+```
+
+`--non-interactive` (`-i`) is required: without a TTY any prompt hangs the job. `--sec` reads the
+credential from the pipeline's secret store; nsyte reads no environment variable itself, the name is
+yours. Never echo the variable or pass a literal.
+
+### GitHub Actions (pinned binary)
+
+```yaml
+- name: Install nsyte
+  run: |
+    curl -fsSLo /usr/local/bin/nsyte \
+      https://github.com/sandwichfarm/nsyte/releases/download/v0.28.1/nsyte-linux-0.28.1
+    chmod +x /usr/local/bin/nsyte
+- run: nsyte scan ./dist --scan-level high --quiet
+- run: nsyte validate
+- run: nsyte deploy ./dist --non-interactive --sec "${{ secrets.NBUNK_SECRET }}"
+```
+
+### GitLab CI
+
+```yaml
+deploy-nsite:
+  stage: deploy
+  image: debian:bookworm-slim
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+  before_script:
+    - apt-get update -qq && apt-get install -y -qq curl ca-certificates
+    - curl -fsSLo /usr/local/bin/nsyte
+      https://github.com/sandwichfarm/nsyte/releases/download/v0.28.1/nsyte-linux-0.28.1
+    - chmod +x /usr/local/bin/nsyte
+  script:
+    - nsyte scan ./dist --scan-level high --quiet
+    - nsyte validate
+    - nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET"
+```
+
+Mark `NBUNK_SECRET` as **masked** and **protected** in GitLab's CI variables.
+
+### Overriding config per environment
+
+`nsyte deploy` accepts `--relays`, `--servers` (comma-separated), `--name`, `--fallback`, and the
+global `--config <file>` to point at an alternative config, so staging vs production can share one
+repo:
+
+```bash
+nsyte --config .nsite/staging.json deploy ./dist -i --sec "$NBUNK_SECRET"
+nsyte deploy ./dist -i --name preview-${CI_COMMIT_SHORT_SHA} --sec "$NBUNK_SECRET"
+```
+
+Named sites (`--name`) are separate kind 35128 manifests under the same pubkey, so a per-branch
+preview does not disturb the root site. Clean them up with `nsyte delete -d <name> -y` — only in a
+job the user has explicitly asked to be destructive.
+
+---
+
+## Snapshots as release markers
+
+A snapshot (`nsyte snapshot`) publishes an immutable kind 5128 event that pins the **currently
+published** manifest's aggregate hash and file set. It reads that manifest from the relays, so it
+must run after a successful deploy has propagated — never before, and never on a build that did not
+deploy.
+
+```bash
+nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET"
+nsyte snapshot --sec "$NBUNK_SECRET" --title "v${TAG}" --description "Release ${TAG}"
+```
+
+- `--title` / `--description` label **this snapshot only**; the live manifest is not rewritten.
+  Omitted, they inherit from the manifest. `--no-title` / `--no-description` drop the inherited tag.
+- `-d <name>` snapshots a named site; without it, the root site.
+- The hash and file set always come from the manifest and cannot be overridden.
+- `snapshot` has no `--non-interactive` flag; with `--sec` it never prompts.
+- Preview with `--dry-run` in the same job first if the pipeline is new.
+- nsyte has no command to list snapshots; they are visible to relay clients that query kind 5128 by
+  author.
+- Not available through `nsite-action` — use a pinned-binary step.
+
+Typical trigger: a job that runs only on `v*` tags, after the deploy job.
+
+---
+
+## Checklist
+
+- [ ] `nbunksec1…` from `nsyte ci` stored as a masked pipeline secret; no `nsec`/hex key in CI
+- [ ] nsyte version pinned (`version:` input or release URL)
+- [ ] `.nsite/config.json` committed (no secrets in it) **or** relays/servers passed explicitly
+- [ ] Secrets scan enabled: `skip_secrets_scan: "false"` / `nsyte scan` step
+- [ ] `nsyte validate` before deploy
+- [ ] `--non-interactive` on `deploy`; `--yes` only on `delete`/`undeploy` the user asked for
+- [ ] Deploy job restricted to the release branch/tag; PR builds use `--dry-run` or skip deploy
+- [ ] Signer app for the CI bunker is online during runs
+
+---
+
+## Troubleshooting
+
+- **Job hangs, then times out** — a prompt was hit without a TTY. Add `--non-interactive`; with the
+  action, this is automatic.
+- **"waiting for bunker" / NIP-46 timeout** — the signer app is offline or not on the relay in the
+  bunker URL. Start the signer; check the relay is reachable from the runner.
+- **"No signing method provided"** — `--sec`/`nbunksec` was empty. GitHub does not expose secrets to
+  workflows triggered from forks; check the secret name and job conditions.
+- **"No stored bunker found for pubkey …"** — the committed config has a `bunkerPubkey` but the
+  runner has no keychain entry for it (it never will). Pass `--sec` in CI; the stored bunker is a
+  dev-machine convenience only.
+- **`nbunksec` input rejected** — the value starts with `sec1`. Generate an `nbunksec1…` with
+  `nsyte ci` instead.
+- **Secrets scan blocked the deploy** — inspect the findings; remove the credential from the build
+  output. Only lower `scan_level` / set `skip_secrets_scan: "true"` after the user confirms they are
+  false positives.
+- **Config validation failed** — `config_path` must be relative to the repo root and match
+  `https://nsyte.run/schemas/config.schema.json`; run `nsyte validate` locally.
+- **Asset download 404** — the release tag or asset name is wrong; list assets at
+  `https://github.com/sandwichfarm/nsyte/releases/tag/v<ver>`.
+- **Manifest published to zero relays** — relays unreachable from the runner (firewalled egress or
+  `ws://`/`wss://` mismatch). Try `--use-fallback-relays` to isolate.
+- **Snapshot says "No manifest found"** — the deploy has not propagated to the relays being queried,
+  or the job ran against a different pubkey/name than the deploy.

--- a/skills/nsyte/SKILL.md
+++ b/skills/nsyte/SKILL.md
@@ -25,22 +25,23 @@ relays. Sites are censorship-resistant and served by any nsite gateway.
 
 ## Agent Quick Reference
 
-| User wants to…                         | Run                                                           |
-| -------------------------------------- | ------------------------------------------------------------- |
-| Check nsyte is installed               | `nsyte --version`                                             |
-| Set up a new project                   | `nsyte init` (interactive) or write `.nsite/config.json`      |
-| Validate config                        | `nsyte validate`                                              |
-| Preview a deploy without publishing    | `nsyte deploy ./dist --dry-run`                               |
-| Deploy a built site                    | `nsyte deploy ./dist`                                         |
-| Deploy in CI                           | `nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET"` |
-| Check for leaked secrets before deploy | `nsyte scan ./dist`                                           |
-| See what is published                  | `nsyte list` (file tree) / `nsyte status` (propagation)       |
-| Fetch one published file               | `nsyte get /index.html`                                       |
-| Replace one published file             | `nsyte put ./dist/index.html /index.html`                     |
-| List all sites for a pubkey            | `nsyte sites`                                                 |
-| Preview locally                        | `nsyte serve -d ./dist` / `nsyte run`                         |
-| Diagnose a broken site                 | `nsyte debug [npub]`                                          |
-| Remove a site                          | `nsyte delete` (manifest) / `nsyte undeploy` (everything)     |
+| User wants to…                         | Run                                                                                  |
+| -------------------------------------- | ------------------------------------------------------------------------------------ |
+| Check nsyte is installed               | `nsyte --version`                                                                    |
+| Set up a new project                   | `nsyte init` (interactive) or write `.nsite/config.json`                             |
+| Validate config                        | `nsyte validate`                                                                     |
+| Preview a deploy without publishing    | `nsyte deploy ./dist --dry-run`                                                      |
+| Deploy a built site                    | `nsyte deploy ./dist`                                                                |
+| Deploy in CI                           | `nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET"` (see `nsyte-ci` skill) |
+| Pin the current deploy as a release    | `nsyte snapshot --title "v1.2.3"`                                                    |
+| Check for leaked secrets before deploy | `nsyte scan ./dist`                                                                  |
+| See what is published                  | `nsyte list` (file tree) / `nsyte status` (propagation)                              |
+| Fetch one published file               | `nsyte get /index.html`                                                              |
+| Replace one published file             | `nsyte put ./dist/index.html /index.html`                                            |
+| List all sites for a pubkey            | `nsyte sites`                                                                        |
+| Preview locally                        | `nsyte serve -d ./dist` / `nsyte run`                                                |
+| Diagnose a broken site                 | `nsyte debug [npub]`                                                                 |
+| Remove a site                          | `nsyte delete` (manifest) / `nsyte undeploy` (everything)                            |
 
 ### Rules for agents
 
@@ -459,14 +460,43 @@ nsyte get assets/logo.svg -o ./logo.svg
 nsyte put ./dist/about.html /about.html   # upload one file and republish the manifest
 nsyte put ./logo.svg assets/              # directory-style path → basename appended
 nsyte download -o ./backup     # download the whole site
-nsyte snapshot                 # publish an immutable kind 5128 snapshot of the current manifest
-nsyte snapshot --title "v1.2.3" --description "Release v1.2.3"   # label this snapshot only
 nsyte browse                   # interactive TUI (requires a TTY)
 ```
 
 Most of these accept `-p, --pubkey <npub|hex|name@domain>` to inspect someone else's site,
 `-d, --name <id>` for named sites (`put` uses `-n, --name`), `-r, --relays`, and
 `--use-fallback-relays`. `put` requires an existing manifest — deploy at least once first.
+
+---
+
+## Snapshots
+
+`nsyte snapshot` publishes an **immutable** kind 5128 event that pins the currently published
+manifest — its aggregate hash and file set — as a historical point (a release marker, an audit
+anchor). Unlike the site manifest it is never replaced; each run adds a new snapshot.
+
+```bash
+nsyte snapshot --dry-run                                  # preview the event, publish nothing
+nsyte snapshot                                            # snapshot the root site
+nsyte snapshot -d blog                                    # snapshot the named site "blog"
+nsyte snapshot --title "v1.2.3" --description "Release"   # label this snapshot only
+nsyte snapshot --no-title --no-description                # drop the inherited labels
+nsyte snapshot --sec "$NBUNK_SECRET" --use-fallback-relays
+```
+
+How it works and what to tell the user:
+
+- **It reads the manifest from the relays**, not from disk. Deploy first and let it propagate; "No
+  manifest found" means the relays queried have no manifest for that pubkey/name yet.
+- **Labels:** `--title` / `--description` apply to this snapshot only — the live manifest is not
+  rewritten. Omitted, they inherit from the manifest; `--no-title` / `--no-description` drop the
+  inherited tag. The hash and file set always come from the manifest and cannot be overridden.
+- **Signing:** same as every publishing command (`--sec`, `--prompt-sec`, or the stored bunker). It
+  never prompts when `--sec` is given, so it needs no `--non-interactive` flag.
+- **Relays:** `-r` overrides the config; `--use-fallback-relays` adds nsyte's defaults.
+- **No list command:** nsyte cannot enumerate snapshots; they are visible to relay clients that
+  query kind 5128 by author. Tell the user this before they expect `nsyte status` to show them.
+- **CI:** the natural place is a tag-triggered job after deploy — see the `nsyte-ci` skill.
 
 ---
 
@@ -517,51 +547,17 @@ manifest. Relays may not honor delete requests; treat deletion as best-effort.
 
 ## CI/CD
 
-### Step 1: Generate a CI credential (one-time, on a dev machine)
+Full coverage — `nsite-action` inputs and traps, GitLab and other runners, release snapshots,
+checklist, troubleshooting — lives in the companion **`nsyte-ci`** skill. The essentials:
 
-```bash
-nsyte ci
-nsyte ci '<bunker-url>'                  # or omit the URL to scan a QR / paste it at the prompt
-```
-
-Prints an `nbunksec1…` string **once** and never stores it. Save it as a CI secret (e.g.
-`NBUNK_SECRET`). Prefer a dedicated bunker connection for CI so it can be revoked independently.
-
-### Step 2: Deploy from the pipeline
-
-```bash
-nsyte scan ./dist --scan-level high --quiet
-nsyte validate
-nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET"
-```
-
-Pass the credential with `--sec` from the pipeline's secret store. There is no `NBUNK_SECRET`-style
-environment variable read by nsyte itself — the name of the secret is up to you. Pin the nsyte
-release in the workflow (as above) rather than installing "latest" so deploys are reproducible.
-
-### GitHub Actions example
-
-```yaml
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: npm ci && npm run build
-      - run: |
-          curl -fsSLo /usr/local/bin/nsyte \
-            https://github.com/sandwichfarm/nsyte/releases/download/v0.28.1/nsyte-linux-0.28.1
-          chmod +x /usr/local/bin/nsyte
-      - run: nsyte validate
-      - run: nsyte deploy ./dist --non-interactive --sec "${{ secrets.NBUNK_SECRET }}"
-```
-
-### CI checklist
-
-- [ ] `.nsite/config.json` committed (it holds no secrets) or generated in the job
-- [ ] `NBUNK_SECRET` set to the `nbunksec1…` string from `nsyte ci`
-- [ ] `--non-interactive` on `deploy` (and `--yes` on any `delete`/`undeploy`)
-- [ ] `nsyte scan` and `nsyte validate` run before `deploy`
+1. **Credential:** the user runs `nsyte ci` once on a dev machine; it prints an `nbunksec1…`
+   **once**, never stored. They save it as a pipeline secret (e.g. `NBUNK_SECRET`). Never a raw
+   `nsec`/hex key in CI.
+2. **GitHub Actions:** use `sandwichfarm/nsite-action` with `nbunksec:`, a pinned `version:`, and
+   `skip_secrets_scan: "false"` (its default skips the scan). It only runs `deploy`.
+3. **Any other runner:** download a pinned release binary, then `nsyte scan ./dist`,
+   `nsyte validate`, `nsyte deploy ./dist --non-interactive --sec "$NBUNK_SECRET"`.
+4. `--non-interactive` is mandatory without a TTY; otherwise the job hangs on a prompt.
 
 ---
 


### PR DESCRIPTION
## Why

Audit of the agent skill against `sandwichfarm/nsite-action` and the `snapshot` command:

- **nsite-action was not mentioned anywhere.** The only GitHub Actions path was a hand-rolled binary download. The action has agent-facing traps that were undocumented: `skip_secrets_scan` defaults to **`true`** (opposite of the CLI), `version` defaults to `latest`, `relays`/`servers` inputs *replace* the config arrays rather than merge, `nbunksec` rejects `sec1…`, it only runs `deploy` (no snapshot / delete / dry-run), `config_path` must be relative with no `..`.
- **Snapshots had two example lines.** Missing: what a snapshot is (immutable kind 5128 pinning the published manifest's aggregate hash), that it reads the manifest *from relays* so a deploy must propagate first, `--title`/`--description`/`--no-*` inherit/override/drop semantics, that nsyte has no list command for them, and that `snapshot` has no `--non-interactive` flag.

CI is a different path (YAML inputs, not CLI flags) with its own trigger words, so it gets a companion skill rather than growing the primary one.

## What changed

**`skills/nsyte-ci/SKILL.md`** (new) — `nsyte ci` credential flow; nsite-action minimal workflow, full inputs table, and traps (all verified against `action.yml` on `main`, latest tag `v0.7.0`); pinned-binary pipeline for GitHub Actions / GitLab CI / any runner; snapshots as tag-triggered release markers; checklist; CI troubleshooting using the real error strings from `signer-factory.ts`.

**`skills/nsyte/SKILL.md`** — new "Snapshots" section; CI/CD trimmed to essentials + pointer to `nsyte-ci`; quick-reference rows added.

**`scripts/check-doc-drift.ts`** — companion skills (`skills/*/SKILL.md` other than the primary) are auto-discovered and checked for phantom `--flags` only (they aren't required to cover every command or bundle the schema). Reported as a fifth section, included in the exit code. Negative-tested: an injected `--bogus-flag` is reported.

**`skills/README.md`** — table, install options, layout, gate description; note that nsite-action input changes must be mirrored by hand (nothing checks that automatically).

## Verification

- `deno task check-doc-drift` — no drift (primary + companion)
- `deno fmt --check` — clean
- No scanner-trigger patterns (`| bash`, `secret=xxx`, literal keys) in either skill
- Removed two claims I couldn't verify before committing (YAML boolean quoting, "Linux is the tested path")

## Follow-ups (not in this PR)

- `v0.28.1` / `v0.7.0` pins in examples need bumping on releases.
- skills.sh will list the new skill only after it re-indexes `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LiFWdqRdA735eXgUgwJpvL
